### PR TITLE
feat: add mock fallback for market data

### DIFF
--- a/netlify/functions/marketstack.js
+++ b/netlify/functions/marketstack.js
@@ -1,3 +1,25 @@
+const corsHeaders = { 'access-control-allow-origin': '*' };
+
+function generateMockData(days = 30) {
+  const today = new Date();
+  return Array.from({ length: days }).map((_, i) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const open = 150 + Math.sin(i / 3) * 5 + (i % 7) - 3;
+    const close = open + (Math.random() - 0.5) * 4;
+    const high = Math.max(open, close) + Math.random() * 2;
+    const low = Math.min(open, close) - Math.random() * 2;
+    return {
+      date: d.toISOString(),
+      open: +open.toFixed(2),
+      high: +high.toFixed(2),
+      low: +low.toFixed(2),
+      close: +close.toFixed(2),
+      volume: Math.floor(1e7 + Math.random() * 5e6),
+    };
+  });
+}
+
 export default async (request) => {
   const url = new URL(request.url);
   const symbol = url.searchParams.get('symbol') || 'AAPL';
@@ -5,26 +27,13 @@ export default async (request) => {
   const interval = url.searchParams.get('interval') || '';
   const limit = url.searchParams.get('limit') || '30';
   const exchange = url.searchParams.get('exchange') || '';
+
+  const sendMock = (extra = {}) =>
+    Response.json({ symbol, data: generateMockData(), ...extra }, { headers: corsHeaders });
+
   // return mock if no key
   if (!process.env.MARKETSTACK_KEY && !process.env.REACT_APP_MARKETSTACK_KEY) {
-    const today = new Date();
-    const data = Array.from({ length: 30 }).map((_, i) => {
-      const d = new Date(today);
-      d.setDate(d.getDate() - i);
-      const open = 150 + Math.sin(i / 3) * 5 + (i % 7) - 3;
-      const close = open + (Math.random() - 0.5) * 4;
-      const high = Math.max(open, close) + Math.random() * 2;
-      const low = Math.min(open, close) - Math.random() * 2;
-      return {
-        date: d.toISOString(),
-        open: +open.toFixed(2),
-        high: +high.toFixed(2),
-        low: +low.toFixed(2),
-        close: +close.toFixed(2),
-        volume: Math.floor(1e7 + Math.random() * 5e6),
-      };
-    });
-    return Response.json({ symbol, data });
+    return sendMock();
   }
   try {
     const key = process.env.MARKETSTACK_KEY || process.env.REACT_APP_MARKETSTACK_KEY;
@@ -44,7 +53,10 @@ export default async (request) => {
     if (exchange) api.searchParams.set('exchange', exchange);
     const resp = await fetch(api);
     const body = await resp.json();
-    const rows = (body.data || []).map((r) => ({
+    if (!resp.ok || body.error || !Array.isArray(body.data) || body.data.length === 0) {
+      return sendMock({ warning: 'marketstack unavailable' });
+    }
+    const rows = body.data.map((r) => ({
       date: r.date,
       exchange: r.exchange,
       open: r.open,
@@ -53,11 +65,8 @@ export default async (request) => {
       close: r.close ?? r.last ?? r.price,
       volume: r.volume,
     }));
-    return Response.json(
-      { symbol, data: rows },
-      { headers: { 'access-control-allow-origin': '*' } }
-    );
+    return Response.json({ symbol, data: rows }, { headers: corsHeaders });
   } catch (e) {
-    return Response.json({ error: 'marketstack failed', detail: String(e) }, { status: 500 });
+    return sendMock({ error: 'marketstack failed', detail: String(e) });
   }
 };


### PR DESCRIPTION
## Summary
- ensure Marketstack function always returns data when upstream API is unavailable
- include consistent CORS headers and generate mock data for failures

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5126b05fc8329968065d289222d8f