### PR TITLE
Use Marketstack v2 for symbol and search

### DIFF
--- a/netlify/functions/marketstack.js
+++ b/netlify/functions/marketstack.js
@@ -86,7 +86,7 @@ export default async (request) => {
     const rows = body.data.map((r) => {
       const rate = rates[r.currency] || 1;
       return {
-        symbol: r.symbol.replace(/-/g, '.'),
+        symbol: (r.symbol || '').replace(/-/g, '.'),
         date: r.date,
         exchange: r.exchange,
         open: r.open != null ? r.open * rate : null,

--- a/netlify/functions/search.js
+++ b/netlify/functions/search.js
@@ -32,7 +32,7 @@ export default async (request) => {
     const resp = await fetch(api);
     const body = await resp.json();
     const all = (body.data || []).map((x) => ({
-      symbol: x.symbol.replace(/-/g, '.'),
+      symbol: (x.symbol || '').replace(/-/g, '.'),
       name: x.name,
       exchange: x.stock_exchange?.acronym || '',
       mic: x.stock_exchange?.mic || '',

--- a/netlify/functions/search.js
+++ b/netlify/functions/search.js
@@ -25,14 +25,14 @@ export default async (request) => {
 
   try {
     const key = process.env.MARKETSTACK_KEY || process.env.REACT_APP_MARKETSTACK_KEY;
-    const api = new URL('http://api.marketstack.com/v1/tickers');
+    const api = new URL('https://api.marketstack.com/v2/tickers');
     api.searchParams.set('access_key', key);
-    api.searchParams.set('search', q);
+    api.searchParams.set('search', q.replace(/\./g, '-'));
     api.searchParams.set('limit', '10');
     const resp = await fetch(api);
     const body = await resp.json();
     const all = (body.data || []).map((x) => ({
-      symbol: x.symbol,
+      symbol: x.symbol.replace(/-/g, '.'),
       name: x.name,
       exchange: x.stock_exchange?.acronym || '',
       mic: x.stock_exchange?.mic || '',

--- a/readme_intelfin.md
+++ b/readme_intelfin.md
@@ -241,7 +241,7 @@ You can open it directly in a browser, or copy parts into your project.
 const DEFAULT_KEY = 'YOUR_MARKETSTACK_API_KEY';  // override with ?ms_key= or localStorage
 const qsKey = new URLSearchParams(location.search).get('ms_key');
 const API_KEY = qsKey || localStorage.getItem('ms_key') || DEFAULT_KEY;
-const BASE = 'https://api.marketstack.com/v1';
+const BASE = 'https://api.marketstack.com/v2';
 document.getElementById('apiKeyEcho').textContent = 'API: ' + API_KEY.replace(/.(?=.{4})/g, '•');
 
 // ===== Utils =====


### PR DESCRIPTION
## Summary
- Convert dotted ticker symbols to Marketstack v2 hyphen format and add `after_hours` support
- Query the Marketstack v2 tickers endpoint and normalize symbol formatting
- Document v2 API base URL in Intelfin demo README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6afcc1ecc83299362e6a5267d32e4