### PR TITLE
Add AI research and screener pages with Tiingo analytics

### DIFF
--- a/netlify/functions/ai-analyst.js
+++ b/netlify/functions/ai-analyst.js
@@ -1,0 +1,142 @@
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
+
+const tidyNumber = (value, digits = 2) => {
+  if (value == null || Number.isNaN(value)) return '—';
+  return Number(value).toFixed(digits);
+};
+
+const percentText = (value, digits = 1) => {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${value >= 0 ? '+' : ''}${(value * 100).toFixed(digits)}%`;
+};
+
+function buildSummaryLines(items = [], limit = 5) {
+  return items
+    .slice(0, limit)
+    .map((item) => {
+      const date = item.date ? new Date(item.date).toISOString().split('T')[0] : '—';
+      return `- [${date}] ${item.type || 'Event'}: ${item.headline || item.title || item.summary || ''}`;
+    })
+    .join('\n');
+}
+
+function buildPrompt(payload = {}) {
+  const mode = payload.mode || 'single-equity';
+  const baseIntro = `You are ChatGPT 5, an institutional-grade equity research analyst plugged into Tiingo market data. Write in concise paragraphs, cite catalysts, highlight risks and conclude with a conviction-weighted fair value.`;
+  if (mode === 'screen') {
+    const lines = (payload.universe || []).map((row, idx) => `#${idx + 1} ${row.symbol} (${row.name || 'n/a'}) — spot ${tidyNumber(row.price)} ${row.currency || ''}, fair value ${tidyNumber(row.fairValue || row.price)} (${percentText(row.upside || 0)}), quality ${tidyNumber(row.qualityScore || 0, 0)}, momentum ${tidyNumber(row.momentumScore || 0, 0)}, yield ${percentText(row.dividendYield || 0, 1)}`).join('\n');
+    return `${baseIntro}\n\nTask: Review a multi-asset screen, rank conviction, highlight catalysts and risk hedges.\n\nUniverse:\n${lines}\n\nScreening filters: min market cap ${payload.filters?.minCap || 0}m, max forward PE ${payload.filters?.maxPe || 'n/a'}, min dividend ${percentText(payload.filters?.minYield || 0)}.\n\nStructure output with sections: 1) Leadership picks, 2) Event map, 3) Risk controls, 4) Trade ideas.`;
+  }
+
+  const events = buildSummaryLines(payload.events || []);
+  const documents = buildSummaryLines(payload.documents || []);
+  const valuation = payload.valuations || {};
+  const metrics = payload.metrics || {};
+  return `${baseIntro}\n\nInstrument: ${payload.symbol} (${payload.name || 'Unknown'})\nCurrency: ${payload.currency || 'USD'}\nLast price: ${tidyNumber(payload.price)}\nFair value: ${tidyNumber(valuation.fairValue || payload.price)} (${percentText(valuation.upside || 0)})\nValuation band: ${tidyNumber(valuation.rangeLow || valuation.fairValue || payload.price)} – ${tidyNumber(valuation.rangeHigh || valuation.fairValue || payload.price)}\nQuality score: ${tidyNumber(payload.qualityScore || 0, 0)}\nMomentum score: ${tidyNumber(payload.momentumScore || 0, 0)}\nDividend yield: ${percentText(metrics.dividendYield || payload.dividendYield || 0, 1)}\nRevenue growth: ${percentText(metrics.revenueGrowth || 0, 1)}\nMargins: gross ${percentText(metrics.grossMargin || 0, 1)}, operating ${percentText(metrics.operatingMargin || 0, 1)}\nLeverage: debt/equity ${tidyNumber(metrics.debtToEquity || 0, 2)}\n\nKey events:\n${events || '- none logged'}\n\nKey documents:\n${documents || '- none logged'}\n\nNarrative cues: ${payload.narrative || 'n/a'}.\n\nDeliverable: One investment thesis paragraph, one valuation & scenario paragraph, one risk paragraph, and a closing recommendation with position sizing guidance.`;
+}
+
+function offlineInsight(payload = {}) {
+  const mode = payload.mode || 'single-equity';
+  if (mode === 'screen') {
+    const rows = payload.universe || [];
+    if (!rows.length) {
+      return {
+        content: 'AI playbook offline — provide tickers to receive a ranked roadmap.',
+        model: 'chatgpt-5-offline',
+        warning: 'OPENAI_API_KEY missing. Returning locally generated guidance.',
+      };
+    }
+    const leaders = rows.slice(0, 3).map((row, idx) => `#${idx + 1} ${row.symbol} (${row.name || 'n/a'}) → upside ${percentText(row.upside || 0)}, quality ${tidyNumber(row.qualityScore || 0, 0)}, momentum ${tidyNumber(row.momentumScore || 0, 0)}.`).join('\n');
+    const laggards = rows.slice(-2).map((row) => `${row.symbol}: monitor ${percentText(row.momentumScore / 100 || 0)} momentum drift and event risk.`).join('\n');
+    return {
+      content: `**Leadership picks**\n${leaders || 'Universe empty.'}\n\n**Catalyst radar**\n${buildSummaryLines(rows.flatMap((row) => row.events || []), 6) || 'Load earnings calendars to populate catalysts.'}\n\n**Risk posture**\n${laggards || 'No risk warnings flagged — diversify across factors.'}\n\n**Playbook**\nScale into top-ranked ideas over three tranches, hedge beta with index futures and revisit when new filings land.`,
+      model: 'chatgpt-5-offline',
+      warning: 'OPENAI_API_KEY missing. Returning locally generated guidance.',
+    };
+  }
+
+  const upside = payload.valuations?.upside ?? 0;
+  const bias = upside > 0.1 ? 'Bullish' : upside < -0.05 ? 'Defensive' : 'Neutral';
+  const events = buildSummaryLines(payload.events || [], 4) || 'No upcoming events recorded.';
+  const docs = buildSummaryLines(payload.documents || [], 4) || 'Recent filings not captured. Sync with EDGAR for depth.';
+  return {
+    content: `**View: ${bias}**\nSpot ${tidyNumber(payload.price)} vs fair ${tidyNumber(payload.valuations?.fairValue || payload.price)} (${percentText(upside)}). Quality score ${tidyNumber(payload.qualityScore || 0, 0)}, momentum ${tidyNumber(payload.momentumScore || 0, 0)}.\n\n**Catalysts**\n${events}\n\n**Document focus**\n${docs}\n\n**Positioning**\nAllocate sizing proportional to conviction, stagger entries around event risk and monitor leverage (${tidyNumber(payload.metrics?.debtToEquity || 0, 2)}x).`,
+    model: 'chatgpt-5-offline',
+    warning: 'OPENAI_API_KEY missing. Returning locally generated guidance.',
+  };
+}
+
+async function callOpenAi(prompt, apiKey) {
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: DEFAULT_MODEL,
+      input: prompt,
+      max_output_tokens: 900,
+      temperature: 0.3,
+    }),
+  });
+  const text = await response.text();
+  if (!text) throw new Error('Empty response from OpenAI');
+  const data = JSON.parse(text);
+  if (!response.ok) {
+    const message = data?.error?.message || response.statusText || 'OpenAI request failed';
+    throw new Error(message);
+  }
+  const content = data?.output?.[0]?.content?.map?.((segment) => segment?.text || '').join(' ').trim();
+  return {
+    content: content || 'OpenAI returned no content.',
+    model: data?.model || DEFAULT_MODEL,
+    usage: data?.usage || null,
+  };
+}
+
+export default async function handleAiAnalyst(request) {
+  if (request.method && request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+  let payload = {};
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return Response.json({ error: 'invalid_json', detail: String(error) }, { status: 400, headers: corsHeaders });
+  }
+
+  const apiKey = (process.env.OPENAI_API_KEY || '').trim();
+  if (!apiKey) {
+    return Response.json(offlineInsight(payload), { status: 200, headers: corsHeaders });
+  }
+
+  try {
+    const prompt = buildPrompt(payload);
+    const result = await callOpenAi(prompt, apiKey);
+    return Response.json(result, { headers: corsHeaders });
+  } catch (error) {
+    const fallback = offlineInsight(payload);
+    fallback.warning = `OpenAI call failed: ${error.message}`;
+    return Response.json(fallback, { status: 200, headers: corsHeaders });
+  }
+}
+
+export const handler = async (event) => {
+  const body = event?.body || '{}';
+  const request = new Request(event?.rawUrl || 'https://example.org/.netlify/functions/ai-analyst', {
+    method: event?.httpMethod || 'POST',
+    headers: event?.headers || {},
+    body: event?.httpMethod === 'GET' ? undefined : body,
+  });
+  const response = await handleAiAnalyst(request);
+  const headers = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  return { statusCode: response.status, headers, body: await response.text() };
+};
+
+export const __testables = { buildPrompt, offlineInsight };

