### PR TITLE
Support common Tiingo API key env names

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,8 +19,12 @@
     "KV_TOKEN",
     "KV_URL",
     "TIINGO_KEY",
+    "TIINGO_API_KEY",
+    "TIINGO_TOKEN",
+    "TIINGO_ACCESS_TOKEN",
     "REACT_APP_API_KEY",
-    "REACT_APP_TIINGO_KEY"
+    "REACT_APP_TIINGO_KEY",
+    "REACT_APP_TIINGO_TOKEN"
   ]
   omit_paths = [
     ".env",

--- a/netlify/functions/env-check.js
+++ b/netlify/functions/env-check.js
@@ -1,3 +1,5 @@
+import { TIINGO_TOKEN_ENV_KEYS, isEnvPresent } from './lib/env.js';
+
 const KEY_ALIASES = {
   EMAILJS_PRIVATE_KEY: ["EMAILJS_PRIVATE_KEY", "EMAILS_PRIVATE_KEY"],
   EMAILJS_SERVICE_ID: ["EMAILJS_SERVICE_ID", "EMAILS_SERVICE_ID"],
@@ -5,17 +7,18 @@ const KEY_ALIASES = {
 };
 
 export default async () => {
-  const keys = [
-    "TIINGO_KEY",
-    "REACT_APP_TIINGO_KEY",
-    "REACT_APP_API_KEY",
-    ...new Set(Object.values(KEY_ALIASES).flat()),
-  ];
-  const present = {};
+  const keys = new Set([
+    ...TIINGO_TOKEN_ENV_KEYS,
+    ...Object.keys(KEY_ALIASES),
+  ]);
+  Object.values(KEY_ALIASES).forEach((aliases) => {
+    aliases.forEach((alias) => keys.add(alias));
+  });
 
-  for (const key of keys) {
-    present[key] = !!process.env[key];
-  }
+  const present = {};
+  keys.forEach((key) => {
+    present[key] = isEnvPresent(key);
+  });
 
   for (const [canonical, aliases] of Object.entries(KEY_ALIASES)) {
     if (present[canonical]) continue;

--- a/netlify/functions/lib/env.js
+++ b/netlify/functions/lib/env.js
@@ -1,0 +1,26 @@
+export const TIINGO_TOKEN_ENV_KEYS = [
+  'TIINGO_KEY',
+  'TIINGO_API_KEY',
+  'TIINGO_TOKEN',
+  'TIINGO_ACCESS_TOKEN',
+  'REACT_APP_TIINGO_KEY',
+  'REACT_APP_TIINGO_TOKEN',
+  'REACT_APP_API_KEY',
+];
+
+const readEnvValue = (key) => {
+  const raw = process.env?.[key];
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : '';
+};
+
+export const getTiingoToken = () => {
+  for (const key of TIINGO_TOKEN_ENV_KEYS) {
+    const value = readEnvValue(key);
+    if (value) return value;
+  }
+  return '';
+};
+
+export const isEnvPresent = (key) => readEnvValue(key) !== '';

--- a/netlify/functions/search.js
+++ b/netlify/functions/search.js
@@ -1,4 +1,5 @@
 import { searchLocalSymbols } from './lib/localSymbolSearch.js';
+import { getTiingoToken } from './lib/env.js';
 
 const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
 const DEFAULT_LIMIT = 25;
@@ -28,7 +29,7 @@ export default async (request) => {
     ? searchLocalSymbols(cleanedQuery, { micFilter: exchangeFilter, limit })
     : [];
 
-  const token = process.env.TIINGO_KEY || process.env.REACT_APP_TIINGO_KEY;
+  const token = getTiingoToken();
   if (!token) {
     return Response.json({ data: localMatches }, { headers: corsHeaders });
   }

--- a/netlify/functions/tiingo.js
+++ b/netlify/functions/tiingo.js
@@ -1,4 +1,6 @@
 // netlify/functions/tiingo.js
+import { getTiingoToken } from './lib/env.js';
+
 const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
 const API_BASE = 'https://api.tiingo.com/';
 
@@ -415,7 +417,7 @@ async function handleTiingoRequest(request) {
     return Response.json(body, responseInit);
   };
 
-  const token = process.env.TIINGO_KEY || process.env.REACT_APP_TIINGO_KEY;
+  const token = getTiingoToken();
   if (!token) {
     return sendMock(isQuoteRequest ? 'quotes' : 'series', {
       warning: 'Tiingo API key missing. Showing sample data.',


### PR DESCRIPTION
## Summary
- add a shared helper that reads the Tiingo token from multiple environment variable names and trims whitespace
- use the helper within the Tiingo data and search functions and expand the environment check to report on all supported keys
- update the secrets scan configuration to ignore the newly supported Tiingo environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d22d4df03083299e9529ea3f04346c