### PR TITLE
Improve Tiingo fallback handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const API_BASE = 'https://api.tiingo.com/';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const INTRADAY_STEP_MS = 5 * 60 * 1000;
 
-/* ----------------------------- MIC Helpers ---------------------------- */
 const MIC_ALIASES = {
   NASDAQ: 'XNAS', NAS: 'XNAS', NASD: 'XNAS',
   NYSE: 'XNYS', ARCA: 'ARCX', BATS: 'BATS', IEX: 'IEXG',
@@ -60,7 +59,21 @@ const MIC_TO_TIINGO_PREFIX = {
   XIDX: 'IDX', XKLS: 'KLSE', XBKK: 'SET', XTAI: 'TWSE',
 };
 
+const REALTIME_US_MICS = new Set(['XNAS', 'XNYS', 'ARCX', 'BATS', 'IEXG', 'XASE']);
+
+const MIC_TO_CURRENCY = {
+  XNAS: 'USD', XNYS: 'USD', XASE: 'USD', ARCX: 'USD', BATS: 'USD', IEXG: 'USD',
+  XASX: 'AUD', XTSE: 'CAD', XTSX: 'CAD', XLON: 'GBP', XHKG: 'HKD',
+  XTKS: 'JPY', XSES: 'SGD', XNSE: 'INR', XBOM: 'INR',
+  XFRA: 'EUR', XETR: 'EUR', XSWX: 'CHF', XAMS: 'EUR', XBRU: 'EUR',
+  XMAD: 'EUR', XPAR: 'EUR', XMIL: 'EUR', XMEX: 'MXN', BVMF: 'BRL',
+  XJSE: 'ZAR', XKRX: 'KRW', XKOS: 'KRW', XSHG: 'CNY', XSHE: 'CNY',
+  XNZE: 'NZD', XOSL: 'NOK', XCSE: 'DKK', XSTO: 'SEK', XHEL: 'EUR',
+  XIDX: 'IDR', XKLS: 'MYR', XBKK: 'THB', XTAI: 'TWD',
+};
+
 const parseList = (v) => (v || '').split(',').map(s => s.trim()).filter(Boolean);
+
 const normalizeMic = (v) => {
   const up = (v || '').toUpperCase();
   if (!up) return '';
@@ -68,19 +81,48 @@ const normalizeMic = (v) => {
   if (up.startsWith('X') && up.length >= 3) return up;
   return '';
 };
+
 const micFromSuffix = (suffix) => SUFFIX_TO_MIC[(suffix || '').toUpperCase()] || '';
+
 const tiingoPrefixForMic = (mic) => {
   if (!mic) return '';
   if (Object.prototype.hasOwnProperty.call(MIC_TO_TIINGO_PREFIX, mic)) return MIC_TO_TIINGO_PREFIX[mic];
   if (mic.startsWith('X') && mic.length > 1) return mic.slice(1);
   return mic;
 };
+
 const buildTiingoTicker = (symbol, mic) => {
   const upSymbol = (symbol || '').toUpperCase();
   if (!upSymbol) return '';
-  if (upSymbol.includes(':')) return upSymbol; // already prefixed
+  if (upSymbol.includes(':')) return upSymbol;
   const prefix = tiingoPrefixForMic(mic);
   return prefix ? `${prefix}:${upSymbol}` : upSymbol;
+};
+
+const readCurrencyField = (row) => {
+  const candidates = [
+    row?.currency,
+    row?.currencyCode,
+    row?.currencyCodeIex,
+    row?.priceCurrency,
+    row?.quoteCurrency,
+    row?.tickerCurrency,
+    row?.fxCurrency,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) return trimmed.toUpperCase();
+    }
+  }
+  return '';
+};
+
+const inferCurrency = (row, mic) => {
+  const fromRow = row ? readCurrencyField(row) : '';
+  if (fromRow) return fromRow;
+  if (mic && MIC_TO_CURRENCY[mic]) return MIC_TO_CURRENCY[mic];
+  return 'USD';
 };
 
 function resolveSymbolRequests(symbolParam, exchangeParam) {
@@ -97,7 +139,6 @@ function resolveSymbolRequests(symbolParam, exchangeParam) {
     let baseSymbol = upper;
     let mic = '';
 
-    // "XLON:VOD" style
     const colonIdx = upper.indexOf(':');
     if (colonIdx > 0) {
       const prefix = upper.slice(0, colonIdx);
@@ -107,7 +148,6 @@ function resolveSymbolRequests(symbolParam, exchangeParam) {
       baseSymbol = rest;
     }
 
-    // "BHP.AX" style
     const dotMatch = baseSymbol.match(/^([A-Z0-9\-]+)\.([A-Z]{1,5})$/);
     if (dotMatch) {
       const suffixMic = micFromSuffix(dotMatch[2]);
@@ -139,7 +179,6 @@ function resolveSymbolRequests(symbolParam, exchangeParam) {
   return requests.filter(r => (seen.has(r.key) ? false : (seen.add(r.key), true)));
 }
 
-/* ------------------------- Mock data generators ------------------------ */
 function hashCode(input) {
   const str = (input || 'MOCK').toUpperCase();
   let hash = 0;
@@ -184,7 +223,6 @@ function generateMockSeries(symbol, points = 30, mode = 'eod') {
 const generateMockQuote  = (s) => generateMockSeries(s, 1, 'intraday')[0];
 const generateMockQuotes = (symbols) => (symbols.length ? symbols : ['MOCK']).map(generateMockQuote);
 
-/* --------------------------- Utils & fetchers -------------------------- */
 const toNumber = (v) => (v == null || v === '' ? null : (Number.isFinite(+v) ? +v : null));
 const firstNonNull = (...values) => { for (const v of values) if (v != null) return v; return null; };
 const formatDate = (d) => d.toISOString().split('T')[0];
@@ -215,7 +253,7 @@ async function fetchTiingo(path, params, token) {
   return data;
 }
 
-const normalizeQuote = (row, fallbackSymbol) => {
+const normalizeQuote = (row, fallbackSymbol, fallbackMic) => {
   const symbol = (row?.ticker || row?.symbol || fallbackSymbol || '').toUpperCase();
   const price = toNumber(firstNonNull(row?.last, row?.tngoLast, row?.lastPrice, row?.mid));
   const fallbackClose = toNumber(firstNonNull(row?.close, row?.openPrice));
@@ -228,16 +266,17 @@ const normalizeQuote = (row, fallbackSymbol) => {
   const volume = toNumber(firstNonNull(row?.volume, row?.lastSize, row?.tngoLastSize));
   const timestamp = row?.timestamp || row?.lastSaleTimestamp || row?.quoteTimestamp ||
                     row?.tngoLastTime || row?.date || new Date().toISOString();
+  const currency = inferCurrency(row, fallbackMic);
   return {
     symbol, date: timestamp,
     exchange: row?.exchange || row?.exchangeCode || '',
     open, high, low, close, last: close, price: close,
     previousClose: prevClose ?? null,
-    volume, currency: 'USD',
+    volume, currency,
   };
 };
 
-const normalizeCandle = (row, symbol, prevRow) => {
+const normalizeCandle = (row, symbol, prevRow, fallbackMic) => {
   const close = toNumber(firstNonNull(row?.close, row?.last, row?.adjClose, row?.tngoLast));
   const prevClose = toNumber(firstNonNull(
     row?.prevClose, row?.adjPrevClose, prevRow?.close, prevRow?.adjClose, prevRow?.last
@@ -246,21 +285,22 @@ const normalizeCandle = (row, symbol, prevRow) => {
   const high = toNumber(firstNonNull(row?.high, row?.adjHigh, row?.highPrice, close, prevClose));
   const low  = toNumber(firstNonNull(row?.low,  row?.adjLow,  row?.lowPrice,  close, prevClose));
   const volume = toNumber(firstNonNull(row?.volume, row?.adjVolume, row?.sharesOutstanding, row?.volumeNotional));
+  const currency = inferCurrency(row, fallbackMic);
   return {
     symbol: (row?.symbol || row?.ticker || symbol || '').toUpperCase(),
     date: row?.date || row?.timestamp || new Date().toISOString(),
     open, high, low, close, last: close, price: close,
     previousClose: prevClose ?? null,
-    volume, exchange: row?.exchange || row?.exchangeCode || '', currency: 'USD',
+    volume, exchange: row?.exchange || row?.exchangeCode || '', currency,
   };
 };
 
 const minutesForInterval = (interval) => (interval === '30min' ? 30 : interval === '1hour' ? 60 : 5);
 
-/* ------------------------------- Loaders ------------------------------- */
 async function loadIntradayLatest(requests, token) {
   if (!requests.length) return new Map();
-  const tickers = Array.from(new Set(requests.map(r => r.ticker).filter(Boolean)));
+  const eligible = requests.filter((req) => req?.ticker && (!req.mic || REALTIME_US_MICS.has(req.mic)));
+  const tickers = Array.from(new Set(eligible.map((r) => r.ticker).filter(Boolean)));
   if (!tickers.length) return new Map();
   const data = await fetchTiingo('/iex', { tickers: tickers.join(',') }, token);
   const rows = Array.isArray(data) ? data : [];
@@ -277,7 +317,7 @@ async function loadIntradayLatest(requests, token) {
       if (source.has(key)) { match = source.get(key); break; }
     }
     if (match) {
-      const normalized = normalizeQuote(match, req.symbol);
+      const normalized = normalizeQuote(match, req.symbol, req.mic);
       normalized.symbol = req.symbol;
       if (req.mic) normalized.exchange = req.mic;
       out.set(req.symbol, normalized);
@@ -299,7 +339,7 @@ async function loadEodLatest(requests, token) {
         const latest = rows[rows.length - 1];
         const prev = rows.length > 1 ? rows[rows.length - 2] : null;
         if (!latest) return null;
-        const normalized = normalizeCandle(latest, req.symbol, prev);
+        const normalized = normalizeCandle(latest, req.symbol, prev, req.mic);
         normalized.symbol = req.symbol;
         if (req.mic) normalized.exchange = req.mic;
         return [req.symbol, normalized];
@@ -323,9 +363,9 @@ async function loadIntraday(request, interval, limit, token) {
   const count = Math.max(Number(limit) || 30, 1);
   const sliced = rows.slice(-count);
   return sliced.map((row, idx) => {
-    const normalized = normalizeCandle(row, request.symbol, idx > 0 ? sliced[idx - 1] : null);
+    const normalized = normalizeCandle(row, request.symbol, idx > 0 ? sliced[idx - 1] : null, request.mic);
     normalized.symbol = request.symbol;
-    if (req.mic) normalized.exchange = request.mic;
+    if (request.mic) normalized.exchange = request.mic;
     return normalized;
   });
 }
@@ -340,14 +380,13 @@ async function loadEod(request, limit, token) {
   const rows = Array.isArray(data) ? data : [];
   const sliced = rows.slice(-count);
   return sliced.map((row, idx) => {
-    const normalized = normalizeCandle(row, request.symbol, idx > 0 ? sliced[idx - 1] : null);
+    const normalized = normalizeCandle(row, request.symbol, idx > 0 ? sliced[idx - 1] : null, request.mic);
     normalized.symbol = request.symbol;
     if (request.mic) normalized.exchange = request.mic;
     return normalized;
   });
 }
 
-/* ------------------------------ HTTP layer ---------------------------- */
 async function handleTiingoRequest(request) {
   const url = new URL(request.url);
   const symbolParam = url.searchParams.get('symbol') || 'AAPL';
@@ -389,9 +428,20 @@ async function handleTiingoRequest(request) {
     let warning = '';
 
     if (kind === 'intraday_latest') {
-      const quoteMap = await loadIntradayLatest(requests, token);
+      let quoteMap = new Map();
+      let realtimeError = null;
+      try {
+        quoteMap = await loadIntradayLatest(requests, token);
+      } catch (err) {
+        realtimeError = err;
+        console.warn('tiingo intraday_latest fetch failed', err);
+        quoteMap = new Map();
+      }
+
       const map = new Map();
-      requests.forEach((req) => { if (quoteMap.has(req.symbol)) map.set(req.symbol, quoteMap.get(req.symbol)); });
+      requests.forEach((req) => {
+        if (quoteMap.has(req.symbol)) map.set(req.symbol, quoteMap.get(req.symbol));
+      });
 
       let usedEodFallback = false;
       let usedMockFallback = false;
@@ -405,6 +455,7 @@ async function handleTiingoRequest(request) {
           if (fallbackRow) { map.set(req.symbol, fallbackRow); usedEodFallback = true; }
         });
       }
+
       const stillMissing = requests.filter((req) => !map.has(req.symbol));
       if (stillMissing.length) {
         const mocks = generateMockQuotes(stillMissing.map((req) => req.symbol));
@@ -412,28 +463,59 @@ async function handleTiingoRequest(request) {
           const req = stillMissing[idx]; if (!req) return;
           const clone = { ...mock, symbol: req.symbol };
           if (req.mic) clone.exchange = req.mic;
+          const inferredCurrency = inferCurrency(null, req.mic);
+          if (inferredCurrency) clone.currency = inferredCurrency;
           map.set(req.symbol, clone);
         });
         usedMockFallback = true;
       }
+
       data = requests.map((req) => map.get(req.symbol)).filter(Boolean);
 
-      if (usedMockFallback) {
-        warning = 'Some symbols are unavailable from Tiingo in real time; displaying sample data for those tickers.';
-      } else if (usedEodFallback) {
-        warning = 'Some symbols are using end-of-day fallback prices because real-time quotes were unavailable.';
+      const realtimeEligibleCount = requests.filter((req) => !req.mic || REALTIME_US_MICS.has(req.mic)).length;
+      const hasRealtimeIneligible = requests.length > 0 && realtimeEligibleCount < requests.length;
+
+      const warningParts = [];
+      if (realtimeError) {
+        warningParts.push('Real-time Tiingo quotes are temporarily unavailable; showing the latest available prices instead.');
       }
+      if (hasRealtimeIneligible) {
+        warningParts.push('Real-time pricing from Tiingo is limited to US-listed equities; international symbols use end-of-day data.');
+      }
+      if (usedMockFallback) {
+        warningParts.push('Some symbols are unavailable from Tiingo in real time; displaying sample data for those tickers.');
+      } else if (usedEodFallback && !realtimeError && !hasRealtimeIneligible) {
+        warningParts.push('Some symbols are using end-of-day fallback prices because real-time quotes were unavailable.');
+      }
+      if (warningParts.length) warning = warningParts.join(' ');
     } else if (kind === 'eod_latest') {
       const eodMap = await loadEodLatest(requests, token);
       data = requests.map((req) => eodMap.get(req.symbol)).filter(Boolean);
     } else if (kind === 'intraday') {
       const target = requests[0] || { symbol: 'AAPL', ticker: 'AAPL', mic: '' };
-      data = await loadIntraday(target, interval, limit, token);
+      let intradayError = null;
+      try {
+        data = await loadIntraday(target, interval, limit, token);
+      } catch (err) {
+        intradayError = err;
+        console.warn('tiingo intraday series fetch failed', err);
+        data = [];
+      }
       if (!data.length) {
-        const fallback = await loadEod(target, limit, token);
+        let fallback = [];
+        try {
+          fallback = await loadEod(target, limit, token);
+        } catch (err) {
+          console.warn('tiingo end-of-day fallback failed', err);
+          fallback = [];
+        }
         if (fallback.length) {
           data = fallback;
-          warning = 'Showing end-of-day prices because intraday data was unavailable.';
+          warning = intradayError
+            ? 'Real-time Tiingo intraday data is unavailable; showing end-of-day prices instead.'
+            : 'Showing end-of-day prices because intraday data was unavailable.';
+        } else if (intradayError && !warning) {
+          warning = 'Real-time Tiingo intraday data is unavailable.';
         }
       }
     } else {
@@ -467,7 +549,7 @@ async function handleTiingoRequest(request) {
 
 export default handleTiingoRequest;
 
-// Netlify (lambda) entrypoint
+// Netlify runtime compatibility
 export const handler = async (event) => {
   const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';
   const path = event?.path || '/api/tiingo';


### PR DESCRIPTION
## Summary
- derive ticker currencies from Tiingo payloads or exchange metadata so fallback rows report the correct currency
- gate IEX real-time calls to supported MICs, add richer warnings, and fall back to end-of-day or mock data when quotes are missing or the upstream call fails
- sync the client copy of the Tiingo handler with the updated server logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfaca5c2848329a8dd55b00374c17d