--- a/netlify/functions/tiingo-fundamentals.js
+++ b/netlify/functions/tiingo-fundamentals.js
@@ -1,0 +1,482 @@
+import { getTiingoToken } from './lib/env.js';
+
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+const API_BASE = 'https://api.tiingo.com/';
+
+const MIC_ALIASES = {
+  NASDAQ: 'XNAS', NAS: 'XNAS', NASD: 'XNAS',
+  NYSE: 'XNYS', ARCA: 'ARCX', AMEX: 'XASE', ASE: 'XASE',
+  LSE: 'XLON', LON: 'XLON', HKEX: 'XHKG', HKG: 'XHKG', HK: 'XHKG',
+  ASX: 'XASX', AU: 'XASX', TSX: 'XTSE', TSXV: 'XTSX',
+  JP: 'XTKS', TYO: 'XTKS', TSE: 'XTKS',
+  NSE: 'XNSE', BSE: 'XBOM',
+  XETRA: 'XETR', ETR: 'XETR', FWB: 'XFRA',
+};
+
+const SUFFIX_TO_MIC = {
+  AX: 'XASX', ASX: 'XASX', AU: 'XASX',
+  L: 'XLON', LN: 'XLON', LSE: 'XLON',
+  HK: 'XHKG', H: 'XHKG', HKG: 'XHKG',
+  TO: 'XTSE', TSX: 'XTSE', V: 'XTSX',
+  T: 'XTKS',
+  NS: 'XNSE', BO: 'XBOM',
+  DE: 'XETR', F: 'XFRA',
+};
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const toNumber = (value) => {
+  if (value == null || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const percent = (value) => {
+  if (value == null) return null;
+  return value > 1.5 ? value / 100 : value;
+};
+
+const mapSuffixToMic = (suffix) => SUFFIX_TO_MIC[(suffix || '').toUpperCase()] || '';
+const normalizeMic = (value) => {
+  const up = (value || '').toUpperCase();
+  if (!up) return '';
+  if (up.startsWith('X') && up.length >= 3) return up;
+  return MIC_ALIASES[up] || '';
+};
+
+function parseSymbols(symbolParam = '', exchangeParam = '') {
+  const raw = (symbolParam || '').split(',');
+  const fallback = exchangeParam ? normalizeMic(exchangeParam) : '';
+  const requests = [];
+  raw.forEach((piece) => {
+    const trimmed = (piece || '').trim();
+    if (!trimmed) return;
+    let symbol = trimmed.toUpperCase();
+    let mic = '';
+    if (symbol.includes(':')) {
+      const [prefix, rest] = symbol.split(':');
+      mic = normalizeMic(prefix) || mic;
+      symbol = rest;
+    }
+    const dotMatch = symbol.match(/^([A-Z0-9\-]+)\.([A-Z]{1,4})$/);
+    if (dotMatch) {
+      const suffixMic = mapSuffixToMic(dotMatch[2]);
+      if (suffixMic) {
+        mic = mic || suffixMic;
+        symbol = dotMatch[1];
+      }
+    }
+    requests.push({ symbol, mic: mic || fallback });
+  });
+  if (!requests.length) requests.push({ symbol: 'AAPL', mic: fallback });
+  const seen = new Set();
+  return requests.filter((item) => {
+    const key = `${item.symbol}::${item.mic}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildTiingoTicker(symbol, mic) {
+  if (!symbol) return '';
+  if (symbol.includes(':')) return symbol;
+  if (!mic) return symbol;
+  if (mic === 'XASX') return `ASX:${symbol}`;
+  if (mic === 'XLON') return `LSE:${symbol}`;
+  if (mic === 'XHKG') return `HKEX:${symbol}`;
+  if (mic === 'XTSE') return `TSX:${symbol}`;
+  if (mic === 'XTSX') return `TSXV:${symbol}`;
+  if (mic === 'XTKS') return `TSE:${symbol}`;
+  return symbol;
+}
+
+async function fetchTiingo(path, params, token) {
+  const url = new URL(path, API_BASE);
+  url.searchParams.set('token', token);
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value != null && value !== '') url.searchParams.set(key, value);
+  });
+  const response = await fetch(url);
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try { data = JSON.parse(text); }
+    catch (err) { throw new Error(`Tiingo response parse failed: ${text.slice(0, 160)}`); }
+  }
+  if (!response.ok) {
+    const detail = data?.message || data?.error || response.statusText;
+    throw new Error(`Tiingo ${response.status}: ${detail}`);
+  }
+  return data;
+}
+
+async function fetchFundamentals(symbol, mic, token) {
+  const ticker = buildTiingoTicker(symbol, mic);
+  const path = `/tiingo/fundamentals/${encodeURIComponent(ticker)}/daily`;
+  const data = await fetchTiingo(path, { limit: 16 }, token);
+  return Array.isArray(data) ? data : [];
+}
+
+async function fetchNews(symbol, token) {
+  const data = await fetchTiingo('/tiingo/news', { tickers: symbol, limit: 20 }, token);
+  return Array.isArray(data) ? data : [];
+}
+
+async function fetchQuotes(symbols, token) {
+  if (!symbols.length) return new Map();
+  const data = await fetchTiingo('/iex', { tickers: symbols.join(',') }, token);
+  const rows = Array.isArray(data) ? data : [];
+  const map = new Map();
+  rows.forEach((row) => {
+    const keys = [row?.ticker, row?.symbol, row?.requestTicker]
+      .map((v) => (v || '').toUpperCase())
+      .filter(Boolean);
+    keys.forEach((key) => {
+      map.set(key, row);
+      const colon = key.indexOf(':');
+      if (colon > 0) map.set(key.slice(colon + 1), row);
+    });
+  });
+  return map;
+}
+
+function formatMagnitude(value) {
+  const num = toNumber(value);
+  if (!num) return '—';
+  const abs = Math.abs(num);
+  if (abs >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${(num / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(num / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(num / 1e3).toFixed(2)}K`;
+  return num.toFixed(2);
+}
+
+function computeValuation(metrics, price) {
+  const baselinePrice = price || toNumber(metrics.price) || 0;
+  const eps = toNumber(metrics.eps) || toNumber(metrics.epsTtm) || toNumber(metrics.dilutedEps) || (baselinePrice / 20) || 0;
+  const growth = clamp(percent(metrics.revenueGrowth) ?? 0.05, -0.2, 0.35);
+  const margin = clamp(percent(metrics.operatingMargin) ?? percent(metrics.netMargin) ?? 0.2, -0.3, 0.6);
+  const cashflow = toNumber(metrics.freeCashFlowPerShare) || (eps * (0.8 + margin));
+  const forwardPe = clamp(toNumber(metrics.forwardPe) || toNumber(metrics.pe) || 18, 8, 40);
+  const targetPe = clamp(forwardPe * (1 + growth * 1.4 + margin * 0.3), 8, 48);
+  const multiples = eps ? eps * targetPe : baselinePrice;
+  const marginPremium = baselinePrice * (1 + margin * 0.6);
+  const discount = 0.09;
+  let dcf = baselinePrice;
+  if (cashflow && discount > growth) {
+    dcf = cashflow * (1 + growth) / (discount - growth);
+  }
+  const candidates = [baselinePrice, multiples, marginPremium, dcf].filter((x) => Number.isFinite(x) && x > 1);
+  const fairValue = candidates.length ? candidates.reduce((a, b) => a + b, 0) / candidates.length : baselinePrice;
+  const rangeLow = fairValue * 0.88;
+  const rangeHigh = fairValue * 1.18;
+  const upside = baselinePrice ? (fairValue - baselinePrice) / baselinePrice : 0;
+  let signalLabel = 'Fairly valued';
+  let signalClass = '';
+  if (upside >= 0.18) { signalLabel = 'Strong upside'; signalClass = 'ok'; }
+  else if (upside >= 0.07) { signalLabel = 'Moderate upside'; signalClass = 'ok'; }
+  else if (upside <= -0.12) { signalLabel = 'Overvalued'; signalClass = 'error'; }
+  else if (upside <= -0.05) { signalLabel = 'Slight downside'; signalClass = 'error'; }
+  return {
+    fairValue,
+    rangeLow,
+    rangeHigh,
+    methodology: 'Hybrid cashflow & multiples model',
+    upside,
+    signalLabel,
+    signalClass,
+  };
+}
+
+function computeQualityScore(metrics) {
+  const growth = clamp(percent(metrics.revenueGrowth) ?? 0.05, -0.3, 0.4);
+  const margin = clamp(percent(metrics.operatingMargin) ?? percent(metrics.netMargin) ?? 0.15, -0.25, 0.6);
+  const roe = clamp(percent(metrics.returnOnEquity) ?? 0.12, -0.2, 0.5);
+  const freeCash = toNumber(metrics.freeCashFlowPerShare) ?? 0;
+  const leverage = toNumber(metrics.debtToEquity) ?? 0.6;
+  const dividend = percent(metrics.dividendYield) ?? 0;
+  const growthScore = 55 + growth * 120;
+  const marginScore = 50 + margin * 160;
+  const roeScore = 55 + roe * 150;
+  const cashScore = freeCash > 0 ? 65 : 45;
+  const dividendScore = dividend > 0.02 ? 60 : dividend > 0.005 ? 50 : 40;
+  const leveragePenalty = leverage > 2 ? (leverage - 2) * 25 : leverage > 1 ? (leverage - 1) * 12 : leverage < 0.3 ? -5 : 0;
+  const raw = growthScore * 0.3 + marginScore * 0.25 + roeScore * 0.2 + cashScore * 0.15 + dividendScore * 0.1 - leveragePenalty;
+  return clamp(Math.round(raw), 5, 95);
+}
+
+function computeMomentumScore(price, metrics) {
+  const high = toNumber(metrics.week52High) || toNumber(metrics.price52WeekHigh) || price;
+  const low = toNumber(metrics.week52Low) || toNumber(metrics.price52WeekLow) || price;
+  const range = high && low ? high - low : null;
+  const percentile = range && range > 0 ? clamp((price - low) / range, -0.2, 1.2) : 0.5;
+  const monthChange = percent(metrics.monthChange) ?? percent(metrics.priceChange1Month) ?? 0;
+  const quarterChange = percent(metrics.quarterChange) ?? percent(metrics.priceChange3Month) ?? 0;
+  const signal = percentile * 70 + (monthChange * 100) * 0.15 + (quarterChange * 100) * 0.15 + 25;
+  return clamp(Math.round(signal), 5, 95);
+}
+
+function normaliseNews(list = []) {
+  return list.slice(0, 8).map((item) => ({
+    date: item?.publishedDate || item?.date || item?.timestamp || new Date().toISOString(),
+    type: item?.tags?.[0] || item?.categories?.[0] || 'News',
+    headline: item?.title || item?.description || 'News item',
+    summary: item?.description || item?.snippet || '',
+    url: item?.url || '',
+    importance: item?.sentimentScore > 0.25 ? 'Positive' : item?.sentimentScore < -0.25 ? 'Watch' : 'Neutral',
+  }));
+}
+
+function deriveDocuments(news = [], symbol = '') {
+  const filings = news.filter((item) => (item?.url || '').includes('sec.gov') || /10\-|8\-K|prospectus|earnings call/i.test(item?.title || ''))
+    .slice(0, 6)
+    .map((item) => ({
+      date: item?.date || item?.publishedDate || new Date().toISOString(),
+      type: /transcript/i.test(item?.title || '') ? 'Transcript' : /10-|8-K/i.test(item?.title || '') ? 'SEC Filing' : 'Document',
+      title: item?.headline || item?.title || `${symbol} filing`,
+      url: item?.url || '',
+      summary: item?.summary || '',
+    }));
+  if (filings.length) return filings;
+  return [
+    {
+      date: new Date().toISOString(),
+      type: 'SEC Filing',
+      title: `${symbol} Form 10-K (illustrative)`,
+      url: 'https://www.sec.gov/',
+      summary: 'Sample filing reference — configure TIINGO or SEC feeds for live data.',
+    },
+    {
+      date: new Date(Date.now() - 90 * 86400000).toISOString(),
+      type: 'Earnings transcript',
+      title: `${symbol} Q&A session (illustrative)`,
+      url: 'https://www.sec.gov/',
+      summary: 'Replace with actual transcript once API keys are configured.',
+    },
+  ];
+}
+
+function buildHistory(rows = []) {
+  const sorted = rows.slice().sort((a, b) => new Date(b.reportDate || b.date || 0) - new Date(a.reportDate || a.date || 0));
+  return sorted.slice(0, 8).map((row) => ({
+    period: row.reportDate || row.date || '—',
+    revenueGrowth: percent(row.revenueGrowth) ?? percent(row.revenueYoY) ?? percent(row.revenueGrowthTTM) ?? 0,
+    eps: toNumber(row.eps) ?? toNumber(row.epsTtm) ?? toNumber(row.dilutedEPS) ?? null,
+    margin: percent(row.operatingMargin) ?? percent(row.netMargin) ?? percent(row.operatingMarginTTM) ?? null,
+    leverage: toNumber(row.debtToEquity) ?? toNumber(row.totalDebtToEquity) ?? null,
+  }));
+}
+
+function formatKeyMetrics(metrics, valuations) {
+  return [
+    { label: 'Market cap', value: formatMagnitude(metrics.marketCap) },
+    { label: 'Forward P/E', value: metrics.forwardPe ? metrics.forwardPe.toFixed(1) : '—' },
+    { label: 'PEG (est)', value: metrics.pe && percent(metrics.revenueGrowth) ? (metrics.pe / Math.max(percent(metrics.revenueGrowth), 0.01)).toFixed(2) : '—' },
+    { label: 'Dividend yield', value: percent(metrics.dividendYield) != null ? `${(percent(metrics.dividendYield) * 100).toFixed(2)}%` : '—' },
+    { label: 'FCF / share', value: metrics.freeCashFlowPerShare != null ? metrics.freeCashFlowPerShare.toFixed(2) : '—' },
+    { label: 'Fair value range', value: `${valuations ? valuations.rangeLow.toFixed(2) : '—'} – ${valuations ? valuations.rangeHigh.toFixed(2) : '—'}` },
+  ];
+}
+
+function buildNarrative(symbol, valuations, qualityScore, momentumScore, events) {
+  const tone = valuations?.upside > 0.15 ? 'upside skew' : valuations?.upside < -0.05 ? 'valuation stretch' : 'balanced setup';
+  const catalyst = events?.[0]?.headline || 'monitor upcoming filings and macro catalysts';
+  return `${symbol} screens with ${tone}. Quality ${qualityScore}/100, momentum ${momentumScore}/100. Immediate catalyst: ${catalyst}.`;
+}
+
+function normaliseRecord(entry, fundamentals = [], quote = null, news = []) {
+  const sorted = fundamentals.slice().sort((a, b) => new Date(b.reportDate || b.date || 0) - new Date(a.reportDate || a.date || 0));
+  const latest = sorted[0] || {};
+  const currency = latest?.currencyCode || latest?.currency || quote?.currency || 'USD';
+  const price = toNumber(quote?.last) || toNumber(latest?.close) || toNumber(latest?.adjClose) || toNumber(latest?.tngoLast) || 0;
+  const prevClose = toNumber(quote?.prevClose) || toNumber(latest?.prevClose) || toNumber(latest?.adjPrevClose) || price;
+  const metrics = {
+    price,
+    pe: toNumber(latest?.peRatio) || toNumber(latest?.peRatioTTM),
+    forwardPe: toNumber(latest?.forwardPERatio) || toNumber(latest?.forwardPe),
+    revenueGrowth: percent(latest?.revenueGrowth) ?? percent(latest?.revenueGrowthTTM),
+    eps: toNumber(latest?.eps) || toNumber(latest?.epsTTM) || toNumber(latest?.dilutedEPS),
+    epsTtm: toNumber(latest?.epsTTM) || null,
+    dividendYield: percent(latest?.dividendYield),
+    operatingMargin: percent(latest?.operatingMargin) ?? percent(latest?.operatingMarginTTM),
+    netMargin: percent(latest?.netMargin) ?? percent(latest?.netMarginTTM),
+    grossMargin: percent(latest?.grossMargin) ?? percent(latest?.grossMarginTTM),
+    freeCashFlowPerShare: toNumber(latest?.freeCashFlowPerShare) || toNumber(latest?.freeCashFlowPerShareTTM),
+    returnOnEquity: percent(latest?.returnOnEquity) ?? percent(latest?.roe),
+    debtToEquity: toNumber(latest?.debtToEquity) ?? toNumber(latest?.totalDebtToEquity),
+    marketCap: toNumber(latest?.marketCap) || toNumber(quote?.marketCap),
+    week52High: toNumber(latest?.week52High) || toNumber(latest?.price52WeekHigh),
+    week52Low: toNumber(latest?.week52Low) || toNumber(latest?.price52WeekLow),
+    monthChange: percent(latest?.priceChange1Month) ?? percent(latest?.monthChange),
+    quarterChange: percent(latest?.priceChange3Month) ?? percent(latest?.quarterChange),
+  };
+  const valuations = computeValuation(metrics, price);
+  const qualityScore = computeQualityScore(metrics);
+  const momentumScore = computeMomentumScore(price || prevClose, metrics);
+  const priceChangeAbs = price && prevClose ? price - prevClose : 0;
+  const priceChangePct = prevClose ? priceChangeAbs / prevClose : 0;
+  const events = normaliseNews(news);
+  const documents = deriveDocuments(news, entry.symbol);
+  const history = buildHistory(fundamentals);
+  const compositeScore = clamp((qualityScore * 0.55 + momentumScore * 0.25 + (valuations.upside * 100) * 0.2), 0, 100);
+  return {
+    symbol: entry.symbol,
+    name: latest?.name || latest?.ticker || entry.symbol,
+    exchange: entry.mic || latest?.exchangeCode || '',
+    currency,
+    price,
+    priceChange: {
+      absolute: priceChangeAbs,
+      percent: priceChangePct,
+    },
+    valuations,
+    qualityScore,
+    momentumScore,
+    dividendYield: percent(metrics.dividendYield) ?? 0,
+    marketCapUsd: metrics.marketCap || 0,
+    keyMetrics: formatKeyMetrics(metrics, valuations),
+    metrics,
+    history,
+    events,
+    documents,
+    narrative: buildNarrative(entry.symbol, valuations, qualityScore, momentumScore, events),
+    timestamp: new Date().toISOString(),
+    compositeScore,
+  };
+}
+
+function generateFallbackRecord(symbol, index = 0) {
+  const basePrice = 120 + ((symbol.charCodeAt(0) || 65) % 25) * 2 + index * 3;
+  const fairValue = basePrice * 1.12;
+  const events = [
+    { date: new Date(Date.now() + 14 * 86400000).toISOString(), type: 'Earnings', headline: `${symbol} quarterly earnings call`, summary: 'Consensus expects mid-single-digit revenue growth.', url: '' },
+    { date: new Date(Date.now() + 42 * 86400000).toISOString(), type: 'Product launch', headline: `${symbol} flagship product roadmap`, summary: 'Management teased AI-driven refresh cycle.', url: '' },
+  ];
+  const documents = [
+    { date: new Date(Date.now() - 120 * 86400000).toISOString(), type: 'SEC Filing', title: `${symbol} Form 10-K`, summary: 'Annual report covering fiscal performance and outlook.', url: 'https://www.sec.gov/' },
+    { date: new Date(Date.now() - 30 * 86400000).toISOString(), type: 'Earnings transcript', title: `${symbol} Q&A transcript`, summary: 'Prepared remarks and analyst questions from latest call.', url: 'https://www.sec.gov/' },
+  ];
+  return {
+    symbol,
+    name: `${symbol} Holdings (sample)`,
+    exchange: 'XNAS',
+    currency: 'USD',
+    price: Number(basePrice.toFixed(2)),
+    priceChange: { absolute: 1.2, percent: 0.012 },
+    valuations: {
+      fairValue,
+      rangeLow: fairValue * 0.9,
+      rangeHigh: fairValue * 1.15,
+      methodology: 'Illustrative hybrid model',
+      upside: (fairValue - basePrice) / basePrice,
+      signalLabel: 'Moderate upside',
+      signalClass: 'ok',
+    },
+    qualityScore: 72,
+    momentumScore: 64,
+    dividendYield: 0.006,
+    marketCapUsd: 2.4e11,
+    keyMetrics: [
+      { label: 'Market cap', value: '240.00B' },
+      { label: 'Forward P/E', value: '21.4' },
+      { label: 'PEG (est)', value: '1.4' },
+      { label: 'Dividend yield', value: '0.60%' },
+      { label: 'FCF / share', value: '5.60' },
+      { label: 'Fair value range', value: `${(fairValue * 0.9).toFixed(2)} – ${(fairValue * 1.15).toFixed(2)}` },
+    ],
+    metrics: {
+      pe: 24.1,
+      forwardPe: 21.4,
+      revenueGrowth: 0.09,
+      eps: 5.8,
+      dividendYield: 0.006,
+      operatingMargin: 0.27,
+      netMargin: 0.22,
+      freeCashFlowPerShare: 5.6,
+      returnOnEquity: 0.38,
+      debtToEquity: 1.1,
+      marketCap: 2.4e11,
+      week52High: basePrice * 1.18,
+      week52Low: basePrice * 0.78,
+      monthChange: 0.015,
+      quarterChange: 0.035,
+    },
+    history: [
+      { period: 'FY23', revenueGrowth: 0.08, eps: 5.6, margin: 0.25, leverage: 1.1 },
+      { period: 'FY22', revenueGrowth: 0.07, eps: 5.2, margin: 0.24, leverage: 1.0 },
+    ],
+    events,
+    documents,
+    narrative: `${symbol} sample profile. Configure TIINGO_KEY for live fundamentals.`,
+    timestamp: new Date().toISOString(),
+    compositeScore: 68,
+  };
+}
+
+async function loadRecord(entry, token, quoteMap) {
+  const warnings = [];
+  const [fundamentalsResult, newsResult] = await Promise.allSettled([
+    fetchFundamentals(entry.symbol, entry.mic, token),
+    fetchNews(entry.symbol, token),
+  ]);
+  const fundamentals = fundamentalsResult.status === 'fulfilled' ? fundamentalsResult.value : [];
+  const news = newsResult.status === 'fulfilled' ? newsResult.value : [];
+  if (fundamentalsResult.status === 'rejected') warnings.push(`Fundamentals unavailable: ${fundamentalsResult.reason?.message || fundamentalsResult.reason}`);
+  if (newsResult.status === 'rejected') warnings.push(`News unavailable: ${newsResult.reason?.message || newsResult.reason}`);
+  const quote = quoteMap.get(entry.symbol.toUpperCase()) || null;
+  const record = normaliseRecord(entry, fundamentals, quote, news);
+  if (warnings.length) record.warning = warnings.join(' ');
+  return record;
+}
+
+export default async function handleFundamentalsRequest(request) {
+  const url = new URL(request.url);
+  const symbolParam = url.searchParams.get('symbols') || url.searchParams.get('symbol') || 'AAPL';
+  const exchangeParam = url.searchParams.get('exchange') || '';
+  const entries = parseSymbols(symbolParam, exchangeParam);
+  const token = getTiingoToken();
+  if (!token) {
+    return Response.json({
+      data: entries.map((entry, idx) => generateFallbackRecord(entry.symbol || 'AAPL', idx)),
+      warning: 'Tiingo API key missing. Showing illustrative fundamentals.',
+      fallback: true,
+    }, { headers: corsHeaders });
+  }
+  try {
+    const quoteMap = await fetchQuotes(entries.map((item) => buildTiingoTicker(item.symbol, item.mic)), token).catch(() => new Map());
+    const records = [];
+    for (const entry of entries) {
+      records.push(await loadRecord(entry, token, quoteMap));
+    }
+    return Response.json({ data: records }, { headers: corsHeaders });
+  } catch (error) {
+    return Response.json({
+      data: entries.map((entry, idx) => generateFallbackRecord(entry.symbol || 'AAPL', idx)),
+      warning: `Tiingo fundamentals request failed: ${error.message}`,
+      fallback: true,
+    }, { headers: corsHeaders });
+  }
+}
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';
+  const path = event?.path || '/.netlify/functions/tiingo-fundamentals';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'GET';
+  const request = new Request(url, { method, headers: event?.headers || {} });
+  const response = await handleFundamentalsRequest(request);
+  const headers = {};
+  response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};
+
+export const __testables = {
+  parseSymbols,
+  computeValuation,
+  computeQualityScore,
+  computeMomentumScore,
+  generateFallbackRecord,
+  normaliseRecord,
+};

--- a/netlify/functions/tiingo.js
+++ b/netlify/functions/tiingo.js
@@ -558,6 +558,26 @@ async function handleTiingoRequest(request) {
 
 export default handleTiingoRequest;
 
+export {
+  resolveSymbolRequests,
+  generateMockSeries,
+  normalizeQuote,
+  normalizeCandle,
+  minutesForInterval,
+  buildTiingoTicker,
+  inferCurrency,
+};
+
+export const __testables = {
+  resolveSymbolRequests,
+  generateMockSeries,
+  normalizeQuote,
+  normalizeCandle,
+  minutesForInterval,
+  buildTiingoTicker,
+  inferCurrency,
+};
+
 // Netlify runtime compatibility
 export const handler = async (event) => {
   const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
+    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r pages build/pages && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
     "start": "npx netlify-cli@latest dev",
-    "generate:symbols": "node scripts/build-symbols.mjs"
+    "generate:symbols": "node scripts/build-symbols.mjs",
+    "test": "node --test"
   },
   "devDependencies": {
     "csv-parse": "^5.5.6",

--- a/pages/ai-pages.css
+++ b/pages/ai-pages.css
@@ -1,0 +1,393 @@
+:root {
+  --ai-bg:#0f172a;
+  --ai-panel:#101a33;
+  --ai-panel-alt:#13203d;
+  --ai-border:#1e2a4a;
+  --ai-text:#f4f5f7;
+  --ai-muted:#9aa4c6;
+  --ai-accent:#4f9dff;
+  --ai-green:#4ade80;
+  --ai-red:#f87171;
+  --ai-yellow:#facc15;
+}
+
+body {
+  margin:0;
+  font-family:"Inter",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  background:radial-gradient(circle at top,#102347,#050914 55%);
+  color:var(--ai-text);
+  min-height:100vh;
+  display:flex;
+  flex-direction:column;
+  overflow-x:hidden;
+}
+
+a {
+  color:var(--ai-accent);
+}
+
+a:hover {
+  color:#80c4ff;
+}
+
+.ai-shell {
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  max-width:1400px;
+  margin:0 auto;
+  width:100%;
+  padding:32px 28px 48px;
+  gap:24px;
+}
+
+.ai-header {
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:16px;
+}
+
+.ai-header h1 {
+  margin:0;
+  font-size:2.2rem;
+  letter-spacing:0.02em;
+}
+
+.ai-tagline {
+  color:var(--ai-muted);
+  max-width:560px;
+  line-height:1.5;
+}
+
+.ai-nav {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+
+.ai-nav a {
+  text-decoration:none;
+  border:1px solid var(--ai-border);
+  padding:8px 14px;
+  border-radius:999px;
+  font-size:0.9rem;
+  color:var(--ai-muted);
+  background-color:rgba(79,157,255,0.08);
+  transition:background-color 0.2s ease,color 0.2s ease,border-color 0.2s ease;
+}
+
+.ai-nav a:hover,
+.ai-nav a.active {
+  background:var(--ai-accent);
+  color:#041229;
+  border-color:var(--ai-accent);
+}
+
+.ai-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(320px,1fr));
+  gap:20px;
+}
+
+.ai-card {
+  background:linear-gradient(160deg,rgba(19,32,61,0.98),rgba(12,22,42,0.98));
+  border:1px solid rgba(79,157,255,0.15);
+  border-radius:16px;
+  padding:20px;
+  box-shadow:0 25px 60px rgba(0,0,0,0.25);
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.ai-card h2,
+.ai-card h3 {
+  margin:0;
+  font-size:1.1rem;
+  letter-spacing:0.01em;
+}
+
+.ai-card h2 span,
+.ai-card h3 span {
+  color:var(--ai-accent);
+}
+
+.ai-chip {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 12px;
+  border-radius:999px;
+  font-size:0.78rem;
+  background:rgba(79,157,255,0.12);
+  border:1px solid rgba(79,157,255,0.3);
+  color:var(--ai-muted);
+}
+
+.ai-flex {
+  display:flex;
+  gap:16px;
+  flex-wrap:wrap;
+}
+
+.ai-flex > * {
+  flex:1;
+  min-width:240px;
+}
+
+.ai-section-title {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:12px;
+}
+
+.ai-section-title small {
+  color:var(--ai-muted);
+}
+
+.ai-pill-list {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+
+.ai-pill {
+  padding:6px 12px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.08);
+  font-size:0.8rem;
+  color:var(--ai-muted);
+  background:rgba(15,23,42,0.6);
+}
+
+.ai-status {
+  font-size:0.9rem;
+  color:var(--ai-yellow);
+}
+
+.ai-status.error {
+  color:var(--ai-red);
+}
+
+.ai-status.ok {
+  color:var(--ai-green);
+}
+
+.ai-table {
+  width:100%;
+  border-collapse:collapse;
+  font-size:0.9rem;
+}
+
+.ai-table th,
+.ai-table td {
+  padding:10px;
+  border-bottom:1px solid rgba(255,255,255,0.08);
+  text-align:left;
+}
+
+.ai-table th {
+  font-size:0.78rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:var(--ai-muted);
+}
+
+.ai-metric {
+  font-size:1.3rem;
+  font-weight:600;
+}
+
+.ai-metric.bad {
+  color:var(--ai-red);
+}
+
+.ai-metric.good {
+  color:var(--ai-green);
+}
+
+.ai-list {
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.ai-list-item {
+  padding:12px 14px;
+  border-radius:12px;
+  background:rgba(15,23,42,0.65);
+  border:1px solid rgba(79,157,255,0.08);
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.ai-list-item strong {
+  font-weight:600;
+}
+
+.ai-highlight {
+  font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace;
+  background:rgba(15,23,42,0.55);
+  padding:10px 12px;
+  border-radius:10px;
+  border:1px solid rgba(255,255,255,0.08);
+  font-size:0.88rem;
+  line-height:1.6;
+  white-space:pre-wrap;
+}
+
+.ai-chart-container {
+  position:relative;
+  width:100%;
+  height:360px;
+}
+
+.ai-timeframes {
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+}
+
+.ai-timeframes button {
+  background:rgba(79,157,255,0.12);
+  border:1px solid rgba(79,157,255,0.3);
+  color:var(--ai-text);
+  padding:6px 12px;
+  border-radius:10px;
+  font-size:0.82rem;
+  cursor:pointer;
+  transition:all 0.2s ease;
+}
+
+.ai-timeframes button.active,
+.ai-timeframes button:hover {
+  background:var(--ai-accent);
+  color:#041229;
+  border-color:var(--ai-accent);
+}
+
+.ai-input,
+.ai-select,
+.ai-textarea {
+  width:100%;
+  padding:10px 12px;
+  border-radius:10px;
+  border:1px solid rgba(79,157,255,0.18);
+  background:rgba(12,21,37,0.9);
+  color:var(--ai-text);
+  font-size:0.95rem;
+}
+
+.ai-textarea {
+  min-height:120px;
+  resize:vertical;
+}
+
+.ai-button {
+  background:linear-gradient(120deg,var(--ai-accent),#83b4ff);
+  border:none;
+  color:#041229;
+  font-weight:600;
+  padding:10px 16px;
+  border-radius:12px;
+  cursor:pointer;
+  box-shadow:0 12px 30px rgba(79,157,255,0.35);
+  transition:transform 0.18s ease,box-shadow 0.18s ease;
+}
+
+.ai-button:hover {
+  transform:translateY(-1px);
+  box-shadow:0 16px 34px rgba(79,157,255,0.45);
+}
+
+.ai-signal {
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-size:0.82rem;
+  padding:4px 10px;
+  border-radius:999px;
+  background:rgba(74,222,128,0.1);
+  color:var(--ai-green);
+  border:1px solid rgba(74,222,128,0.4);
+}
+
+.ai-signal.neutral {
+  background:rgba(250,204,21,0.12);
+  color:var(--ai-yellow);
+  border-color:rgba(250,204,21,0.4);
+}
+
+.ai-signal.negative {
+  background:rgba(248,113,113,0.12);
+  color:var(--ai-red);
+  border-color:rgba(248,113,113,0.4);
+}
+
+.ai-search-panel {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.ai-search-results {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  max-height:260px;
+  overflow-y:auto;
+}
+
+.ai-search-result {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:12px;
+  padding:10px 12px;
+  background:rgba(15,23,42,0.6);
+  border-radius:12px;
+  border:1px solid rgba(79,157,255,0.1);
+}
+
+.ai-search-result button {
+  background:rgba(79,157,255,0.2);
+  border:1px solid rgba(79,157,255,0.4);
+  color:var(--ai-text);
+  padding:6px 10px;
+  border-radius:10px;
+  cursor:pointer;
+}
+
+.ai-compact-grid {
+  display:grid;
+  gap:16px;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+}
+
+.ai-footer {
+  padding:24px 0 32px;
+  color:var(--ai-muted);
+  text-align:center;
+  font-size:0.85rem;
+}
+
+@media (max-width:768px) {
+  .ai-shell {
+    padding:24px 16px 48px;
+  }
+
+  .ai-header h1 {
+    font-size:1.7rem;
+  }
+
+  .ai-chart-container {
+    height:300px;
+  }
+}

--- a/pages/ai-research.html
+++ b/pages/ai-research.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Research Lab — Professional Trading Desk</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="ai-pages.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
+</head>
+<body>
+  <div class="ai-shell">
+    <header class="ai-header">
+      <div>
+        <h1>AI Research Lab</h1>
+        <p class="ai-tagline">An institutional-grade intelligence surface for equity research. Search any listing, interrogate company events and filings, and let ChatGPT 5 synthesize a defensible view of intrinsic value in seconds.</p>
+      </div>
+      <nav class="ai-nav">
+        <a href="../index.html">Core Desk</a>
+        <a href="ai-screener.html">AI Screener</a>
+        <a class="active" href="ai-research.html">AI Research Lab</a>
+      </nav>
+    </header>
+
+    <section class="ai-card ai-search-panel">
+      <div class="ai-section-title">
+        <h2>Find a listing</h2>
+        <span class="ai-chip"><i class="fa-solid fa-robot"></i> ChatGPT 5 valuation engine</span>
+      </div>
+      <div class="ai-flex">
+        <label style="flex:2;min-width:220px;">
+          <span class="ai-muted">Search ticker, ISIN, exchange or company</span>
+          <input id="researchSearch" class="ai-input" placeholder="Try AAPL, ASX:WOW, LSE:BARC…" autocomplete="off" />
+        </label>
+        <label style="flex:1;min-width:200px;">
+          <span class="ai-muted">Exchange filter</span>
+          <select id="researchExchange" class="ai-select">
+            <option value="">All venues</option>
+            <option value="XNAS">NASDAQ</option>
+            <option value="XNYS">NYSE</option>
+            <option value="XASE">AMEX</option>
+            <option value="XASX">ASX</option>
+            <option value="XLON">London (LSE)</option>
+            <option value="XTSE">TSX</option>
+            <option value="XHKG">HKEX</option>
+            <option value="XTKS">Tokyo</option>
+            <option value="XETR">XETRA</option>
+          </select>
+        </label>
+      </div>
+      <div id="researchSearchResults" class="ai-search-results"></div>
+    </section>
+
+    <section class="ai-grid">
+      <article class="ai-card">
+        <div class="ai-section-title">
+          <h2>Live market structure <span id="researchSymbolLabel"></span></h2>
+          <div class="ai-timeframes" id="researchTimeframes">
+            <button data-kind="intraday" data-interval="5min" data-limit="78" class="active">1D</button>
+            <button data-kind="intraday" data-interval="15min" data-limit="156">1W</button>
+            <button data-kind="eod" data-interval="daily" data-limit="90">3M</button>
+            <button data-kind="eod" data-interval="daily" data-limit="180">6M</button>
+            <button data-kind="eod" data-interval="daily" data-limit="365">1Y</button>
+            <button data-kind="eod" data-interval="daily" data-limit="730">2Y</button>
+          </div>
+        </div>
+        <div class="ai-chart-container">
+          <canvas id="researchChart"></canvas>
+        </div>
+        <div class="ai-status" id="researchChartStatus"></div>
+      </article>
+
+      <article class="ai-card" id="researchSnapshot">
+        <div class="ai-section-title">
+          <h2>Quant snapshot</h2>
+          <small id="researchSnapshotTimestamp"></small>
+        </div>
+        <div class="ai-grid" style="grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:16px;">
+          <div>
+            <div class="ai-muted">Last price</div>
+            <div class="ai-metric" id="researchLastPrice">—</div>
+            <div class="ai-status" id="researchLastChange">—</div>
+          </div>
+          <div>
+            <div class="ai-muted">Valuation</div>
+            <div class="ai-metric" id="researchFairValue">—</div>
+            <div class="ai-status" id="researchValuationSignal">—</div>
+          </div>
+          <div>
+            <div class="ai-muted">Quality</div>
+            <div class="ai-metric" id="researchQualityScore">—</div>
+            <div class="ai-status" id="researchQualityLabel">—</div>
+          </div>
+          <div>
+            <div class="ai-muted">Momentum</div>
+            <div class="ai-metric" id="researchMomentum">—</div>
+            <div class="ai-status" id="researchMomentumLabel">—</div>
+          </div>
+        </div>
+        <div class="ai-pill-list" id="researchKeyMetrics"></div>
+      </article>
+    </section>
+
+    <section class="ai-grid">
+      <article class="ai-card" id="researchAiPanel">
+        <div class="ai-section-title">
+          <h2>ChatGPT 5 view</h2>
+          <div class="ai-status" id="researchAiStatus">Awaiting prompt…</div>
+        </div>
+        <div class="ai-highlight" id="researchAiOutput">Select a company to generate an AI research note. The assistant will blend price action, fundamentals, filings and event risk into a concise thesis with a fair value range.</div>
+        <button class="ai-button" id="researchAiRefresh"><i class="fa-solid fa-wand-magic-sparkles"></i>&nbsp;Refresh insight</button>
+      </article>
+
+      <article class="ai-card" id="researchEvents">
+        <div class="ai-section-title">
+          <h2>Company events</h2>
+          <small class="ai-status" id="researchEventsStatus">Waiting for symbol…</small>
+        </div>
+        <ul class="ai-list" id="researchEventsList"></ul>
+      </article>
+    </section>
+
+    <section class="ai-grid">
+      <article class="ai-card" id="researchDocuments">
+        <div class="ai-section-title">
+          <h2>Key filings &amp; transcripts</h2>
+          <small class="ai-status" id="researchDocumentsStatus">—</small>
+        </div>
+        <ul class="ai-list" id="researchDocumentsList"></ul>
+      </article>
+      <article class="ai-card" id="researchFundamentals">
+        <div class="ai-section-title">
+          <h2>Fundamental trendlines</h2>
+          <small class="ai-status" id="researchFundamentalsStatus">—</small>
+        </div>
+        <table class="ai-table" id="researchFundamentalsTable">
+          <thead>
+            <tr><th>Period</th><th>Revenue YoY</th><th>EPS</th><th>Margins</th><th>Leverage</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </section>
+  </div>
+
+  <footer class="ai-footer">Built for deep work. Configure API keys for Tiingo, NewsAPI and OpenAI/ChatGPT 5 in your Netlify environment to go live.</footer>
+
+  <script type="module" src="ai-utils.js"></script>
+  <script type="module" src="ai-research.js"></script>
+</body>
+</html>

--- a/pages/ai-research.js
+++ b/pages/ai-research.js
@@ -1,0 +1,396 @@
+import {
+  debounce,
+  searchSymbols,
+  renderSearchResults,
+  loadSeries,
+  loadFundamentals,
+  runAiAnalyst,
+  formatCurrency,
+  formatPercent,
+  formatNumber,
+  scoreToLabel,
+  momentumToLabel,
+  safeArray,
+  formatDate,
+  clamp,
+} from './ai-utils.js';
+
+const dom = {
+  searchInput: document.getElementById('researchSearch'),
+  searchResults: document.getElementById('researchSearchResults'),
+  exchangeSelect: document.getElementById('researchExchange'),
+  symbolLabel: document.getElementById('researchSymbolLabel'),
+  chartStatus: document.getElementById('researchChartStatus'),
+  timeframes: document.getElementById('researchTimeframes'),
+  chartCanvas: document.getElementById('researchChart'),
+  snapshotTimestamp: document.getElementById('researchSnapshotTimestamp'),
+  lastPrice: document.getElementById('researchLastPrice'),
+  lastChange: document.getElementById('researchLastChange'),
+  fairValue: document.getElementById('researchFairValue'),
+  valuationSignal: document.getElementById('researchValuationSignal'),
+  qualityScore: document.getElementById('researchQualityScore'),
+  qualityLabel: document.getElementById('researchQualityLabel'),
+  momentumScore: document.getElementById('researchMomentum'),
+  momentumLabel: document.getElementById('researchMomentumLabel'),
+  keyMetrics: document.getElementById('researchKeyMetrics'),
+  eventsStatus: document.getElementById('researchEventsStatus'),
+  eventsList: document.getElementById('researchEventsList'),
+  documentsStatus: document.getElementById('researchDocumentsStatus'),
+  documentsList: document.getElementById('researchDocumentsList'),
+  fundamentalsStatus: document.getElementById('researchFundamentalsStatus'),
+  fundamentalsTable: document.querySelector('#researchFundamentalsTable tbody'),
+  aiStatus: document.getElementById('researchAiStatus'),
+  aiOutput: document.getElementById('researchAiOutput'),
+  aiRefresh: document.getElementById('researchAiRefresh'),
+};
+
+const state = {
+  symbol: 'AAPL',
+  exchange: '',
+  fundamentals: null,
+  aiPayload: null,
+  chart: null,
+  chartConfig: { kind: 'intraday', interval: '5min', limit: 78 },
+};
+
+const buildChart = () => {
+  if (state.chart) return state.chart;
+  state.chart = new Chart(dom.chartCanvas.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label: 'Price',
+          data: [],
+          borderColor: '#4f9dff',
+          backgroundColor: 'rgba(79,157,255,0.15)',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.25,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          mode: 'index',
+          intersect: false,
+          callbacks: {
+            label: (ctx) => `${formatCurrency(ctx.parsed.y)}`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: '#9aa4c6',
+            maxTicksLimit: 6,
+          },
+          grid: { display: false },
+        },
+        y: {
+          ticks: {
+            color: '#9aa4c6',
+            callback: (value) => formatCurrency(value),
+          },
+          grid: { color: 'rgba(79,157,255,0.08)' },
+        },
+      },
+    },
+  });
+  return state.chart;
+};
+
+function formatSeriesTimestamp(ts, useDateOnly = false) {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  if (useDateOnly) return d.toLocaleDateString();
+  return d.toLocaleString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' });
+}
+
+async function refreshSeries() {
+  dom.chartStatus.textContent = 'Loading price history…';
+  const { kind, interval, limit } = state.chartConfig;
+  try {
+    const result = await loadSeries(state.symbol, {
+      kind,
+      interval,
+      limit,
+      exchange: state.exchange,
+    });
+    const points = safeArray(result?.data).slice().sort((a, b) => new Date(a.date) - new Date(b.date));
+    const useDateOnly = kind === 'eod';
+    const chart = buildChart();
+    chart.data.labels = points.map((row) => formatSeriesTimestamp(row.date, useDateOnly));
+    chart.data.datasets[0].data = points.map((row) => Number(row.close ?? row.price ?? row.last) || null);
+    chart.update('none');
+    const warning = result?.warning;
+    dom.chartStatus.textContent = warning || '';
+    if (!points.length) {
+      dom.chartStatus.textContent = warning || 'No series data returned.';
+    }
+  } catch (error) {
+    console.error('Failed to load series', error);
+    dom.chartStatus.textContent = 'Price history unavailable. Check Tiingo connectivity.';
+  }
+}
+
+function renderKeyMetrics(items = []) {
+  dom.keyMetrics.innerHTML = '';
+  if (!items.length) return;
+  const fragment = document.createDocumentFragment();
+  items.forEach((item) => {
+    const pill = document.createElement('span');
+    pill.className = 'ai-pill';
+    pill.textContent = `${item.label}: ${item.value}`;
+    fragment.appendChild(pill);
+  });
+  dom.keyMetrics.appendChild(fragment);
+}
+
+function updateSnapshot(data) {
+  if (!data) {
+    dom.lastPrice.textContent = '—';
+    dom.lastChange.textContent = '—';
+    dom.fairValue.textContent = '—';
+    dom.valuationSignal.textContent = '—';
+    dom.qualityScore.textContent = '—';
+    dom.qualityLabel.textContent = '—';
+    dom.momentumScore.textContent = '—';
+    dom.momentumLabel.textContent = '—';
+    dom.keyMetrics.innerHTML = '';
+    dom.snapshotTimestamp.textContent = '';
+    dom.symbolLabel.textContent = '';
+    return;
+  }
+  const currency = data.currency || 'USD';
+  dom.symbolLabel.textContent = `${data.symbol}${data.exchange ? ` · ${data.exchange}` : ''}`;
+  dom.snapshotTimestamp.textContent = data.timestamp ? `Updated ${formatDate(data.timestamp)}` : '';
+  dom.lastPrice.textContent = formatCurrency(data.price, currency, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const delta = data.priceChange || {};
+  dom.lastChange.textContent = `${formatCurrency(delta.absolute ?? 0, currency, { maximumFractionDigits: 2 })} (${formatPercent(delta.percent ?? 0, 2)})`;
+  dom.lastChange.className = `ai-status ${delta.percent > 0 ? 'ok' : delta.percent < 0 ? 'error' : ''}`;
+  const valuation = data.valuations || {};
+  dom.fairValue.textContent = valuation.fairValue ? formatCurrency(valuation.fairValue, currency) : '—';
+  dom.valuationSignal.textContent = valuation.signalLabel || '—';
+  dom.valuationSignal.className = `ai-status ${valuation.signalClass || ''}`.trim();
+  dom.qualityScore.textContent = data.qualityScore != null ? formatNumber(data.qualityScore, { maximumFractionDigits: 1 }) : '—';
+  dom.qualityLabel.textContent = scoreToLabel(data.qualityScore);
+  dom.qualityLabel.className = 'ai-status';
+  dom.momentumScore.textContent = data.momentumScore != null ? formatNumber(data.momentumScore, { maximumFractionDigits: 1 }) : '—';
+  dom.momentumLabel.textContent = momentumToLabel(data.momentumScore);
+  dom.momentumLabel.className = 'ai-status';
+  renderKeyMetrics(data.keyMetrics || []);
+}
+
+function renderEvents(list = []) {
+  dom.eventsList.innerHTML = '';
+  if (!list.length) {
+    dom.eventsStatus.textContent = 'No upcoming events on file.';
+    return;
+  }
+  dom.eventsStatus.textContent = `${list.length} events tracked`;
+  const fragment = document.createDocumentFragment();
+  list.forEach((event) => {
+    const li = document.createElement('li');
+    li.className = 'ai-list-item';
+    const headline = document.createElement('strong');
+    headline.textContent = event.headline || event.type || 'Event';
+    const meta = document.createElement('div');
+    meta.className = 'ai-muted';
+    const importance = event.importance ? ` · ${event.importance}` : '';
+    meta.textContent = `${formatDate(event.date)} · ${event.type || 'Event'}${importance}`;
+    const detail = document.createElement('div');
+    detail.textContent = event.summary || '';
+    li.append(headline, meta);
+    if (event.url) {
+      const link = document.createElement('a');
+      link.href = event.url;
+      link.target = '_blank';
+      link.rel = 'noreferrer noopener';
+      link.textContent = 'Open source';
+      li.appendChild(link);
+    }
+    if (event.summary) li.appendChild(detail);
+    fragment.appendChild(li);
+  });
+  dom.eventsList.appendChild(fragment);
+}
+
+function renderDocuments(list = []) {
+  dom.documentsList.innerHTML = '';
+  if (!list.length) {
+    dom.documentsStatus.textContent = 'Filings cache empty.';
+    return;
+  }
+  dom.documentsStatus.textContent = `${list.length} artefacts ready`;
+  const fragment = document.createDocumentFragment();
+  list.forEach((doc) => {
+    const li = document.createElement('li');
+    li.className = 'ai-list-item';
+    const title = document.createElement('strong');
+    title.textContent = doc.title || `${doc.type || 'Document'} (${formatDate(doc.date)})`;
+    const meta = document.createElement('div');
+    meta.className = 'ai-muted';
+    meta.textContent = `${formatDate(doc.date)}${doc.type ? ` · ${doc.type}` : ''}`;
+    li.append(title, meta);
+    if (doc.summary) {
+      const summary = document.createElement('div');
+      summary.textContent = doc.summary;
+      li.appendChild(summary);
+    }
+    if (doc.url) {
+      const link = document.createElement('a');
+      link.href = doc.url;
+      link.target = '_blank';
+      link.rel = 'noreferrer noopener';
+      link.textContent = 'Open document';
+      li.appendChild(link);
+    }
+    fragment.appendChild(li);
+  });
+  dom.documentsList.appendChild(fragment);
+}
+
+function renderFundamentalsTable(rows = []) {
+  dom.fundamentalsTable.innerHTML = '';
+  if (!rows.length) {
+    dom.fundamentalsStatus.textContent = 'No historical metrics';
+    return;
+  }
+  dom.fundamentalsStatus.textContent = '';
+  const fragment = document.createDocumentFragment();
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    const cells = [
+      row.period || '—',
+      formatPercent(row.revenueGrowth ?? 0, 1),
+      row.eps != null ? formatNumber(row.eps, { maximumFractionDigits: 2 }) : '—',
+      formatPercent(row.margin ?? 0, 1),
+      row.leverage != null ? formatNumber(row.leverage, { maximumFractionDigits: 2 }) : '—',
+    ];
+    cells.forEach((value) => {
+      const td = document.createElement('td');
+      td.textContent = value;
+      tr.appendChild(td);
+    });
+    fragment.appendChild(tr);
+  });
+  dom.fundamentalsTable.appendChild(fragment);
+}
+
+async function refreshAi(force = false) {
+  if (!state.aiPayload) return;
+  dom.aiStatus.textContent = 'Requesting ChatGPT 5 insight…';
+  dom.aiStatus.className = 'ai-status';
+  try {
+    const payload = force ? { ...state.aiPayload, force } : state.aiPayload;
+    const response = await runAiAnalyst(payload);
+    dom.aiOutput.textContent = response?.content || 'AI analyst returned no content.';
+    dom.aiStatus.textContent = response?.warning ? `⚠️ ${response.warning}` : response?.model ? `Model: ${response.model}` : 'ChatGPT 5 insight ready';
+    if (response?.warning) dom.aiStatus.className = 'ai-status error';
+  } catch (error) {
+    dom.aiOutput.textContent = 'Unable to reach the AI analyst. Configure OPENAI_API_KEY in your environment.';
+    dom.aiStatus.textContent = 'AI offline';
+    dom.aiStatus.className = 'ai-status error';
+  }
+}
+
+async function refreshFundamentals() {
+  dom.eventsStatus.textContent = 'Loading…';
+  dom.documentsStatus.textContent = 'Loading…';
+  dom.fundamentalsStatus.textContent = 'Loading…';
+  try {
+    const response = await loadFundamentals([state.symbol], { exchange: state.exchange });
+    const record = safeArray(response?.data)[0];
+    state.fundamentals = record || null;
+    if (!record) {
+      dom.eventsStatus.textContent = 'No data available.';
+      dom.documentsStatus.textContent = 'No data available.';
+      dom.fundamentalsStatus.textContent = 'No data available.';
+      updateSnapshot(null);
+      return;
+    }
+    updateSnapshot(record);
+    renderEvents(record.events || []);
+    renderDocuments(record.documents || []);
+    renderFundamentalsTable(record.history || []);
+    state.aiPayload = {
+      mode: 'single-equity',
+      symbol: record.symbol,
+      name: record.name,
+      currency: record.currency,
+      price: record.price,
+      valuations: record.valuations,
+      qualityScore: record.qualityScore,
+      momentumScore: record.momentumScore,
+      events: record.events,
+      documents: record.documents,
+      metrics: record.metrics,
+      narrative: record.narrative,
+    };
+    await refreshAi();
+  } catch (error) {
+    console.error('Fundamentals fetch failed', error);
+    dom.eventsStatus.textContent = 'Unable to load events.';
+    dom.documentsStatus.textContent = 'Unable to load documents.';
+    dom.fundamentalsStatus.textContent = 'Unable to load fundamentals.';
+  }
+}
+
+const handleSearch = debounce(async () => {
+  const query = dom.searchInput.value;
+  const exchange = dom.exchangeSelect.value;
+  if (!query) {
+    dom.searchResults.innerHTML = '';
+    return;
+  }
+  dom.searchResults.innerHTML = '<div class="ai-status">Searching…</div>';
+  const matches = await searchSymbols(query, { exchange, limit: 25 });
+  renderSearchResults(dom.searchResults, matches, (item) => {
+    dom.searchResults.innerHTML = '';
+    selectSymbol(item.symbol, item.mic || exchange, item.name);
+  });
+}, 260);
+
+function selectSymbol(symbol, exchange = '', name = '') {
+  state.symbol = (symbol || 'AAPL').toUpperCase();
+  state.exchange = exchange || '';
+  state.chartConfig = { kind: 'intraday', interval: '5min', limit: 78 };
+  dom.aiOutput.textContent = 'Refreshing…';
+  dom.aiStatus.textContent = 'Preparing insight';
+  dom.aiStatus.className = 'ai-status';
+  dom.symbolLabel.textContent = `${state.symbol}${exchange ? ` · ${exchange}` : ''}`;
+  if (name) dom.symbolLabel.textContent += ` — ${name}`;
+  dom.searchInput.value = state.symbol;
+  dom.timeframes.querySelectorAll('button').forEach((btn, idx) => {
+    btn.classList.toggle('active', idx === 0);
+  });
+  refreshFundamentals();
+  refreshSeries();
+}
+
+dom.searchInput.addEventListener('input', handleSearch);
+dom.exchangeSelect.addEventListener('change', () => {
+  if (dom.searchInput.value) handleSearch();
+});
+dom.aiRefresh.addEventListener('click', () => refreshAi(true));
+
+dom.timeframes.querySelectorAll('button').forEach((button) => {
+  button.addEventListener('click', (event) => {
+    dom.timeframes.querySelectorAll('button').forEach((btn) => btn.classList.remove('active'));
+    button.classList.add('active');
+    const { kind, interval, limit } = event.currentTarget.dataset;
+    state.chartConfig = {
+      kind: kind || 'intraday',
+      interval: interval || '5min',
+      limit: clamp(Number(limit) || 78, 10, 1500),
+    };
+    refreshSeries();
+  });
+});
+
+selectSymbol(state.symbol);

--- a/pages/ai-screener.html
+++ b/pages/ai-screener.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Screener — Professional Trading Desk</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="ai-pages.css" />
+</head>
+<body>
+  <div class="ai-shell">
+    <header class="ai-header">
+      <div>
+        <h1>AI Screener</h1>
+        <p class="ai-tagline">Design intelligent universes, surface catalysts and let ChatGPT 5 draft actionable playbooks. Pair Tiingo market structure with fundamentals and quality signals in seconds.</p>
+      </div>
+      <nav class="ai-nav">
+        <a href="../index.html">Core Desk</a>
+        <a class="active" href="ai-screener.html">AI Screener</a>
+        <a href="ai-research.html">AI Research Lab</a>
+      </nav>
+    </header>
+
+    <section class="ai-card">
+      <div class="ai-section-title">
+        <h2>Build a screen</h2>
+        <small class="ai-status" id="screenerStatus">Waiting for criteria…</small>
+      </div>
+      <div class="ai-grid" style="grid-template-columns:repeat(auto-fit,minmax(220px,1fr));">
+        <label>
+          <span class="ai-muted">Universe search</span>
+          <input id="screenerSearch" class="ai-input" placeholder="Add tickers or keywords" autocomplete="off" />
+        </label>
+        <label>
+          <span class="ai-muted">Exchange</span>
+          <select id="screenerExchange" class="ai-select">
+            <option value="">All</option>
+            <option value="XNAS">NASDAQ</option>
+            <option value="XNYS">NYSE</option>
+            <option value="XASE">AMEX</option>
+            <option value="XASX">ASX</option>
+            <option value="XTSX">TSXV</option>
+            <option value="XTSE">TSX</option>
+            <option value="XHKG">HKEX</option>
+            <option value="XLON">LSE</option>
+          </select>
+        </label>
+        <label>
+          <span class="ai-muted">Min market cap (USD m)</span>
+          <input id="screenerMinCap" class="ai-input" type="number" min="0" step="100" placeholder="500" />
+        </label>
+        <label>
+          <span class="ai-muted">Max forward P/E</span>
+          <input id="screenerMaxPe" class="ai-input" type="number" min="0" step="1" placeholder="30" />
+        </label>
+        <label>
+          <span class="ai-muted">Min dividend yield (%)</span>
+          <input id="screenerMinYield" class="ai-input" type="number" min="0" max="25" step="0.1" placeholder="0" />
+        </label>
+        <label>
+          <span class="ai-muted">Momentum lookback (days)</span>
+          <input id="screenerMomentumWindow" class="ai-input" type="number" min="10" max="250" step="5" value="63" />
+        </label>
+      </div>
+      <div class="ai-search-results" id="screenerSearchResults"></div>
+      <div class="ai-flex">
+        <button class="ai-button" id="screenerRun"><i class="fa-solid fa-filter-circle-dollar"></i>&nbsp;Run screen</button>
+        <button class="ai-button" id="screenerClear" style="background:rgba(79,157,255,0.16);color:var(--ai-text);box-shadow:none;">Clear</button>
+      </div>
+    </section>
+
+    <section class="ai-card">
+      <div class="ai-section-title">
+        <h2>Screening universe</h2>
+        <small class="ai-status" id="screenerUniverseStatus">No selections yet.</small>
+      </div>
+      <table class="ai-table" id="screenerTable">
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Name</th>
+            <th>Price</th>
+            <th>Fair value</th>
+            <th>Quality</th>
+            <th>Momentum</th>
+            <th>Yield</th>
+            <th>Score</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <section class="ai-grid">
+      <article class="ai-card">
+        <div class="ai-section-title">
+          <h2>Portfolio intelligence</h2>
+          <small class="ai-status" id="screenerPortfolioStatus">Awaiting dataset…</small>
+        </div>
+        <div class="ai-compact-grid" id="screenerPortfolioStats"></div>
+      </article>
+      <article class="ai-card">
+        <div class="ai-section-title">
+          <h2>ChatGPT 5 watchlist brief</h2>
+          <small class="ai-status" id="screenerAiStatus">Ready</small>
+        </div>
+        <div class="ai-highlight" id="screenerAiOutput">Load a watchlist to draft a multi-asset playbook. The AI will rank opportunities, highlight event risk and flag dislocations.</div>
+        <button class="ai-button" id="screenerAiRun"><i class="fa-solid fa-lightbulb"></i>&nbsp;Generate playbook</button>
+      </article>
+    </section>
+  </div>
+
+  <footer class="ai-footer">Uses Tiingo fundamentals &amp; prices with AI overlays. Configure API keys to activate live data.</footer>
+
+  <script type="module" src="ai-utils.js"></script>
+  <script type="module" src="ai-screener.js"></script>
+</body>
+</html>

--- a/pages/ai-screener.js
+++ b/pages/ai-screener.js
@@ -1,0 +1,235 @@
+import {
+  debounce,
+  searchSymbols,
+  renderSearchResults,
+  loadFundamentals,
+  runAiAnalyst,
+  formatCurrency,
+  formatPercent,
+  formatNumber,
+  scoreToLabel,
+  momentumToLabel,
+  computePortfolioStats,
+  renderPortfolioStats,
+  uniqSymbols,
+  safeArray,
+} from './ai-utils.js';
+
+const dom = {
+  searchInput: document.getElementById('screenerSearch'),
+  searchResults: document.getElementById('screenerSearchResults'),
+  exchangeSelect: document.getElementById('screenerExchange'),
+  minCap: document.getElementById('screenerMinCap'),
+  maxPe: document.getElementById('screenerMaxPe'),
+  minYield: document.getElementById('screenerMinYield'),
+  momentumWindow: document.getElementById('screenerMomentumWindow'),
+  runButton: document.getElementById('screenerRun'),
+  clearButton: document.getElementById('screenerClear'),
+  status: document.getElementById('screenerStatus'),
+  tableBody: document.querySelector('#screenerTable tbody'),
+  universeStatus: document.getElementById('screenerUniverseStatus'),
+  portfolioStatus: document.getElementById('screenerPortfolioStatus'),
+  portfolioStats: document.getElementById('screenerPortfolioStats'),
+  aiStatus: document.getElementById('screenerAiStatus'),
+  aiOutput: document.getElementById('screenerAiOutput'),
+  aiRun: document.getElementById('screenerAiRun'),
+};
+
+const state = {
+  selections: new Map(),
+  rows: [],
+  lastQueryResults: [],
+  aiPayload: null,
+};
+
+function updateUniverseStatus() {
+  const count = state.selections.size;
+  dom.universeStatus.textContent = count ? `${count} instruments selected` : 'No selections yet.';
+}
+
+function addSelection(item) {
+  if (!item?.symbol) return;
+  const sym = item.symbol.toUpperCase();
+  if (state.selections.has(sym)) return;
+  state.selections.set(sym, { symbol: sym, mic: item.mic || '', name: item.name || '' });
+  updateUniverseStatus();
+}
+
+const handleSearch = debounce(async () => {
+  const query = dom.searchInput.value.trim();
+  if (!query) {
+    dom.searchResults.innerHTML = '';
+    return;
+  }
+  dom.searchResults.innerHTML = '<div class="ai-status">Scanning universe…</div>';
+  const exchange = dom.exchangeSelect.value;
+  const matches = await searchSymbols(query, { exchange, limit: 30 });
+  state.lastQueryResults = matches;
+  renderSearchResults(dom.searchResults, matches, (item) => {
+    addSelection(item);
+    dom.searchResults.innerHTML = '';
+    dom.searchInput.value = '';
+  });
+}, 240);
+
+dom.searchInput.addEventListener('input', handleSearch);
+dom.exchangeSelect.addEventListener('change', () => {
+  if (dom.searchInput.value) handleSearch();
+});
+
+dom.clearButton.addEventListener('click', () => {
+  state.selections.clear();
+  state.rows = [];
+  state.aiPayload = null;
+  dom.tableBody.innerHTML = '';
+  dom.aiOutput.textContent = 'Load a watchlist to draft a multi-asset playbook. The AI will rank opportunities, highlight event risk and flag dislocations.';
+  dom.aiStatus.textContent = 'Ready';
+  renderPortfolioStats(dom.portfolioStats, []);
+  updateUniverseStatus();
+});
+
+function buildFilters() {
+  return {
+    minCap: Number(dom.minCap.value) || 0,
+    maxPe: Number(dom.maxPe.value) || Number.POSITIVE_INFINITY,
+    minYield: (Number(dom.minYield.value) || 0) / 100,
+    momentumWindow: Number(dom.momentumWindow.value) || 63,
+  };
+}
+
+function applyFilters(rows, filters) {
+  return rows.filter((row) => {
+    if (filters.minCap && (row.marketCapUsd ?? 0) < filters.minCap * 1_000_000) return false;
+    if (Number.isFinite(filters.maxPe) && filters.maxPe > 0) {
+      const forwardPe = row.metrics?.forwardPe ?? row.metrics?.pe ?? Infinity;
+      if (forwardPe > filters.maxPe) return false;
+    }
+    if (filters.minYield && (row.dividendYield ?? 0) < filters.minYield) return false;
+    return true;
+  });
+}
+
+function renderRows(rows) {
+  dom.tableBody.innerHTML = '';
+  if (!rows.length) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 9;
+    td.className = 'ai-status';
+    td.textContent = 'No matches for the current filters.';
+    tr.appendChild(td);
+    dom.tableBody.appendChild(tr);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    const cells = [
+      row.symbol,
+      row.name || '—',
+      formatCurrency(row.price, row.currency || 'USD'),
+      row.valuations?.fairValue ? `${formatCurrency(row.valuations.fairValue, row.currency || 'USD')} (${formatPercent(row.upside ?? 0, 1)})` : '—',
+      `${formatNumber(row.qualityScore ?? 0, { maximumFractionDigits: 0 })} (${scoreToLabel(row.qualityScore)})`,
+      `${formatNumber(row.momentumScore ?? 0, { maximumFractionDigits: 0 })} (${momentumToLabel(row.momentumScore)})`,
+      formatPercent(row.dividendYield ?? 0, 2),
+      formatNumber(row.compositeScore ?? 0, { maximumFractionDigits: 1 }),
+    ];
+    cells.forEach((value) => {
+      const td = document.createElement('td');
+      td.textContent = value;
+      tr.appendChild(td);
+    });
+    const actionTd = document.createElement('td');
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = 'Remove';
+    removeBtn.className = 'ai-button';
+    removeBtn.style.background = 'rgba(248,113,113,0.2)';
+    removeBtn.style.color = '#f87171';
+    removeBtn.style.boxShadow = 'none';
+    removeBtn.addEventListener('click', () => {
+      state.selections.delete(row.symbol);
+      updateUniverseStatus();
+      runScreen();
+    });
+    actionTd.appendChild(removeBtn);
+    tr.appendChild(actionTd);
+    fragment.appendChild(tr);
+  });
+  dom.tableBody.appendChild(fragment);
+}
+
+async function runScreen() {
+  if (!state.selections.size && !state.lastQueryResults.length) {
+    dom.status.textContent = 'Add tickers or a query first.';
+    return;
+  }
+  dom.status.textContent = 'Pulling Tiingo fundamentals…';
+  try {
+    const symbols = state.selections.size
+      ? Array.from(state.selections.keys())
+      : uniqSymbols(state.lastQueryResults.map((item) => item.symbol)).slice(0, 12);
+    if (!symbols.length) {
+      dom.status.textContent = 'No symbols available for screening.';
+      return;
+    }
+    const fundamentals = await loadFundamentals(symbols, { exchange: dom.exchangeSelect.value });
+    const rows = applyFilters(safeArray(fundamentals?.data), buildFilters())
+      .map((row) => ({
+        ...row,
+        upside: row.valuations?.upside ?? 0,
+        compositeScore: row.compositeScore ?? ((row.qualityScore ?? 0) * 0.6 + (row.momentumScore ?? 0) * 0.4) / 1,
+      }))
+      .sort((a, b) => (b.compositeScore ?? 0) - (a.compositeScore ?? 0));
+    state.rows = rows;
+    renderRows(rows);
+    renderPortfolioStats(dom.portfolioStats, computePortfolioStats(rows));
+    dom.portfolioStatus.textContent = rows.length ? `${rows.length} candidates` : 'Awaiting dataset…';
+    dom.status.textContent = fundamentals?.warning ? `Warning: ${fundamentals.warning}` : 'Screen complete';
+    state.aiPayload = {
+      mode: 'screen',
+      universe: rows.map((row) => ({
+        symbol: row.symbol,
+        name: row.name,
+        currency: row.currency,
+        price: row.price,
+        fairValue: row.valuations?.fairValue,
+        upside: row.upside,
+        qualityScore: row.qualityScore,
+        momentumScore: row.momentumScore,
+        dividendYield: row.dividendYield,
+        events: row.events?.slice?.(0, 3) || [],
+      })),
+      filters: buildFilters(),
+    };
+  } catch (error) {
+    console.error('Screen failed', error);
+    dom.status.textContent = 'Screen failed. Verify Tiingo configuration.';
+  }
+}
+
+dom.runButton.addEventListener('click', runScreen);
+
+dom.aiRun.addEventListener('click', async () => {
+  if (!state.aiPayload || !state.rows.length) {
+    dom.aiStatus.textContent = 'Add instruments and run the screen first.';
+    return;
+  }
+  dom.aiStatus.textContent = 'Requesting ChatGPT 5 playbook…';
+  dom.aiStatus.className = 'ai-status';
+  try {
+    const response = await runAiAnalyst(state.aiPayload);
+    dom.aiOutput.textContent = response?.content || 'AI analyst produced no output.';
+    dom.aiStatus.textContent = response?.model ? `Model: ${response.model}` : 'ChatGPT 5 playbook ready';
+    if (response?.warning) {
+      dom.aiStatus.textContent = `⚠️ ${response.warning}`;
+      dom.aiStatus.className = 'ai-status error';
+    }
+  } catch (error) {
+    dom.aiOutput.textContent = 'AI playbook unavailable. Configure OPENAI_API_KEY to enable insights.';
+    dom.aiStatus.textContent = 'AI offline';
+    dom.aiStatus.className = 'ai-status error';
+  }
+});
+
+updateUniverseStatus();

--- a/pages/ai-utils.js
+++ b/pages/ai-utils.js
@@ -1,0 +1,251 @@
+const NETLIFY_BASE = '/.netlify/functions';
+
+export const endpoints = {
+  search: `${NETLIFY_BASE}/search`,
+  tiingo: `${NETLIFY_BASE}/tiingo`,
+  fundamentals: `${NETLIFY_BASE}/tiingo-fundamentals`,
+  aiAnalyst: `${NETLIFY_BASE}/ai-analyst`,
+};
+
+export function debounce(fn, wait = 220) {
+  let timeout = 0;
+  return (...args) => {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), wait);
+  };
+}
+
+export const formatCurrency = (value, currency = 'USD', options = {}) => {
+  if (value == null || Number.isNaN(value)) return '—';
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: options.maximumFractionDigits ?? 2,
+      minimumFractionDigits: options.minimumFractionDigits ?? 0,
+    }).format(value);
+  } catch (err) {
+    return `${currency} ${value.toFixed(options.maximumFractionDigits ?? 2)}`;
+  }
+};
+
+export const formatNumber = (value, options = {}) => {
+  if (value == null || Number.isNaN(value)) return '—';
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: options.maximumFractionDigits ?? 2,
+    minimumFractionDigits: options.minimumFractionDigits ?? 0,
+    notation: options.notation,
+  });
+  return formatter.format(value);
+};
+
+export const formatPercent = (value, digits = 2) => {
+  if (value == null || Number.isNaN(value)) return '—';
+  const percent = value * 100;
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: Math.min(2, digits),
+  });
+  return `${percent >= 0 ? '+' : ''}${formatter.format(percent)}%`;
+};
+
+export async function fetchJson(input, init) {
+  const response = await fetch(input, init);
+  const text = await response.text();
+  if (!text) {
+    if (!response.ok) throw new Error(`Request failed (${response.status})`);
+    return {};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Malformed JSON response: ${text.slice(0, 160)}`);
+  }
+  if (!response.ok) {
+    const message = parsed?.error || parsed?.message || response.statusText;
+    throw new Error(message);
+  }
+  return parsed;
+}
+
+export async function searchSymbols(query, { exchange = '', limit = 15 } = {}) {
+  const cleaned = (query || '').trim();
+  if (!cleaned) return [];
+  const url = new URL(endpoints.search, window.location.origin);
+  url.searchParams.set('q', cleaned);
+  if (exchange) url.searchParams.set('exchange', exchange);
+  url.searchParams.set('limit', String(limit));
+  try {
+    const result = await fetchJson(url);
+    return Array.isArray(result?.data) ? result.data : [];
+  } catch (error) {
+    console.warn('Symbol search failed', error);
+    return [];
+  }
+}
+
+export async function loadSeries(symbol, { kind = 'intraday', interval = '5min', limit = 78, exchange = '' } = {}) {
+  const url = new URL(endpoints.tiingo, window.location.origin);
+  url.searchParams.set('symbol', symbol);
+  url.searchParams.set('kind', kind);
+  if (interval) url.searchParams.set('interval', interval);
+  if (limit) url.searchParams.set('limit', String(limit));
+  if (exchange) url.searchParams.set('exchange', exchange);
+  return fetchJson(url);
+}
+
+export async function loadFundamentals(symbols, { exchange = '' } = {}) {
+  const list = Array.isArray(symbols) ? symbols : String(symbols || '').split(',');
+  const cleaned = list.map((s) => (s || '').trim()).filter(Boolean);
+  if (!cleaned.length) return { data: [] };
+  const url = new URL(endpoints.fundamentals, window.location.origin);
+  url.searchParams.set('symbols', cleaned.join(','));
+  if (exchange) url.searchParams.set('exchange', exchange);
+  return fetchJson(url);
+}
+
+export async function runAiAnalyst(payload) {
+  try {
+    const response = await fetch(endpoints.aiAnalyst, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const text = await response.text();
+    if (!text) return { content: 'No response from AI analyst.' };
+    const data = JSON.parse(text);
+    return data;
+  } catch (error) {
+    console.warn('AI analyst call failed', error);
+    return {
+      content: 'AI analyst is offline. Configure OPENAI_API_KEY to enable live commentary.',
+      error: String(error),
+    };
+  }
+}
+
+export const signalClass = (value) => {
+  if (typeof value !== 'number') return '';
+  if (value > 0.4) return 'ai-status ok';
+  if (value < -0.2) return 'ai-status error';
+  return 'ai-status';
+};
+
+export const scoreToLabel = (score) => {
+  if (score == null) return '—';
+  if (score >= 80) return 'Institutional grade';
+  if (score >= 65) return 'High quality';
+  if (score >= 50) return 'Neutral';
+  if (score >= 35) return 'Watch risk';
+  return 'Distressed';
+};
+
+export const momentumToLabel = (score) => {
+  if (score == null) return '—';
+  if (score >= 70) return 'Strong positive';
+  if (score >= 55) return 'Positive drift';
+  if (score >= 45) return 'Sideways';
+  if (score >= 30) return 'Losing momentum';
+  return 'Negative trend';
+};
+
+export function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+export function renderSearchResults(container, items, onSelect) {
+  container.innerHTML = '';
+  if (!items.length) {
+    const empty = document.createElement('div');
+    empty.className = 'ai-status';
+    empty.textContent = 'No matches';
+    container.appendChild(empty);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  items.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'ai-search-result';
+    const info = document.createElement('div');
+    info.innerHTML = `<strong>${item.symbol}</strong><div class="ai-muted">${item.name || ''}</div>`;
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.textContent = 'Select';
+    addBtn.addEventListener('click', () => onSelect(item));
+    row.append(info, addBtn);
+    fragment.appendChild(row);
+  });
+  container.appendChild(fragment);
+}
+
+export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export const formatDate = (input) => {
+  if (!input) return '—';
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return input;
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+};
+
+export const uniqSymbols = (list) => {
+  const seen = new Set();
+  const out = [];
+  list.forEach((item) => {
+    const sym = (item.symbol || item).toUpperCase();
+    if (!sym || seen.has(sym)) return;
+    seen.add(sym);
+    out.push(sym);
+  });
+  return out;
+};
+
+export const computePortfolioStats = (rows = []) => {
+  if (!rows.length) return [];
+  const totalWeight = rows.length;
+  const avg = (key, fallback = 0) => rows.reduce((acc, row) => acc + (Number(row[key]) || fallback), 0) / totalWeight;
+  const metrics = [
+    {
+      label: 'Average upside',
+      value: formatPercent(avg('upside', 0), 1),
+    },
+    {
+      label: 'Average quality score',
+      value: formatNumber(avg('qualityScore', 0), { maximumFractionDigits: 1 }),
+    },
+    {
+      label: 'Average momentum score',
+      value: formatNumber(avg('momentumScore', 0), { maximumFractionDigits: 1 }),
+    },
+    {
+      label: 'Median dividend yield',
+      value: formatPercent(rows.map((row) => row.dividendYield || 0).sort((a, b) => a - b)[Math.floor(rows.length / 2)] || 0, 2),
+    },
+  ];
+  return metrics;
+};
+
+export function renderPortfolioStats(container, stats) {
+  container.innerHTML = '';
+  if (!stats.length) {
+    const empty = document.createElement('div');
+    empty.className = 'ai-status';
+    empty.textContent = 'No portfolio metrics calculated yet.';
+    container.appendChild(empty);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  stats.forEach((item) => {
+    const card = document.createElement('div');
+    card.className = 'ai-list-item';
+    const label = document.createElement('div');
+    label.className = 'ai-muted';
+    label.textContent = item.label;
+    const value = document.createElement('div');
+    value.className = 'ai-metric';
+    value.textContent = item.value;
+    card.append(label, value);
+    fragment.appendChild(card);
+  });
+  container.appendChild(fragment);
+}

--- a/tests/ai-analyst.test.mjs
+++ b/tests/ai-analyst.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handleAiAnalyst, { __testables } from '../netlify/functions/ai-analyst.js';
+
+const { buildPrompt, offlineInsight } = __testables;
+
+test('buildPrompt structures single equity payload', () => {
+  const prompt = buildPrompt({
+    mode: 'single-equity',
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    currency: 'USD',
+    price: 189.2,
+    valuations: { fairValue: 205, upside: 0.083 },
+    qualityScore: 75,
+    momentumScore: 62,
+    events: [{ date: '2024-07-01', type: 'Earnings', headline: 'Q3 earnings call' }],
+    documents: [{ date: '2024-05-01', type: 'SEC Filing', title: '10-Q filing' }],
+    metrics: { revenueGrowth: 0.08, operatingMargin: 0.29, debtToEquity: 1.2 },
+    narrative: 'Focus on services and AI attach rate.',
+  });
+  assert.match(prompt, /Instrument: AAPL/);
+  assert.match(prompt, /Key events:/);
+  assert.match(prompt, /Deliverable:/);
+});
+
+test('offlineInsight returns deterministic fallback content', () => {
+  const result = offlineInsight({
+    mode: 'single-equity',
+    symbol: 'TEST',
+    price: 100,
+    valuations: { fairValue: 120, upside: 0.2 },
+    qualityScore: 70,
+    momentumScore: 60,
+    metrics: { debtToEquity: 1.1 },
+    events: [],
+    documents: [],
+  });
+  assert.equal(result.model, 'chatgpt-5-offline');
+  assert.ok(result.warning.includes('OPENAI_API_KEY'));
+  assert.match(result.content, /View:/);
+});
+
+test('handler returns offline insight when OPENAI_API_KEY is absent', async () => {
+  const original = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  try {
+    const response = await handleAiAnalyst(new Request('https://example.org/.netlify/functions/ai-analyst', {
+      method: 'POST',
+      body: JSON.stringify({ mode: 'single-equity', symbol: 'AAPL' }),
+      headers: { 'content-type': 'application/json' },
+    }));
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.model, 'chatgpt-5-offline');
+    assert.ok(body.warning);
+  } finally {
+    if (original) process.env.OPENAI_API_KEY = original;
+  }
+});

--- a/tests/tiingo-fundamentals.test.mjs
+++ b/tests/tiingo-fundamentals.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handleFundamentalsRequest, { __testables } from '../netlify/functions/tiingo-fundamentals.js';
+
+const {
+  parseSymbols,
+  computeValuation,
+  computeQualityScore,
+  computeMomentumScore,
+  generateFallbackRecord,
+} = __testables;
+
+test('parseSymbols normalises colon and suffix formats', () => {
+  const entries = parseSymbols('ASX:WOW, BARC.L', '');
+  assert.deepEqual(entries.map((e) => e.symbol), ['WOW', 'BARC']);
+  assert.equal(entries[0].mic, 'XASX');
+  assert.equal(entries[1].mic, 'XLON');
+});
+
+test('valuation model returns sensible upside signal', () => {
+  const valuations = computeValuation({
+    eps: 6,
+    revenueGrowth: 0.1,
+    operatingMargin: 0.28,
+    forwardPe: 20,
+    freeCashFlowPerShare: 5.6,
+  }, 170);
+  assert.ok(valuations.fairValue > 0);
+  assert.ok(Number.isFinite(valuations.upside));
+  assert.ok(['Strong upside', 'Moderate upside', 'Fairly valued', 'Slight downside', 'Overvalued'].includes(valuations.signalLabel));
+});
+
+test('quality and momentum scores are bounded between 0 and 100', () => {
+  const quality = computeQualityScore({
+    revenueGrowth: 0.12,
+    operatingMargin: 0.32,
+    returnOnEquity: 0.4,
+    freeCashFlowPerShare: 6,
+    debtToEquity: 0.8,
+    dividendYield: 0.02,
+  });
+  assert.ok(quality >= 0 && quality <= 100);
+
+  const momentum = computeMomentumScore(180, {
+    week52High: 210,
+    week52Low: 140,
+    monthChange: 0.04,
+    quarterChange: 0.1,
+  });
+  assert.ok(momentum >= 0 && momentum <= 100);
+});
+
+test('fallback record provides illustrative fundamentals', () => {
+  const record = generateFallbackRecord('TEST');
+  assert.equal(record.symbol, 'TEST');
+  assert.ok(record.events.length >= 1);
+  assert.ok(record.documents.length >= 1);
+  assert.ok(record.valuations.fairValue > 0);
+});
+
+test('handler returns fallback data when token is missing', async () => {
+  const keys = ['TIINGO_KEY', 'TIINGO_API_KEY', 'TIINGO_TOKEN', 'TIINGO_ACCESS_TOKEN', 'REACT_APP_TIINGO_KEY', 'REACT_APP_TIINGO_TOKEN', 'REACT_APP_API_KEY'];
+  const backup = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  keys.forEach((key) => { delete process.env[key]; });
+  try {
+    const response = await handleFundamentalsRequest(new Request('https://example.org/.netlify/functions/tiingo-fundamentals?symbols=AAPL'));
+    const body = await response.json();
+    assert.ok(Array.isArray(body.data));
+    assert.ok(body.data.length >= 1);
+    assert.ok(body.warning);
+    assert.equal(body.fallback, true);
+  } finally {
+    Object.entries(backup).forEach(([key, value]) => {
+      if (value == null) delete process.env[key];
+      else process.env[key] = value;
+    });
+  }
+});

--- a/tests/tiingo.test.mjs
+++ b/tests/tiingo.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { __testables } from '../netlify/functions/tiingo.js';
+
+const {
+  resolveSymbolRequests,
+  generateMockSeries,
+  normalizeQuote,
+  normalizeCandle,
+  minutesForInterval,
+} = __testables;
+
+test('resolveSymbolRequests parses exchange prefixes and suffixes', () => {
+  const [asx] = resolveSymbolRequests('ASX:WOW', '');
+  assert.equal(asx.symbol, 'WOW');
+  assert.equal(asx.mic, 'XASX');
+
+  const [london] = resolveSymbolRequests('BARC.L', '');
+  assert.equal(london.symbol, 'BARC');
+  assert.equal(london.mic, 'XLON');
+
+  const dedup = resolveSymbolRequests('AAPL, aapl ,XNYS:AAPL', '');
+  assert.ok(dedup.length >= 1);
+  assert.ok(dedup.every((entry) => entry.symbol === 'AAPL'));
+});
+
+test('generateMockSeries returns ordered, positive candles', () => {
+  const series = generateMockSeries('AAPL', 40, 'eod');
+  assert.equal(series.length, 40);
+  const dates = series.map((row) => new Date(row.date).getTime());
+  const sorted = [...dates].sort((a, b) => a - b);
+  assert.deepEqual(dates, sorted);
+  series.forEach((row) => {
+    assert.ok(row.close > 0, 'close should be positive');
+    assert.ok(row.high >= row.low, 'high >= low');
+  });
+});
+
+test('normalizeQuote fills missing fields with fallbacks', () => {
+  const normalized = normalizeQuote({ ticker: 'AAPL', last: 190.23 }, 'AAPL', 'XNAS');
+  assert.equal(normalized.symbol, 'AAPL');
+  assert.equal(normalized.price, 190.23);
+  assert.equal(normalized.currency, 'USD');
+});
+
+test('normalizeCandle infers prices and previous close', () => {
+  const row = { close: 100, open: 95, high: 102, low: 94, volume: 1200 };
+  const normalized = normalizeCandle(row, 'TEST', { close: 90 }, 'XNAS');
+  assert.equal(normalized.symbol, 'TEST');
+  assert.equal(normalized.close, 100);
+  assert.equal(normalized.previousClose, 90);
+});
+
+test('minutesForInterval handles intraday buckets', () => {
+  assert.equal(minutesForInterval('5min'), 5);
+  assert.equal(minutesForInterval('30min'), 30);
+  assert.equal(minutesForInterval('1hour'), 60);
+});


### PR DESCRIPTION
## Summary
- add AI Research Lab and AI Screener standalone pages styled for a professional trading desk experience
- introduce Netlify functions for ChatGPT 5 analysis proxy and Tiingo fundamentals aggregation with fallback data
- extend Tiingo utilities export surface and add comprehensive unit tests covering analytics and AI fallbacks

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d38409d7d0832997fa090b85276937