### PR TITLE
Add Netlify news function and integrate client

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ index 5cf3fddac59aec944ff73bf86ef77bb215db11fa..9879927a4c236c12d9856c679b91b3fa
  - Connect the repo/folder and set:
    - **Build command:** `npm run build`
    - **Publish directory:** `build`
- - (Optional) Add an environment variable **MARKETSTACK_KEY** to use live data.
-   Without a key, the app returns mock data so the UI still works.
- 
- ## Endpoints
+- (Optional) Add an environment variable **MARKETSTACK_KEY** to use live data.
+  Without a key, the app returns mock data so the UI still works.
+- (Optional) Add an environment variable **NEWS_API_KEY** (NewsAPI.org) so `/api/news`
+  can retrieve live headlines for the dashboard. Without it, cached mock
+  articles are returned.
+
+## Endpoints

--- a/app.js
+++ b/app.js
@@ -24,6 +24,21 @@ const fmtVol = (v) => {
   if (n >= 1e3) return (n / 1e3).toFixed(2) + 'K';
   return String(n);
 };
+const fmtNewsTime = (ts) => {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  const diff = Math.max(Date.now() - d.getTime(), 0);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const month = 30 * day;
+  if (diff < minute) return 'Just now';
+  if (diff < hour) return `${Math.round(diff / minute)}m ago`;
+  if (diff < day) return `${Math.round(diff / hour)}h ago`;
+  if (diff < month) return `${Math.round(diff / day)}d ago`;
+  return d.toLocaleDateString();
+};
 const sma = (arr, p) => {
   const out = [];
   for (let i = 0; i < arr.length; i++) {
@@ -362,33 +377,87 @@ $id('exchangeFilters').addEventListener('change', (e) => {
 });
 
 /* -------------------------------- News -------------------------------- */
-const mockNews = {
-  Bloomberg: [
-    { title: 'Apple Intelligence to Redefine AI Landscape', source: 'Bloomberg', time: '1h ago' },
-    { title: 'NVIDIA Hits New High on AI Chip Demand', source: 'Bloomberg', time: '3h ago' },
-  ],
-  Reuters: [
-    { title: 'Microsoft Azure Cloud Sees Unprecedented Growth', source: 'Reuters', time: '2h ago' },
-    { title: 'Tesla Faces Stiff Competition in EV Market', source: 'Reuters', time: '5h ago' },
-  ],
-  Yahoo: [
-    { title: 'Is Amazon a Buy After Earnings Beat?', source: 'Yahoo Finance', time: '4h ago' },
-    { title: 'Alphabet Doubles Down on Quantum', source: 'Yahoo Finance', time: '6h ago' },
-  ],
-};
-function loadNews(source = 'All') {
+async function loadNews(source = 'All') {
   const feed = $id('news-feed');
-  feed.innerHTML = '';
-  let articles = source === 'All' ? Object.values(mockNews).flat() : mockNews[source] || [];
-  // simple ordering by "hours ago"
-  articles.sort((a, b) => parseInt(a.time) - parseInt(b.time));
-  articles.forEach((a) => {
-    const d = document.createElement('div');
-    d.className = 'news-item';
-    const gLink = `https://www.google.com/search?q=${encodeURIComponent(a.title)}&tbm=nws`;
-    d.innerHTML = `<a href="${gLink}" target="_blank">${a.title}</a><small>${a.time} — ${a.source}</small>`;
-    feed.appendChild(d);
-  });
+  feed.innerHTML = '<div class="news-item muted">Loading latest headlines…</div>';
+  try {
+    const resp = await fetch(`/api/news?source=${encodeURIComponent(source)}`);
+    if (!resp.ok) {
+      throw new Error(`${resp.status} ${resp.statusText || ''}`.trim());
+    }
+    const data = await resp.json();
+    const articles = Array.isArray(data.articles) ? data.articles : [];
+
+    feed.innerHTML = '';
+    if (data.fromCache) {
+      const notice = document.createElement('div');
+      notice.className = 'news-item muted';
+      notice.textContent = 'Showing cached headlines.';
+      feed.appendChild(notice);
+    }
+
+    if (!articles.length) {
+      const empty = document.createElement('div');
+      empty.className = 'news-item muted';
+      empty.textContent = 'No articles found for this source.';
+      feed.appendChild(empty);
+      if (data.error) {
+        showError(`News fallback in use — ${data.error}`);
+      }
+      return;
+    }
+
+    articles.forEach((article) => {
+      const item = document.createElement('div');
+      item.className = 'news-item';
+
+      const defaultUrl = `https://www.google.com/search?q=${encodeURIComponent(
+        article.title || ''
+      )}&tbm=nws`;
+      const href =
+        typeof article.url === 'string' && article.url.startsWith('http')
+          ? article.url
+          : defaultUrl;
+
+      const link = document.createElement('a');
+      link.href = href;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = article.title || 'Untitled article';
+      item.appendChild(link);
+
+      const timeLabel =
+        fmtNewsTime(article.publishedAt) ||
+        fmtNewsTime(article.time) ||
+        (article.time && typeof article.time === 'string' ? article.time : '');
+      const sourceLabel = typeof article.source === 'string' ? article.source : '';
+      const metaParts = [];
+      if (timeLabel) metaParts.push(timeLabel);
+      if (sourceLabel) metaParts.push(sourceLabel);
+      if (metaParts.length) {
+        const meta = document.createElement('small');
+        meta.textContent = metaParts.join(' — ');
+        item.appendChild(meta);
+      }
+
+      feed.appendChild(item);
+    });
+
+    if (data.error) {
+      showError(`News fallback in use — ${data.error}`);
+    }
+    if (data.warning) {
+      console.warn('News API warning:', data.warning);
+    }
+  } catch (error) {
+    console.error('loadNews error', error);
+    feed.innerHTML = '';
+    const err = document.createElement('div');
+    err.className = 'news-item muted';
+    err.textContent = 'Unable to load news right now.';
+    feed.appendChild(err);
+    showError(`News feed unavailable — ${error.message}`);
+  }
 }
 $id('newsApiButtons').addEventListener('click', (e) => {
   if (e.target.tagName !== 'BUTTON') return;

--- a/netlify/functions/news.js
+++ b/netlify/functions/news.js
@@ -1,0 +1,148 @@
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+
+const hoursAgo = (hours) => new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+const fallbackBySource = {
+  Bloomberg: [
+    {
+      title: 'Tech Shares Lift Major Indexes to Fresh Highs',
+      url: 'https://www.bloomberg.com/markets',
+      source: 'Bloomberg',
+      publishedAt: hoursAgo(1),
+      description: 'US equities extend gains as megacap tech stocks lead another leg higher.',
+    },
+    {
+      title: 'Energy Executives See Oil Demand Holding Firm Into 2025',
+      url: 'https://www.bloomberg.com/energy',
+      source: 'Bloomberg',
+      publishedAt: hoursAgo(4),
+      description: 'Producers say refinery runs and aviation demand remain resilient despite slowing growth.',
+    },
+  ],
+  Reuters: [
+    {
+      title: 'Dollar Eases as Traders Brace for Key Inflation Data',
+      url: 'https://www.reuters.com/markets',
+      source: 'Reuters',
+      publishedAt: hoursAgo(2),
+      description: 'The greenback slips ahead of the latest US inflation report while Treasury yields steady.',
+    },
+    {
+      title: 'Global Automakers Map Out Next Wave of EV Investments',
+      url: 'https://www.reuters.com/business/autos-transportation',
+      source: 'Reuters',
+      publishedAt: hoursAgo(6),
+      description: 'Manufacturers detail spending plans on new battery platforms and software upgrades.',
+    },
+  ],
+  Yahoo: [
+    {
+      title: 'Analysts Highlight AI Winners Going Into Earnings Season',
+      url: 'https://finance.yahoo.com/',
+      source: 'Yahoo Finance',
+      publishedAt: hoursAgo(3),
+      description: 'Strategists flag semiconductor and cloud companies as beneficiaries of accelerating AI demand.',
+    },
+    {
+      title: 'How Retail Investors Are Positioning Around Fed Decisions',
+      url: 'https://finance.yahoo.com/topic/markets/',
+      source: 'Yahoo Finance',
+      publishedAt: hoursAgo(8),
+      description: 'Flows into sector ETFs show investors leaning defensive while watching policy clues.',
+    },
+  ],
+};
+
+const cloneArticles = (arr = []) => arr.map((item) => ({ ...item }));
+
+let cachedArticles = {
+  Bloomberg: cloneArticles(fallbackBySource.Bloomberg),
+  Reuters: cloneArticles(fallbackBySource.Reuters),
+  Yahoo: cloneArticles(fallbackBySource.Yahoo),
+  All: cloneArticles([
+    ...fallbackBySource.Bloomberg,
+    ...fallbackBySource.Reuters,
+    ...fallbackBySource.Yahoo,
+  ]),
+};
+
+const SOURCE_CONFIG = {
+  All: { domains: 'bloomberg.com,reuters.com,finance.yahoo.com', query: 'stocks OR markets' },
+  Bloomberg: { domains: 'bloomberg.com', query: 'stocks OR markets' },
+  Reuters: { domains: 'reuters.com', query: 'stocks OR markets' },
+  Yahoo: { domains: 'finance.yahoo.com', query: 'stocks OR markets' },
+};
+
+const buildResponse = (source, articles, extra = {}) =>
+  Response.json(
+    { source, articles, ...extra },
+    { headers: { ...corsHeaders, 'cache-control': 'no-store' } }
+  );
+
+const fallbackResponse = (source, extra = {}) =>
+  buildResponse(source, cachedArticles[source] || cachedArticles.All || [], {
+    fromCache: true,
+    ...extra,
+  });
+
+export default async (request) => {
+  if (request.method && request.method !== 'GET') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+
+  const url = new URL(request.url);
+  const rawSource = url.searchParams.get('source') || 'All';
+  const source = SOURCE_CONFIG[rawSource] ? rawSource : 'All';
+
+  const apiKey = process.env.NEWS_API_KEY;
+  if (!apiKey) {
+    return fallbackResponse(source, { warning: 'NEWS_API_KEY not configured' });
+  }
+
+  try {
+    const apiUrl = new URL('https://newsapi.org/v2/everything');
+    const { domains, query } = SOURCE_CONFIG[source];
+    apiUrl.searchParams.set('language', 'en');
+    apiUrl.searchParams.set('sortBy', 'publishedAt');
+    apiUrl.searchParams.set('pageSize', '10');
+    apiUrl.searchParams.set('q', query || 'markets');
+    if (domains) apiUrl.searchParams.set('domains', domains);
+
+    const response = await fetch(apiUrl, {
+      headers: { 'X-Api-Key': apiKey },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upstream error ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (!payload || !Array.isArray(payload.articles)) {
+      throw new Error('Malformed news payload');
+    }
+
+    const articles = payload.articles
+      .filter((article) => article && article.title && article.url)
+      .map((article) => ({
+        title: article.title,
+        url: article.url,
+        source: article.source?.name || source,
+        publishedAt: article.publishedAt || new Date().toISOString(),
+        description: article.description || '',
+      }));
+
+    if (!articles.length) {
+      throw new Error('No articles returned');
+    }
+
+    cachedArticles[source] = articles;
+    if (source === 'All') {
+      cachedArticles.All = articles;
+    }
+
+    return buildResponse(source, articles, { fetchedAt: new Date().toISOString() });
+  } catch (error) {
+    console.error('news function error', error);
+    return fallbackResponse(source, { error: 'news fetch failed', detail: String(error) });
+  }
+};


### PR DESCRIPTION
## Summary
- add a Netlify function that proxies NewsAPI requests and falls back to cached headlines when unavailable
- update the dashboard news widget to fetch `/api/news`, show loading/error states, and render returned articles
- document the required `NEWS_API_KEY` environment variable for live headlines

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca0a24dc608329b9b2714d8ba4171e