### PR TITLE
Improve search accuracy and UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,8 @@
 
 /* -------------------------- Utilities & State -------------------------- */
 const $id = (id) => document.getElementById(id);
-const showLoading = (on) => ($id('loading').style.display = on ? 'flex' : 'none');
+// remove refresh animation overlay for smoother UX
+const showLoading = () => {};
 const showError = (msg) => {
   const box = $id('error');
   box.textContent = msg;
@@ -195,7 +196,7 @@ async function loadTimeframe(tf) {
         legend: { labels: { color: '#cfd3da' } },
         tooltip: { mode: 'index', intersect: false },
       },
-      animation: { duration: 600, easing: 'easeOutQuart' },
+      animation: false,
     },
   });
 }
@@ -378,7 +379,8 @@ function loadNews(source = 'All') {
   articles.forEach((a) => {
     const d = document.createElement('div');
     d.className = 'news-item';
-    d.innerHTML = `<a href="#" target="_blank">${a.title}</a><small>${a.time} — ${a.source}</small>`;
+    const gLink = `https://www.google.com/search?q=${encodeURIComponent(a.title)}&tbm=nws`;
+    d.innerHTML = `<a href="${gLink}" target="_blank">${a.title}</a><small>${a.time} — ${a.source}</small>`;
     feed.appendChild(d);
   });
 }

--- a/app.js
+++ b/app.js
@@ -201,6 +201,14 @@ async function loadTimeframe(tf) {
   });
 }
 
+// allow users to switch chart timeframes via the UI controls
+$id('tfControls').addEventListener('click', (e) => {
+  const btn = e.target.closest('button');
+  if (btn && btn.dataset.tf) {
+    loadTimeframe(btn.dataset.tf);
+  }
+});
+
 /* ---------------------------- 52-Week Stats --------------------------- */
 async function load52w() {
   const data = await fx('marketstack', {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="app.css">
 </head>
 <body>
-  <div id="loading"><i class="fa-solid fa-spinner fa-spin"></i>&nbsp;Loading…</div>
+  <div id="loading"><i class="fa-solid fa-spinner"></i>&nbsp;Loading…</div>
 
   <div class="main-container">
     <main class="main-content">

--- a/netlify/functions/search.js
+++ b/netlify/functions/search.js
@@ -1,23 +1,88 @@
 export default async (request) => {
   const url = new URL(request.url);
-  const q = url.searchParams.get('q') || '';
+  let q = url.searchParams.get('q') || '';
+  let exchangeFilter = url.searchParams.get('exchange') || '';
+
+  // Basic parsing to support queries like "ASX:WOW" or "WOW.AX"
+  const colon = q.match(/^([A-Za-z]{2,5})\s*:\s*([A-Za-z0-9.\-]+)$/);
+  if (colon) {
+    exchangeFilter = exchangeFilter || mapPrefix(colon[1]);
+    q = colon[2];
+  } else {
+    const dot = q.match(/^([A-Za-z0-9\-]+)\.([A-Za-z]{1,4})$/);
+    if (dot) {
+      q = dot[1];
+      exchangeFilter = exchangeFilter || mapSuffix(dot[2]);
+    }
+  }
+
   // If no Marketstack key, return mock
   if (!process.env.MARKETSTACK_KEY && !process.env.REACT_APP_MARKETSTACK_KEY) {
     const symbol = q.toUpperCase();
-    const results = q.length >= 2 ? [{ symbol, name: "Mock Result" }] : [];
+    const results = q.length >= 2 ? [{ symbol, name: 'Mock Result', exchange: exchangeFilter, mic: exchangeFilter }] : [];
     return Response.json({ data: results });
   }
+
   try {
     const key = process.env.MARKETSTACK_KEY || process.env.REACT_APP_MARKETSTACK_KEY;
-    const api = new URL("http://api.marketstack.com/v1/tickers");
-    api.searchParams.set("access_key", key);
-    api.searchParams.set("search", q);
-    api.searchParams.set("limit", "10");
+    const api = new URL('http://api.marketstack.com/v1/tickers');
+    api.searchParams.set('access_key', key);
+    api.searchParams.set('search', q);
+    api.searchParams.set('limit', '10');
     const resp = await fetch(api);
     const body = await resp.json();
-    const results = (body.data || []).map(x => ({ symbol: x.symbol, name: x.name }));
-    return Response.json({ data: results }, { headers: { 'access-control-allow-origin': '*' } });
+    const all = (body.data || []).map((x) => ({
+      symbol: x.symbol,
+      name: x.name,
+      exchange: x.stock_exchange?.acronym || '',
+      mic: x.stock_exchange?.mic || '',
+    }));
+    const filtered = all.filter(
+      (it) => !exchangeFilter || it.mic === exchangeFilter || it.exchange === exchangeFilter
+    );
+    return Response.json(
+      { data: filtered },
+      { headers: { 'access-control-allow-origin': '*' } }
+    );
   } catch (e) {
-    return Response.json({ error: 'search failed', detail: String(e) }, { status: 500 });
+    return Response.json(
+      { error: 'search failed', detail: String(e) },
+      { status: 500 }
+    );
   }
 };
+
+// Helpers for exchange alias mapping
+function mapPrefix(prefix) {
+  const up = prefix.toUpperCase();
+  const aliases = {
+    ASX: 'XASX',
+    LSE: 'XLON',
+    HKEX: 'XHKG',
+    TSE: 'XTSE',
+    TSEJP: 'XTKS',
+    NYSE: 'XNYS',
+    NASDAQ: 'XNAS',
+  };
+  if (up.startsWith('X')) return up;
+  return aliases[up] || up;
+}
+
+function mapSuffix(suffix) {
+  const up = suffix.toUpperCase();
+  const map = {
+    AX: 'XASX',
+    ASX: 'XASX',
+    AU: 'XASX',
+    L: 'XLON',
+    LSE: 'XLON',
+    HK: 'XHKG',
+    TO: 'XTSE',
+    T: 'XTKS',
+    DE: 'XETR',
+    NS: 'XNSE',
+    BO: 'XBOM',
+    SW: 'XSWX',
+  };
+  return map[up] || '';
+}


### PR DESCRIPTION
## Summary
- Enhance ticker search to parse exchange codes, return market identifiers, and filter results for accurate global quotes
- Remove refresh spinner and chart animation for smoother user experience
- Link mock news items to Google searches of their titles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c521ae4be88329820f48cda6dd895d