### PR TITLE
Use Netlify proxy for Marketstack API calls

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,8 @@ let watchlist = JSON.parse(localStorage.getItem('stockWatchlistV2') || '[]');
 /* ---------------------------- Fetch via FX ----------------------------- */
 async function fx(path, params = {}) {
   const qs = new URLSearchParams(params).toString();
-  const url = `/api/${path}${qs ? `?${qs}` : ''}`;
+  const base = path.startsWith('http') ? path : `/api/${path}`;
+  const url = `${base}${qs ? `?${qs}` : ''}`;
   showLoading(true);
   try {
     const r = await fetch(url);


### PR DESCRIPTION
## Summary
- handle absolute API paths in `fx` helper to ensure calls are proxied through Netlify functions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4d78c769c83299746259358afb8d0