### PR TITLE
Add AI-driven trading desk experience and extend Tiingo test coverage

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,4 @@
 /api/*  /.netlify/functions/:splat  200
+/pro-desk    /pro-desk.html            200
+/pro-desk/*  /pro-desk.html            200
 /*      /index.html                     200

--- a/netlify/functions/ai-analyst.js
+++ b/netlify/functions/ai-analyst.js
@@ -1,0 +1,180 @@
+const corsHeaders = {
+  'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*',
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': 'content-type',
+};
+
+const OPENAI_URL = process.env.OPENAI_API_URL || 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL = process.env.OPENAI_ANALYST_MODEL || process.env.OPENAI_MODEL || 'gpt-4.1-mini';
+const TARGET_MODEL = process.env.OPENAI_ANALYST_TARGET || 'gpt-5.0-preview';
+
+const sanitizeList = (value, max = 6) => {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, max).map((item) => {
+    if (typeof item === 'string') return item;
+    if (item && typeof item === 'object') {
+      const copy = { ...item };
+      Object.keys(copy).forEach((key) => {
+        if (copy[key] == null) delete copy[key];
+      });
+      return copy;
+    }
+    return item;
+  });
+};
+
+const summarizeQuote = (quote) => {
+  if (!quote || typeof quote !== 'object') return 'No real-time quote available.';
+  const parts = [];
+  if (quote.price != null) parts.push(`Last ${quote.price}`);
+  if (quote.previousClose != null && quote.price != null && quote.previousClose !== 0) {
+    const change = quote.price - quote.previousClose;
+    const pct = quote.previousClose ? (change / quote.previousClose) * 100 : 0;
+    const sign = change >= 0 ? '+' : '';
+    parts.push(`Δ ${sign}${change.toFixed(2)} (${sign}${pct.toFixed(2)}%)`);
+  }
+  if (quote.volume != null) parts.push(`Volume ${quote.volume}`);
+  if (quote.currency) parts.push(`Currency ${quote.currency}`);
+  return parts.join(' · ');
+};
+
+const summarizeValuations = (valuations) => {
+  if (!valuations || typeof valuations !== 'object') return 'No valuation model output.';
+  const lines = [];
+  if (valuations.blended?.fairValue != null) {
+    lines.push(`Blended fair value ${valuations.blended.fairValue.toFixed(2)} (${(valuations.blended.confidence || 0) * 100}% confidence)`);
+  }
+  if (valuations.dcf?.fairValue != null) {
+    const { fairValue, discountRate, terminalGrowth } = valuations.dcf;
+    lines.push(`DCF ${fairValue.toFixed(2)} (discount ${discountRate ? (discountRate * 100).toFixed(1) : 'n/a'}%, terminal ${terminalGrowth ? (terminalGrowth * 100).toFixed(1) : 'n/a'}%)`);
+  }
+  if (valuations.multiples?.fairValue != null) {
+    lines.push(`Multiples ${valuations.multiples.fairValue.toFixed(2)} (${valuations.multiples.notes || 'comps blend'})`);
+  }
+  return lines.join(' | ') || 'No valuation model output.';
+};
+
+const summarizeEvents = (events) => {
+  if (!Array.isArray(events) || events.length === 0) return 'No curated events available.';
+  return events.slice(0, 5).map((event, idx) => {
+    const score = event.impactScore != null ? `impact ${event.impactScore}/5` : 'impact n/a';
+    return `${idx + 1}. ${event.title || 'Event'} (${score}) — ${event.summary || ''}`;
+  }).join('\n');
+};
+
+const clampText = (text = '', max = 6000) => (text.length > max ? `${text.slice(0, max)}…` : text);
+
+const fallbackNarrative = (payload) => {
+  const { symbol, universe, focus } = payload;
+  return `AI analysis offline. Configure OPENAI_API_KEY to enable GPT-5 research.\n\nSymbol: ${symbol || 'n/a'}\nFocus: ${focus || 'balanced'}\nUniverse: ${universe || '—'}\n\nSuggested next steps:\n- Provide an OpenAI key and optional OPENAI_ANALYST_MODEL to target GPT-5 or enterprise models.\n- Re-run the screen to receive automated valuation notes, catalyst review, and risk scoring.`;
+};
+
+const buildPrompt = (payload) => {
+  const mode = payload.mode || 'screener';
+  const header = `You are GPT-5-class equity desk analyst embedded in a professional trading terminal. Deliver crisp, defensible insight with explicit valuation logic, risks, and actionable triggers.`;
+  const quoteSummary = summarizeQuote(payload.quote);
+  const valuationSummary = summarizeValuations(payload.valuations);
+  const eventSummary = summarizeEvents(payload.events);
+  const baseDetails = `Symbol: ${payload.symbol || 'n/a'}\nCurrent quote: ${quoteSummary}\nValuation snapshot: ${valuationSummary}\nMandate: ${payload.focus || 'balanced'} · Risk: ${payload.riskTolerance || 'balanced'} · Horizon: ${payload.horizon || 'medium'}\nUniverse candidates: ${payload.universe || 'n/a'}\nRecent events:\n${eventSummary}`;
+  if (mode === 'document') {
+    const documentExcerpt = clampText(payload.documentText || '', 5500);
+    return `${header}\n\nTask: Review the following disclosure transcript or filing excerpt. Highlight material positives, negatives, accounting quirks, and follow-up questions. Finish with a verdict (Overweight/Market Weight/Underweight) and key catalysts.\n\n${baseDetails}\n\nDocument excerpt:\n"""\n${documentExcerpt}\n"""`;
+  }
+  return `${header}\n\nTask: Evaluate the listed universe and produce a ranked watchlist aligned with the mandate. Blend quantitative valuation with qualitative catalysts. Include: (1) thesis bullet(s), (2) valuation view with fair value range, (3) key catalysts & risks, (4) suggested positioning.\n\n${baseDetails}`;
+};
+
+const respond = (payload, init = {}) => Response.json(payload, { headers: corsHeaders, ...init });
+
+async function handle(request) {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return respond({ error: 'invalid_json', detail: 'Payload must be valid JSON.' }, { status: 400 });
+  }
+
+  const cleaned = {
+    ...body,
+    events: sanitizeList(body.events),
+    valuations: body.valuations || null,
+  };
+
+  const apiKey = process.env.OPENAI_API_KEY || process.env.OPENAI_KEY || '';
+  if (!apiKey) {
+    return respond({
+      analysis: fallbackNarrative(cleaned),
+      model: 'offline-mock',
+      fallback: true,
+      warning: 'OPENAI_API_KEY missing — AI responses are mocked.',
+    });
+  }
+
+  const prompt = buildPrompt(cleaned);
+  try {
+    const response = await fetch(OPENAI_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: DEFAULT_MODEL,
+        messages: [
+          { role: 'system', content: 'You are a fiduciary-grade equity research assistant. Cite valuation logic, catalysts, and risk controls. Be concise but analytical.' },
+          { role: 'user', content: prompt },
+        ],
+        temperature: 0.25,
+        top_p: 0.9,
+        max_tokens: 900,
+        presence_penalty: 0,
+        frequency_penalty: 0,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`OpenAI error ${response.status}: ${text}`);
+    }
+
+    const payload = await response.json();
+    const choice = payload?.choices?.[0]?.message?.content || '';
+    return respond({
+      analysis: choice,
+      model: payload?.model || DEFAULT_MODEL,
+      usage: payload?.usage || null,
+      warning: TARGET_MODEL && TARGET_MODEL !== DEFAULT_MODEL
+        ? `Request executed on ${DEFAULT_MODEL}. Set OPENAI_ANALYST_MODEL=${TARGET_MODEL} to target GPT-5 class when available.`
+        : '',
+    });
+  } catch (error) {
+    console.error('ai-analyst error', error);
+    return respond({
+      analysis: fallbackNarrative(cleaned),
+      model: DEFAULT_MODEL,
+      fallback: true,
+      warning: 'AI request failed. Showing deterministic fallback.',
+      error: String(error),
+    }, { status: 200 });
+  }
+}
+
+export default handle;
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';
+  const path = event?.path || '/api/ai-analyst';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'POST';
+  const body = method === 'GET' || method === 'HEAD' ? undefined : event?.body;
+  const request = new Request(url, { method, headers: event?.headers || {}, body });
+  const response = await handle(request);
+  const headers = {}; response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};

--- a/netlify/functions/document-fetch.js
+++ b/netlify/functions/document-fetch.js
@@ -1,0 +1,98 @@
+const corsHeaders = {
+  'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*',
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': 'content-type',
+};
+
+const MAX_LENGTH = 8000;
+const SUPPORTED_PROTOCOLS = new Set(['https:', 'http:']);
+
+const stripHtml = (html = '') => html
+  .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+  .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+  .replace(/<\/(div|p|br|li|h[1-6])>/gi, '\n')
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const truncate = (text = '', limit = MAX_LENGTH) => (text.length > limit ? text.slice(0, limit) : text);
+
+const respond = (payload, init = {}) => Response.json(payload, { headers: corsHeaders, ...init });
+
+async function handle(request) {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return respond({ error: 'invalid_json', detail: 'Expected JSON body.' }, { status: 400 });
+  }
+  const urlValue = `${body?.url || ''}`.trim();
+  if (!urlValue) {
+    return respond({ error: 'missing_url', detail: 'Provide a document URL to fetch.' }, { status: 400 });
+  }
+  let url;
+  try {
+    url = new URL(urlValue);
+  } catch (error) {
+    return respond({ error: 'invalid_url', detail: 'URL must be absolute and valid.' }, { status: 400 });
+  }
+  if (!SUPPORTED_PROTOCOLS.has(url.protocol)) {
+    return respond({ error: 'unsupported_protocol', detail: 'Only HTTP(S) documents are supported.' }, { status: 400 });
+  }
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'NetlifyTrading-DocumentFetcher/1.0 (mailto:ops@example.com)',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8',
+      },
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Upstream ${response.status}: ${text.slice(0, 200)}`);
+    }
+    const contentType = response.headers.get('content-type') || 'text/plain';
+    if (/pdf/i.test(contentType)) {
+      return respond({
+        url: url.toString(),
+        content: '',
+        truncated: false,
+        contentType,
+        warning: 'PDF documents are not converted server-side. Download locally and paste the relevant excerpts.',
+      });
+    }
+    const raw = await response.text();
+    const cleaned = stripHtml(raw);
+    const truncated = truncate(cleaned);
+    return respond({
+      url: url.toString(),
+      content: truncated,
+      truncated: cleaned.length > truncated.length,
+      contentType,
+      warning: cleaned.length > truncated.length ? 'Document truncated to 8,000 characters for AI analysis.' : '',
+    });
+  } catch (error) {
+    console.error('document-fetch error', error);
+    return respond({ error: 'document_fetch_failed', detail: String(error) }, { status: 502 });
+  }
+}
+
+export default handle;
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';
+  const path = event?.path || '/api/document-fetch';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'POST';
+  const body = method === 'GET' || method === 'HEAD' ? undefined : event?.body;
+  const request = new Request(url, { method, headers: event?.headers || {}, body });
+  const response = await handle(request);
+  const headers = {}; response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};

--- a/netlify/functions/tiingo-events.js
+++ b/netlify/functions/tiingo-events.js
@@ -1,0 +1,148 @@
+import { getTiingoToken } from './lib/env.js';
+
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+const API_BASE = 'https://api.tiingo.com/';
+
+const hoursAgo = (hours) => new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+const FALLBACK_EVENTS = [
+  {
+    id: 'sample-earnings',
+    title: 'Earnings beat with resilient services growth',
+    date: hoursAgo(12),
+    type: 'Earnings',
+    source: 'Tiingo',
+    summary: 'Company delivered top-line and EPS upside versus consensus, driven by services and high-margin software.',
+    impactScore: 4,
+    highlights: 'Watch margin guidance and management commentary on demand elasticity.',
+    url: 'https://www.tiingo.com/',
+  },
+  {
+    id: 'sample-product',
+    title: 'Next-gen product launch expands premium pricing umbrella',
+    date: hoursAgo(30),
+    type: 'Product',
+    source: 'Tiingo',
+    summary: 'New hardware platform integrates custom silicon and AI workflows, supporting ecosystem lock-in and higher ASPs.',
+    impactScore: 3,
+    highlights: 'Track preorder cadence and supply chain commentary for lead times.',
+    url: 'https://www.tiingo.com/',
+  },
+  {
+    id: 'sample-regulatory',
+    title: 'Regulatory inquiry focused on platform billing practices',
+    date: hoursAgo(48),
+    type: 'Regulatory',
+    source: 'Tiingo',
+    summary: 'Regulators requested information on subscription bundling. No fines yet but sets the stage for oversight.',
+    impactScore: 2,
+    highlights: 'Assess potential revenue at risk and timeline for resolution.',
+    url: 'https://www.tiingo.com/',
+  },
+];
+
+const classifyEvent = (article) => {
+  const title = `${article?.title || ''}`.toLowerCase();
+  const tags = (article?.tags || []).map((tag) => `${tag}`.toLowerCase());
+  if (title.includes('earnings') || tags.includes('earnings')) return 'Earnings';
+  if (title.includes('guidance') || tags.includes('guidance')) return 'Guidance';
+  if (title.includes('dividend') || tags.includes('dividend')) return 'Capital returns';
+  if (title.includes('buyback') || tags.includes('buyback')) return 'Capital returns';
+  if (title.includes('acquisition') || title.includes('merger')) return 'M&A';
+  if (title.includes('product') || title.includes('launch')) return 'Product';
+  if (title.includes('regulator') || title.includes('doj') || title.includes('antitrust')) return 'Regulatory';
+  if (title.includes('downgrade') || title.includes('upgrade')) return 'Brokerage';
+  return article?.categories?.[0] || 'News';
+};
+
+const sentimentScore = (value) => {
+  if (value == null) return 3;
+  if (value > 0.35) return 5;
+  if (value > 0.1) return 4;
+  if (value < -0.35) return 1;
+  if (value < -0.1) return 2;
+  return 3;
+};
+
+const toEvents = (articles = []) => articles.map((article) => ({
+  id: article.id || article.url,
+  title: article.title,
+  date: article.publishedDate || article.updatedDate || article.createdDate || new Date().toISOString(),
+  type: classifyEvent(article),
+  source: article.source || article.provider || 'Tiingo',
+  summary: article.description || article.summary || '',
+  impactScore: sentimentScore(article.sentimentScore ?? article.sentiment),
+  highlights: (article.tags || []).slice(0, 4).join(', '),
+  url: article.url,
+  tags: article.tags || [],
+}));
+
+async function fetchTiingo(path, params, token) {
+  const url = new URL(path, API_BASE);
+  url.searchParams.set('token', token);
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value != null && value !== '') url.searchParams.set(key, value);
+  });
+  const response = await fetch(url);
+  const text = await response.text();
+  let data = [];
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (error) {
+      if (!response.ok) throw new Error(`Tiingo ${response.status}: ${text.slice(0, 200)}`);
+      throw error;
+    }
+  }
+  if (!response.ok) {
+    const detail = typeof data === 'object' && data !== null
+      ? data.message || data.error || JSON.stringify(data)
+      : text;
+    throw new Error(`Tiingo ${response.status}: ${detail}`);
+  }
+  return data;
+}
+
+async function handle(request) {
+  const url = new URL(request.url);
+  const symbol = (url.searchParams.get('symbol') || 'AAPL').toUpperCase();
+  const limit = Number(url.searchParams.get('limit')) || 8;
+  const token = getTiingoToken();
+  if (!token) {
+    return Response.json({ symbol, events: FALLBACK_EVENTS, warning: 'Tiingo API key missing — showing sample catalysts.', fallback: true }, { headers: corsHeaders });
+  }
+  try {
+    const startDate = new Date();
+    startDate.setMonth(startDate.getMonth() - 3);
+    const data = await fetchTiingo('/tiingo/news', {
+      tickers: symbol,
+      limit: String(Math.min(Math.max(limit, 1), 20)),
+      sortBy: 'publishedDate',
+      startDate: startDate.toISOString().slice(0, 10),
+    }, token);
+    const articles = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : [];
+    if (!articles.length) {
+      return Response.json({ symbol, events: FALLBACK_EVENTS, warning: 'No recent Tiingo events. Displaying curated samples.', fallback: true }, { headers: corsHeaders });
+    }
+    const events = toEvents(articles).slice(0, limit);
+    return Response.json({ symbol, events, fetchedAt: new Date().toISOString() }, { headers: corsHeaders });
+  } catch (error) {
+    console.error('tiingo-events error', error);
+    return Response.json({ symbol, events: FALLBACK_EVENTS, warning: 'Tiingo news unavailable — showing curated samples.', fallback: true, error: String(error) }, { headers: corsHeaders, status: 200 });
+  }
+}
+
+export default handle;
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';
+  const path = event?.path || '/api/tiingo-events';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'GET';
+  const body = method === 'GET' || method === 'HEAD' ? undefined : event?.body;
+  const request = new Request(url, { method, headers: event?.headers || {}, body });
+  const response = await handle(request);
+  const headers = {}; response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};

--- a/netlify/functions/tiingo-fundamentals.js
+++ b/netlify/functions/tiingo-fundamentals.js
@@ -1,0 +1,386 @@
+import { getTiingoToken } from './lib/env.js';
+
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+const API_BASE = 'https://api.tiingo.com/';
+
+const FALLBACK_SAMPLE = {
+  symbol: 'AAPL',
+  asOf: '2024-03-31',
+  valuations: {
+    dcf: {
+      fairValue: 210,
+      low: 185,
+      high: 235,
+      discountRate: 0.082,
+      terminalGrowth: 0.025,
+      growthRate: 0.07,
+      horizonYears: 5,
+    },
+    multiples: {
+      fairValue: 205,
+      low: 190,
+      high: 220,
+      notes: 'Blend of megacap tech peers (MSFT, GOOGL, NVDA).',
+    },
+    blended: {
+      fairValue: 208,
+      low: 190,
+      high: 228,
+      confidence: 0.68,
+      qualityScore: 86,
+      rationale: 'Strong FCF durability, net cash balance sheet, resilient demand cycle.',
+    },
+  },
+  metrics: {
+    marketCap: 3.1e12,
+    enterpriseValue: 3.0e12,
+    sharesOutstanding: 15.7e9,
+    revenue: 3.83e11,
+    revenueGrowth: 0.06,
+    netIncome: 9.65e10,
+    eps: 6.1,
+    freeCashFlow: 9.8e10,
+    freeCashFlowMargin: 0.26,
+    dividendYield: 0.005,
+    roe: 0.32,
+    roic: 0.29,
+    debtToEquity: 1.5,
+  },
+  table: [
+    { metric: 'Revenue (TTM)', value: '$383.0B', trend: '3y CAGR 6%' },
+    { metric: 'Net income (TTM)', value: '$96.5B', trend: 'Margin 25%' },
+    { metric: 'Free cash flow', value: '$98.0B', trend: 'FCF margin 26%' },
+    { metric: 'ROIC', value: '29%', trend: 'Top decile vs S&P500' },
+    { metric: 'Net debt', value: '$60.0B', trend: 'Comfortable coverage' },
+    { metric: 'Dividend yield', value: '0.5%', trend: '10y growth 7%' },
+  ],
+  assumptions: [
+    'DCF uses 7% FCF CAGR for five years with 8.2% discount rate and 2.5% terminal growth.',
+    'Peer multiples anchored to megacap software/hardware blend to reflect Apple mix.',
+    'Quality score emphasises ROIC, FCF conversion, and leverage profile.',
+  ],
+  qualityNarrative: 'Balance sheet resilience and dominant ecosystem support a premium multiple.',
+  fallback: true,
+  warning: 'Tiingo API key missing — using illustrative fundamentals.',
+};
+
+const toNumber = (value) => {
+  if (value == null || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const sortByDate = (rows = []) => [...rows].filter(Boolean).sort((a, b) => {
+  const da = new Date(a?.date || a?.statementDate || 0).getTime();
+  const db = new Date(b?.date || b?.statementDate || 0).getTime();
+  return da - db;
+});
+
+const readNumber = (row, keys = []) => {
+  for (const key of keys) {
+    if (row && row[key] != null) {
+      const num = toNumber(row[key]);
+      if (num != null) return num;
+    }
+  }
+  return null;
+};
+
+const computeCagr = (series = []) => {
+  const cleaned = series.filter((item) => item && item.value != null && Number.isFinite(item.value));
+  if (cleaned.length < 2) return null;
+  const first = cleaned[0];
+  const last = cleaned[cleaned.length - 1];
+  const firstDate = new Date(first.date || first.statementDate || 0);
+  const lastDate = new Date(last.date || last.statementDate || 0);
+  const years = Math.max((lastDate - firstDate) / (365.25 * 24 * 60 * 60 * 1000), 0.5);
+  if (!Number.isFinite(years) || years <= 0) return null;
+  if (!first.value || !last.value) return null;
+  return (last.value / first.value) ** (1 / years) - 1;
+};
+
+const formatCurrency = (value, currency = 'USD', digits = 1) => {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const formatter = new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: digits });
+  return formatter.format(value);
+};
+
+const formatPercent = (value, digits = 1) => {
+  if (value == null || !Number.isFinite(value)) return '—';
+  return `${(value * 100).toFixed(digits)}%`;
+};
+
+async function fetchTiingo(path, params, token) {
+  const url = new URL(path, API_BASE);
+  url.searchParams.set('token', token);
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value != null && value !== '') url.searchParams.set(key, value);
+  });
+  const response = await fetch(url);
+  const text = await response.text();
+  let data = [];
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (error) {
+      if (!response.ok) throw new Error(`Tiingo ${response.status}: ${text.slice(0, 200)}`);
+      throw error;
+    }
+  }
+  if (!response.ok) {
+    const detail = typeof data === 'object' && data !== null
+      ? data.message || data.error || JSON.stringify(data)
+      : text;
+    throw new Error(`Tiingo ${response.status}: ${detail}`);
+  }
+  return data;
+}
+
+const buildFundamentalTable = (latest, metrics, history, currency = 'USD') => {
+  const revenueRow = {
+    metric: 'Revenue (TTM)',
+    value: formatCurrency(metrics.revenue, currency, 0),
+    trend: metrics.revenueGrowth != null ? `${formatPercent(metrics.revenueGrowth, 1)} CAGR` : '—',
+  };
+  const netIncomeRow = {
+    metric: 'Net income (TTM)',
+    value: formatCurrency(metrics.netIncome, currency, 0),
+    trend: metrics.netMargin != null ? `Margin ${formatPercent(metrics.netMargin, 1)}` : '—',
+  };
+  const fcfRow = {
+    metric: 'Free cash flow',
+    value: formatCurrency(metrics.freeCashFlow, currency, 0),
+    trend: metrics.freeCashFlowMargin != null ? `FCF margin ${formatPercent(metrics.freeCashFlowMargin, 1)}` : '—',
+  };
+  const roeRow = {
+    metric: 'Return on equity',
+    value: metrics.roe != null ? formatPercent(metrics.roe, 1) : '—',
+    trend: metrics.roic != null ? `ROIC ${formatPercent(metrics.roic, 1)}` : '—',
+  };
+  const leverageRow = {
+    metric: 'Leverage',
+    value: metrics.debtToEquity != null ? `${metrics.debtToEquity.toFixed(2)}× D/E` : '—',
+    trend: metrics.netDebt != null ? `${formatCurrency(metrics.netDebt, currency, 0)} net debt` : '—',
+  };
+  const dividendRow = {
+    metric: 'Capital returns',
+    value: metrics.dividendYield != null ? `Yield ${formatPercent(metrics.dividendYield, 2)}` : '—',
+    trend: metrics.buybackYield != null ? `Buyback ${formatPercent(metrics.buybackYield, 2)}` : '—',
+  };
+  return [revenueRow, netIncomeRow, fcfRow, roeRow, leverageRow, dividendRow];
+};
+
+const computeDcf = (latest, history) => {
+  const fcfSeries = history.map((row) => ({ date: row.date, value: readNumber(row, ['freeCashFlow', 'freeCashflow', 'freeCashFlowTtm', 'freeCashFlowTTM']) || null }));
+  const growth = computeCagr(fcfSeries.filter((row) => row.value != null)) ?? 0.05;
+  const shares = readNumber(latest, ['sharesOutstanding', 'sharesOut', 'shares']);
+  const baseFcf = readNumber(latest, ['freeCashFlow', 'freeCashflow', 'freeCashFlowTtm', 'freeCashFlowTTM']);
+  const discountRate = readNumber(latest, ['wacc', 'costOfCapital', 'discountRate']) ?? 0.085;
+  const terminalGrowth = readNumber(latest, ['terminalGrowth', 'longTermGrowth']) ?? 0.025;
+  const debt = readNumber(latest, ['totalDebt', 'totalLiabilitiesNetMinorityInterest', 'ltDebt']) ?? 0;
+  const cash = readNumber(latest, ['cashAndCashEquivalents', 'cashAndShortTermInvestments']) ?? 0;
+
+  if (baseFcf == null || shares == null || shares <= 0) return null;
+
+  const horizon = 5;
+  const rate = Math.max(discountRate, terminalGrowth + 0.01);
+  const flows = [];
+  let runningFcf = baseFcf;
+  for (let year = 1; year <= horizon; year += 1) {
+    runningFcf *= (1 + growth);
+    flows.push(runningFcf);
+  }
+
+  const presentFlows = flows.reduce((acc, flow, idx) => acc + flow / ((1 + rate) ** (idx + 1)), 0);
+  const terminal = flows[flows.length - 1] * (1 + terminalGrowth) / (rate - terminalGrowth);
+  const presentTerminal = terminal / ((1 + rate) ** horizon);
+  const enterpriseValue = presentFlows + presentTerminal;
+  const equityValue = enterpriseValue - (debt - cash);
+  const perShare = equityValue / shares;
+
+  const spread = Math.max(0.15, Math.abs(growth - terminalGrowth) * 2);
+  const low = perShare * (1 - spread / 2);
+  const high = perShare * (1 + spread / 2);
+
+  return {
+    fairValue: perShare,
+    low,
+    high,
+    discountRate: rate,
+    terminalGrowth,
+    growthRate: growth,
+    horizonYears: horizon,
+  };
+};
+
+const computeMultiples = (latest, metrics) => {
+  const shares = metrics.sharesOutstanding;
+  if (!shares || shares <= 0) return null;
+  const eps = readNumber(latest, ['eps', 'earningsPerShare', 'basicEPS', 'dilutedEPS'])
+    ?? (metrics.netIncome != null ? metrics.netIncome / shares : null);
+  const revenuePerShare = metrics.revenue != null ? metrics.revenue / shares : null;
+  const bookValuePerShare = readNumber(latest, ['bookValuePerShare', 'bookValue'])
+    ?? (metrics.shareholderEquity != null ? metrics.shareholderEquity / shares : null);
+  const pe = readNumber(latest, ['peRatio', 'pe']) ?? 20;
+  const ps = readNumber(latest, ['psRatio', 'ps']) ?? 5;
+  const pb = readNumber(latest, ['pbRatio', 'pb']) ?? 8;
+
+  const values = [];
+  const contributions = {};
+  if (eps != null) {
+    const value = eps * Math.max(pe, 8);
+    contributions.pe = value;
+    values.push(value);
+  }
+  if (revenuePerShare != null) {
+    const value = revenuePerShare * Math.max(ps, 2.5);
+    contributions.ps = value;
+    values.push(value);
+  }
+  if (bookValuePerShare != null) {
+    const value = bookValuePerShare * Math.max(pb, 2);
+    contributions.pb = value;
+    values.push(value);
+  }
+
+  if (!values.length) return null;
+  const fairValue = values.reduce((acc, value) => acc + value, 0) / values.length;
+  const low = Math.min(...values);
+  const high = Math.max(...values);
+  return {
+    fairValue,
+    low,
+    high,
+    notes: `PE ${pe?.toFixed?.(1) ?? 'n/a'}, PS ${ps?.toFixed?.(1) ?? 'n/a'}, PB ${pb?.toFixed?.(1) ?? 'n/a'}`,
+    contributions,
+  };
+};
+
+const computeQualityScore = (metrics, growth) => {
+  const growthScore = Math.max(0, Math.min(40, ((growth ?? 0.05) / 0.2) * 40));
+  const profitabilityScore = Math.max(0, Math.min(35, ((metrics.roe ?? 0.18) / 0.25) * 35));
+  const riskScore = Math.max(0, Math.min(25, (1 - Math.min(metrics.debtToEquity ?? 0.8, 2) / 2) * 25));
+  return growthScore + profitabilityScore + riskScore;
+};
+
+const computeBlended = (dcf, multiples, metrics, growth) => {
+  if (!dcf && !multiples) return null;
+  const weights = { dcf: dcf ? 0.6 : 0, multiples: multiples ? 0.4 : 0 };
+  const totalWeight = weights.dcf + weights.multiples;
+  const fairValue = (
+    (dcf?.fairValue ?? 0) * (weights.dcf / totalWeight || 0)
+    + (multiples?.fairValue ?? 0) * (weights.multiples / totalWeight || 0)
+  );
+  const low = Math.min(dcf?.low ?? fairValue, multiples?.low ?? fairValue);
+  const high = Math.max(dcf?.high ?? fairValue, multiples?.high ?? fairValue);
+  const qualityScore = computeQualityScore(metrics, growth);
+  const confidence = Math.min(0.9, 0.4 + (dcf ? 0.3 : 0) + (multiples ? 0.2 : 0));
+  return {
+    fairValue,
+    low,
+    high,
+    confidence,
+    qualityScore,
+    rationale: 'Confidence driven by multi-model agreement and balance sheet resilience.',
+  };
+};
+
+const normaliseFundamentals = (symbol, rows) => {
+  const sorted = sortByDate(rows);
+  const latest = sorted[sorted.length - 1];
+  if (!latest) throw new Error('No fundamentals returned.');
+  const currency = latest.currency || latest.currencyCode || 'USD';
+  const metrics = {
+    marketCap: readNumber(latest, ['marketCap', 'marketCapitalization']),
+    enterpriseValue: readNumber(latest, ['enterpriseValue']),
+    sharesOutstanding: readNumber(latest, ['sharesOutstanding', 'sharesOut', 'shares']),
+    revenue: readNumber(latest, ['revenue', 'totalRevenue', 'revenues']),
+    netIncome: readNumber(latest, ['netIncome', 'netIncomeCommon']),
+    shareholderEquity: readNumber(latest, ['shareholderEquity', 'totalEquity']),
+    freeCashFlow: readNumber(latest, ['freeCashFlow', 'freeCashflow', 'freeCashFlowTtm', 'freeCashFlowTTM']),
+    dividendYield: readNumber(latest, ['dividendYield', 'dividendYieldPercent']),
+    buybackYield: readNumber(latest, ['buybackYield']),
+    roe: readNumber(latest, ['returnOnEquity', 'roe']),
+    roic: readNumber(latest, ['returnOnInvestedCapital', 'roic']),
+    debtToEquity: readNumber(latest, ['debtToEquity', 'totalDebtToEquity']) ?? null,
+    totalDebt: readNumber(latest, ['totalDebt', 'ltDebt']),
+    cash: readNumber(latest, ['cashAndCashEquivalents', 'cashAndShortTermInvestments']),
+  };
+  metrics.netMargin = metrics.netIncome != null && metrics.revenue ? metrics.netIncome / metrics.revenue : null;
+  metrics.freeCashFlowMargin = metrics.freeCashFlow != null && metrics.revenue ? metrics.freeCashFlow / metrics.revenue : null;
+  metrics.netDebt = metrics.totalDebt != null && metrics.cash != null ? metrics.totalDebt - metrics.cash : metrics.totalDebt ?? null;
+  metrics.eps = readNumber(latest, ['eps', 'earningsPerShare', 'basicEPS', 'dilutedEPS']);
+
+  const revenueSeries = sorted.map((row) => ({ date: row.date, value: readNumber(row, ['revenue', 'totalRevenue', 'revenues']) }));
+  const fcfSeries = sorted.map((row) => ({ date: row.date, value: readNumber(row, ['freeCashFlow', 'freeCashflow', 'freeCashFlowTtm', 'freeCashFlowTTM']) }));
+  const epsSeries = sorted.map((row) => ({ date: row.date, value: readNumber(row, ['eps', 'earningsPerShare', 'basicEPS', 'dilutedEPS']) }));
+
+  metrics.revenueGrowth = computeCagr(revenueSeries);
+  metrics.freeCashFlowGrowth = computeCagr(fcfSeries);
+  metrics.epsGrowth = computeCagr(epsSeries);
+
+  const dcf = computeDcf(latest, sorted);
+  const multiples = computeMultiples(latest, metrics);
+  const blended = computeBlended(dcf, multiples, metrics, metrics.freeCashFlowGrowth ?? metrics.revenueGrowth);
+
+  const table = buildFundamentalTable(latest, metrics, sorted, currency);
+  const assumptions = [];
+  if (dcf) {
+    assumptions.push(`DCF: ${formatPercent(dcf.growthRate ?? 0.05, 1)} FCF CAGR, discount ${formatPercent(dcf.discountRate ?? 0.085, 1)}, terminal ${formatPercent(dcf.terminalGrowth ?? 0.025, 1)}.`);
+  }
+  if (multiples) {
+    assumptions.push(`Multiples: Weighted blend ${multiples.notes}.`);
+  }
+  if (metrics.dividendYield != null) {
+    assumptions.push(`Capital returns: dividend yield ${formatPercent(metrics.dividendYield, 2)}${metrics.buybackYield ? `, buyback ${formatPercent(metrics.buybackYield, 2)}` : ''}.`);
+  }
+
+  return {
+    symbol,
+    asOf: latest.date || latest.statementDate || new Date().toISOString(),
+    valuations: { dcf, multiples, blended },
+    metrics,
+    table,
+    assumptions,
+    qualityNarrative: 'Quality blend computed from growth durability, profitability, and leverage.',
+    fallback: false,
+    warning: '',
+  };
+};
+
+async function handle(request) {
+  const url = new URL(request.url);
+  const symbol = (url.searchParams.get('symbol') || 'AAPL').toUpperCase();
+  const token = getTiingoToken();
+  if (!token) {
+    const clone = { ...FALLBACK_SAMPLE, symbol };
+    return Response.json(clone, { headers: corsHeaders });
+  }
+  try {
+    const startDate = new Date();
+    startDate.setFullYear(startDate.getFullYear() - 6);
+    const raw = await fetchTiingo(`/tiingo/fundamentals/${encodeURIComponent(symbol)}/daily`, { startDate: startDate.toISOString().slice(0, 10) }, token);
+    const rows = Array.isArray(raw?.data) ? raw.data : Array.isArray(raw) ? raw : [];
+    const result = normaliseFundamentals(symbol, rows);
+    return Response.json(result, { headers: corsHeaders });
+  } catch (error) {
+    console.error('tiingo-fundamentals error', error);
+    const clone = { ...FALLBACK_SAMPLE, symbol, warning: 'Tiingo fundamentals unavailable — showing illustrative sample.', error: String(error) };
+    return Response.json(clone, { headers: corsHeaders, status: 200 });
+  }
+}
+
+export default handle;
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';
+  const path = event?.path || '/api/tiingo-fundamentals';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'GET';
+  const body = method === 'GET' || method === 'HEAD' ? undefined : event?.body;
+  const request = new Request(url, { method, headers: event?.headers || {}, body });
+  const response = await handle(request);
+  const headers = {}; response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
+    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css pro-desk.html pro-desk.js pro-desk.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data && shx cp -r shared build/shared",
+    "test": "node --test",
     "start": "npx netlify-cli@latest dev",
     "generate:symbols": "node scripts/build-symbols.mjs"
   },

--- a/pro-desk.css
+++ b/pro-desk.css
@@ -1,0 +1,600 @@
+:root {
+  --bg: #05070f;
+  --bg-elevated: #101426;
+  --bg-panel: #12182c;
+  --bg-card: #151d34;
+  --bg-card-alt: #16203b;
+  --border: rgba(255, 255, 255, 0.05);
+  --border-strong: rgba(255, 255, 255, 0.12);
+  --text: #f5f7ff;
+  --text-muted: rgba(235, 240, 255, 0.6);
+  --accent: #62d0ff;
+  --accent-strong: #30a7ff;
+  --accent-soft: rgba(80, 181, 255, 0.15);
+  --danger: #ff6b81;
+  --success: #5fe1a1;
+  --warning: #ffd66b;
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --shadow-1: 0 18px 45px rgba(6, 12, 32, 0.45);
+  --radius-lg: 22px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: radial-gradient(120% 120% at 50% 0%, rgba(46, 79, 255, 0.18), rgba(5, 7, 15, 0.96) 58%),
+    radial-gradient(80% 80% at 80% 20%, rgba(98, 208, 255, 0.18), transparent 60%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-strong);
+}
+
+p {
+  margin: 0;
+}
+
+.app-shell {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 40px 32px 80px;
+}
+
+.hero {
+  background: linear-gradient(145deg, rgba(27, 41, 81, 0.92), rgba(20, 28, 56, 0.88));
+  border-radius: var(--radius-lg);
+  padding: 40px;
+  display: grid;
+  gap: 32px;
+  box-shadow: var(--shadow-1);
+  border: 1px solid var(--border);
+}
+
+.hero-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.hero-content h1 {
+  margin: 12px 0;
+  font-size: 2.6rem;
+  line-height: 1.1;
+}
+
+.hero-content p {
+  max-width: 640px;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.68rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 220px;
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.hero-metrics .metric {
+  background: var(--bg-card);
+  padding: 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.metric-label {
+  display: block;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.metric-value {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.metric-sub {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.sticky-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  margin: 32px 0 26px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 12px 20px;
+  background: rgba(6, 10, 26, 0.8);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+}
+
+.sticky-nav a {
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.sticky-nav a:hover {
+  color: var(--accent);
+}
+
+.page-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.panel {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 48px rgba(5, 8, 20, 0.35);
+}
+
+.panel-header {
+  padding: 32px 32px 18px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-end;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.panel-header p {
+  margin-top: 8px;
+  color: var(--text-muted);
+  max-width: 540px;
+}
+
+.panel-body {
+  padding: 0 32px 36px;
+  display: grid;
+  gap: 28px;
+}
+
+.symbol-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.symbol-form input {
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 1rem;
+  min-width: 200px;
+}
+
+.symbol-form input:focus {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  padding: 10px 16px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent);
+  background: rgba(98, 208, 255, 0.14);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #3b82f6, #22d3ee);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #020617;
+  box-shadow: 0 14px 30px rgba(34, 211, 238, 0.25);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px rgba(34, 211, 238, 0.35);
+}
+
+.card {
+  background: linear-gradient(165deg, rgba(19, 27, 52, 0.94), rgba(14, 19, 36, 0.94));
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.card-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.chart-card {
+  padding: 24px;
+  position: relative;
+}
+
+.timeframe-switcher {
+  display: inline-flex;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  overflow: hidden;
+  background: rgba(8, 11, 24, 0.65);
+}
+
+.timeframe-switcher button {
+  background: transparent;
+  border: none;
+  padding: 10px 14px;
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.timeframe-switcher button.active,
+.timeframe-switcher button:hover {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+}
+
+.metric-card {
+  background: var(--bg-card);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-card .metric-value {
+  font-size: 1.4rem;
+}
+
+.metric-card .metric-sub {
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.ai-grid,
+.doc-grid,
+.valuation-grid {
+  display: grid;
+  gap: 24px;
+}
+
+.ai-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.ai-card textarea,
+.ai-card select,
+.ai-card input,
+#docText,
+#docUrl,
+#aiTickers,
+#aiNotes {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: rgba(9, 14, 30, 0.85);
+  color: var(--text);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+}
+
+.ai-card textarea:focus,
+.ai-card select:focus,
+#docText:focus,
+#docUrl:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-row label {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.status {
+  min-height: 20px;
+}
+
+.ai-output {
+  min-height: 320px;
+}
+
+.ai-output-body {
+  white-space: pre-wrap;
+  line-height: 1.5;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.ai-output-body .highlight {
+  color: var(--accent);
+}
+
+.event-stream {
+  display: grid;
+  gap: 18px;
+}
+
+.event-card {
+  background: var(--bg-card);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 20px;
+  display: grid;
+  gap: 14px;
+}
+
+.event-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+}
+
+.event-title {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.event-title:hover {
+  color: var(--accent);
+}
+
+.event-meta {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.event-summary {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.event-score {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.event-footer {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.doc-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+#documentAnalysis {
+  min-height: 260px;
+}
+
+.valuation-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.valuation-summary {
+  display: grid;
+  gap: 16px;
+}
+
+.valuation-summary > div {
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(14, 24, 48, 0.8);
+  border: 1px solid var(--border);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.assumption-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.assumption-list li {
+  position: relative;
+  padding-left: 20px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.assumption-list li::before {
+  content: '\f35a';
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+
+.footer {
+  margin-top: 60px;
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  background: rgba(8, 12, 24, 0.8);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 20px;
+  color: var(--text-muted);
+}
+
+.footer strong {
+  color: var(--text);
+  font-size: 1.05rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+}
+
+.footer a {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.footer a:hover {
+  color: var(--accent);
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    padding: 28px 20px 60px;
+  }
+
+  .hero {
+    padding: 32px 24px;
+  }
+
+  .panel-header {
+    padding: 28px 24px 16px;
+  }
+
+  .panel-body {
+    padding: 0 24px 28px;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-content h1 {
+    font-size: 2.1rem;
+  }
+
+  .hero-actions {
+    width: 100%;
+  }
+
+  .symbol-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .timeframe-switcher {
+    flex-wrap: wrap;
+  }
+
+  .timeframe-switcher button {
+    flex: 1 1 33%;
+  }
+
+  .sticky-nav {
+    position: static;
+  }
+}

--- a/pro-desk.html
+++ b/pro-desk.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Professional Trading Intelligence Desk</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-oq0b0vnRZ4VfqakiobP6KyHR+Y6z+4dJVpaz6RtWLpmjHtkobaN6D+PfYZ7R6pujISiFDUFxIr05oig3FZp6jQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <link rel="stylesheet" href="pro-desk.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="hero">
+      <div class="hero-content">
+        <div>
+          <span class="eyebrow">AI-Augmented Command Center</span>
+          <h1>Professional Trading Desk &amp; Valuation Lab</h1>
+          <p>
+            Deep fundamental intelligence, event surveillance, and AI-guided valuation workflows built for
+            institutional-grade idea generation. Screen global equities, interrogate disclosures, and surface
+            fair value in real time with Tiingo market data and GPT-5 ready analytics.
+          </p>
+        </div>
+        <div class="hero-actions">
+          <a class="btn primary" href="index.html"><i class="fa-solid fa-arrow-left"></i><span>Return to core terminal</span></a>
+          <a class="btn" href="#ai-screener"><i class="fa-solid fa-robot"></i><span>Jump to AI analyst</span></a>
+          <a class="btn" href="#valuation-lab"><i class="fa-solid fa-chart-line"></i><span>Open valuation lab</span></a>
+        </div>
+      </div>
+      <div class="hero-metrics" id="heroSnapshot">
+        <div class="metric">
+          <div class="metric-label">Symbol</div>
+          <div class="metric-value" id="heroSymbol">AAPL</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Last Price</div>
+          <div class="metric-value" id="heroPrice">—</div>
+          <div class="metric-sub" id="heroChange">—</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">AI Fair Value</div>
+          <div class="metric-value" id="heroFairValue">—</div>
+          <div class="metric-sub" id="heroUpside">—</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Confidence</div>
+          <div class="metric-value" id="heroConfidence">—</div>
+          <div class="metric-sub" id="heroConfidenceDetail">Awaiting analysis</div>
+        </div>
+      </div>
+    </header>
+
+    <nav class="sticky-nav">
+      <a href="#market-overview">Market radar</a>
+      <a href="#ai-screener">AI screening</a>
+      <a href="#event-intel">Event intelligence</a>
+      <a href="#document-lab">Document review</a>
+      <a href="#valuation-lab">Valuation lab</a>
+    </nav>
+
+    <main class="page-grid">
+      <section id="market-overview" class="panel">
+        <header class="panel-header">
+          <div>
+            <h2>Market radar</h2>
+            <p class="muted">Multi-timeframe charting, liquidity heat, and technical posture.</p>
+          </div>
+          <form id="symbolForm" class="symbol-form">
+            <label for="symbolInput" class="muted">Ticker</label>
+            <input id="symbolInput" name="symbol" placeholder="AAPL, MSFT, TSLA" autocomplete="off" />
+            <button class="btn primary" type="submit"><i class="fa-solid fa-chart-line"></i><span>Load</span></button>
+          </form>
+        </header>
+
+        <div class="panel-body">
+          <div class="chart-card card">
+            <div class="card-header">
+              <div>
+                <h3>Price structure</h3>
+                <div id="chartStatus" class="muted"></div>
+              </div>
+              <div class="timeframe-switcher" id="timeframeSwitcher">
+                <button data-tf="1D" class="active">1D</button>
+                <button data-tf="5D">5D</button>
+                <button data-tf="1M">1M</button>
+                <button data-tf="3M">3M</button>
+                <button data-tf="6M">6M</button>
+                <button data-tf="1Y">1Y</button>
+                <button data-tf="5Y">5Y</button>
+              </div>
+            </div>
+            <canvas id="deskChart" height="320"></canvas>
+          </div>
+
+          <div class="metrics-grid" id="marketMetrics">
+            <div class="metric-card">
+              <span class="metric-label">Annualized volatility</span>
+              <span class="metric-value" id="metricVolatility">—</span>
+              <span class="metric-sub" id="metricVolatilityDetail">Awaiting data</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Sharpe (signal)</span>
+              <span class="metric-value" id="metricSharpe">—</span>
+              <span class="metric-sub" id="metricSharpeDetail">—</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Max drawdown</span>
+              <span class="metric-value" id="metricDrawdown">—</span>
+              <span class="metric-sub" id="metricDrawdownDetail">—</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Liquidity</span>
+              <span class="metric-value" id="metricLiquidity">—</span>
+              <span class="metric-sub" id="metricLiquidityDetail">—</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Momentum regime</span>
+              <span class="metric-value" id="metricMomentum">—</span>
+              <span class="metric-sub" id="metricMomentumDetail">—</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Risk radar</span>
+              <span class="metric-value" id="metricRisk">—</span>
+              <span class="metric-sub" id="metricRiskDetail">—</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="ai-screener" class="panel">
+        <header class="panel-header">
+          <div>
+            <h2>AI multi-factor screening</h2>
+            <p class="muted">Let GPT-5-ready analytics synthesize fundamentals, flows, and qualitative catalysts.</p>
+          </div>
+        </header>
+        <div class="panel-body ai-grid">
+          <form id="aiScreenerForm" class="card ai-card">
+            <div class="form-row">
+              <label for="aiTickers">Universe <span class="muted">(comma separated tickers)</span></label>
+              <textarea id="aiTickers" rows="2" placeholder="AAPL, MSFT, NVDA"></textarea>
+            </div>
+            <div class="form-row">
+              <label for="aiFocus">Focus mandate</label>
+              <select id="aiFocus">
+                <option value="growth">High growth &amp; innovation</option>
+                <option value="value">Value &amp; margin of safety</option>
+                <option value="income">Income &amp; stability</option>
+                <option value="turnaround">Turnaround / event-driven</option>
+                <option value="esg">ESG-aligned</option>
+              </select>
+            </div>
+            <div class="form-row">
+              <label for="aiRisk">Risk tolerance</label>
+              <select id="aiRisk">
+                <option value="conservative">Conservative</option>
+                <option value="balanced" selected>Balanced</option>
+                <option value="aggressive">Aggressive</option>
+              </select>
+            </div>
+            <div class="form-row">
+              <label for="aiHorizon">Investment horizon</label>
+              <select id="aiHorizon">
+                <option value="short">0-3 months</option>
+                <option value="medium" selected>6-12 months</option>
+                <option value="long">3+ years</option>
+              </select>
+            </div>
+            <div class="form-row">
+              <label for="aiNotes">Additional mandates</label>
+              <textarea id="aiNotes" rows="3" placeholder="Prioritize AI infrastructure names with improving free cash flow margins."></textarea>
+            </div>
+            <button type="submit" class="btn primary"><i class="fa-solid fa-robot"></i><span>Launch GPT analyst</span></button>
+            <div id="aiScreenerStatus" class="status muted"></div>
+          </form>
+
+          <article class="card ai-output">
+            <header class="card-header">
+              <h3>AI guidance</h3>
+              <div id="aiScreenerModel" class="muted"></div>
+            </header>
+            <div id="aiScreenerOutput" class="ai-output-body"></div>
+          </article>
+        </div>
+      </section>
+
+      <section id="event-intel" class="panel">
+        <header class="panel-header">
+          <div>
+            <h2>Event intelligence</h2>
+            <p class="muted">Structured catalysts, filings, and sentiment-ranked news from Tiingo.</p>
+          </div>
+          <button class="btn" id="refreshEvents"><i class="fa-solid fa-rotate"></i><span>Refresh events</span></button>
+        </header>
+        <div class="panel-body">
+          <div id="eventStatus" class="muted"></div>
+          <div id="eventStream" class="event-stream"></div>
+        </div>
+      </section>
+
+      <section id="document-lab" class="panel">
+        <header class="panel-header">
+          <div>
+            <h2>Document intelligence lab</h2>
+            <p class="muted">Pull transcripts, filings, or investor updates and ask the AI desk to stress-test them.</p>
+          </div>
+        </header>
+        <div class="panel-body doc-grid">
+          <form id="documentForm" class="card">
+            <div class="form-row">
+              <label for="docUrl">Document URL <span class="muted">(10-K, press release, etc.)</span></label>
+              <input id="docUrl" type="url" placeholder="https://www.sec.gov/..." />
+            </div>
+            <div class="form-row">
+              <label for="docText">Document text</label>
+              <textarea id="docText" rows="10" placeholder="Paste disclosure text or fetch via URL"></textarea>
+            </div>
+            <div class="doc-actions">
+              <button type="button" class="btn" id="fetchDocument"><i class="fa-solid fa-file-arrow-down"></i><span>Fetch &amp; clean</span></button>
+              <button type="button" class="btn primary" id="analyzeDocument"><i class="fa-solid fa-magnifying-glass-chart"></i><span>AI review</span></button>
+            </div>
+            <div id="documentStatus" class="status muted"></div>
+          </form>
+          <article class="card ai-output">
+            <header class="card-header">
+              <h3>AI document briefing</h3>
+              <div id="documentModel" class="muted"></div>
+            </header>
+            <div id="documentAnalysis" class="ai-output-body"></div>
+          </article>
+        </div>
+      </section>
+
+      <section id="valuation-lab" class="panel">
+        <header class="panel-header">
+          <div>
+            <h2>Valuation lab</h2>
+            <p class="muted">DCF, multiples, and balance sheet diagnostics computed from Tiingo fundamentals.</p>
+          </div>
+        </header>
+        <div class="panel-body valuation-grid">
+          <article class="card">
+            <header class="card-header">
+              <h3>Summary</h3>
+            </header>
+            <div class="valuation-summary">
+              <div>
+                <span class="metric-label">Blended fair value</span>
+                <span class="metric-value" id="valuationFairValue">—</span>
+                <span class="metric-sub" id="valuationUpside">—</span>
+              </div>
+              <div>
+                <span class="metric-label">DCF range</span>
+                <span class="metric-value" id="valuationDcfRange">—</span>
+                <span class="metric-sub" id="valuationDcfNotes">—</span>
+              </div>
+              <div>
+                <span class="metric-label">Multiples composite</span>
+                <span class="metric-value" id="valuationMultiples">—</span>
+                <span class="metric-sub" id="valuationMultiplesNotes">—</span>
+              </div>
+              <div>
+                <span class="metric-label">Quality score</span>
+                <span class="metric-value" id="valuationQuality">—</span>
+                <span class="metric-sub" id="valuationQualityDetail">—</span>
+              </div>
+            </div>
+          </article>
+
+          <article class="card">
+            <header class="card-header">
+              <h3>Key fundamentals</h3>
+            </header>
+            <table class="data-table" id="fundamentalsTable">
+              <thead>
+                <tr><th>Metric</th><th>Latest</th><th>Trend</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </article>
+
+          <article class="card">
+            <header class="card-header">
+              <h3>Assumptions</h3>
+            </header>
+            <ul class="assumption-list" id="assumptionList"></ul>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <strong>Disclaimers</strong>
+        <p class="muted">Market data sourced from Tiingo. AI modules require an OpenAI API key configured as <code>OPENAI_API_KEY</code>. Outputs are research tools and not investment advice.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://www.tiingo.com/" target="_blank" rel="noopener">Tiingo</a>
+        <a href="https://openai.com/" target="_blank" rel="noopener">OpenAI</a>
+        <a href="index.html">Legacy dashboard</a>
+      </div>
+    </footer>
+  </div>
+
+  <template id="eventTemplate">
+    <article class="event-card">
+      <header class="event-header">
+        <div>
+          <a class="event-title" href="#" target="_blank" rel="noopener"></a>
+          <div class="event-meta"></div>
+        </div>
+        <span class="event-score"></span>
+      </header>
+      <p class="event-summary"></p>
+      <footer class="event-footer"></footer>
+    </article>
+  </template>
+
+  <script type="module" src="pro-desk.js"></script>
+</body>
+</html>

--- a/pro-desk.js
+++ b/pro-desk.js
@@ -1,0 +1,670 @@
+import {
+  analyseSeries,
+  formatNumber,
+  formatPercent,
+} from './shared/quant.js';
+
+const DEFAULT_SYMBOL = 'AAPL';
+const DEFAULT_CURRENCY = 'USD';
+
+const TIMEFRAME_CONFIG = {
+  '1D': { kind: 'intraday', interval: '5min', limit: 78, periodsPerYear: 252 * 78, label: '1 day' },
+  '5D': { kind: 'intraday', interval: '30min', limit: 65, periodsPerYear: 252 * 13, label: '5 days' },
+  '1M': { kind: 'eod', limit: 30, periodsPerYear: 252, label: '1 month' },
+  '3M': { kind: 'eod', limit: 65, periodsPerYear: 252, label: '3 months' },
+  '6M': { kind: 'eod', limit: 130, periodsPerYear: 252, label: '6 months' },
+  '1Y': { kind: 'eod', limit: 260, periodsPerYear: 252, label: '1 year' },
+  '5Y': { kind: 'eod', limit: 1300, periodsPerYear: 252, label: '5 years' },
+};
+
+const dom = {
+  heroSymbol: document.getElementById('heroSymbol'),
+  heroPrice: document.getElementById('heroPrice'),
+  heroChange: document.getElementById('heroChange'),
+  heroFairValue: document.getElementById('heroFairValue'),
+  heroUpside: document.getElementById('heroUpside'),
+  heroConfidence: document.getElementById('heroConfidence'),
+  heroConfidenceDetail: document.getElementById('heroConfidenceDetail'),
+  timeframeSwitcher: document.getElementById('timeframeSwitcher'),
+  chartCanvas: document.getElementById('deskChart'),
+  chartStatus: document.getElementById('chartStatus'),
+  metricVolatility: document.getElementById('metricVolatility'),
+  metricVolatilityDetail: document.getElementById('metricVolatilityDetail'),
+  metricSharpe: document.getElementById('metricSharpe'),
+  metricSharpeDetail: document.getElementById('metricSharpeDetail'),
+  metricDrawdown: document.getElementById('metricDrawdown'),
+  metricDrawdownDetail: document.getElementById('metricDrawdownDetail'),
+  metricLiquidity: document.getElementById('metricLiquidity'),
+  metricLiquidityDetail: document.getElementById('metricLiquidityDetail'),
+  metricMomentum: document.getElementById('metricMomentum'),
+  metricMomentumDetail: document.getElementById('metricMomentumDetail'),
+  metricRisk: document.getElementById('metricRisk'),
+  metricRiskDetail: document.getElementById('metricRiskDetail'),
+  symbolForm: document.getElementById('symbolForm'),
+  symbolInput: document.getElementById('symbolInput'),
+  aiForm: document.getElementById('aiScreenerForm'),
+  aiStatus: document.getElementById('aiScreenerStatus'),
+  aiOutput: document.getElementById('aiScreenerOutput'),
+  aiModel: document.getElementById('aiScreenerModel'),
+  aiTickers: document.getElementById('aiTickers'),
+  aiFocus: document.getElementById('aiFocus'),
+  aiRisk: document.getElementById('aiRisk'),
+  aiHorizon: document.getElementById('aiHorizon'),
+  aiNotes: document.getElementById('aiNotes'),
+  eventStream: document.getElementById('eventStream'),
+  eventStatus: document.getElementById('eventStatus'),
+  eventTemplate: document.getElementById('eventTemplate'),
+  refreshEvents: document.getElementById('refreshEvents'),
+  documentForm: document.getElementById('documentForm'),
+  documentUrl: document.getElementById('docUrl'),
+  documentText: document.getElementById('docText'),
+  documentStatus: document.getElementById('documentStatus'),
+  documentAnalysis: document.getElementById('documentAnalysis'),
+  documentModel: document.getElementById('documentModel'),
+  fetchDocumentBtn: document.getElementById('fetchDocument'),
+  analyzeDocumentBtn: document.getElementById('analyzeDocument'),
+  valuationFairValue: document.getElementById('valuationFairValue'),
+  valuationUpside: document.getElementById('valuationUpside'),
+  valuationDcfRange: document.getElementById('valuationDcfRange'),
+  valuationDcfNotes: document.getElementById('valuationDcfNotes'),
+  valuationMultiples: document.getElementById('valuationMultiples'),
+  valuationMultiplesNotes: document.getElementById('valuationMultiplesNotes'),
+  valuationQuality: document.getElementById('valuationQuality'),
+  valuationQualityDetail: document.getElementById('valuationQualityDetail'),
+  fundamentalsTable: document.querySelector('#fundamentalsTable tbody'),
+  assumptionList: document.getElementById('assumptionList'),
+};
+
+const state = {
+  symbol: DEFAULT_SYMBOL,
+  timeframe: '1M',
+  seriesCache: new Map(),
+  chart: null,
+  quote: null,
+  currency: DEFAULT_CURRENCY,
+  valuations: null,
+  events: [],
+};
+
+const currencyFormatter = (currency = DEFAULT_CURRENCY, digits = 2) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: digits, minimumFractionDigits: digits });
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const escapeHtml = (value = '') => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const renderMarkdownish = (container, text) => {
+  if (!container) return;
+  if (!text) {
+    container.innerHTML = '<p class="muted">No analysis available yet.</p>';
+    return;
+  }
+  const sections = text.trim().split(/\n{2,}/).map((section) => section.trim()).filter(Boolean);
+  const html = sections.map((section) => {
+    if (/^-\s+/m.test(section)) {
+      const items = section.split(/\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith('- '))
+        .map((line) => `<li>${escapeHtml(line.replace(/^-\s*/, ''))}</li>`)
+        .join('');
+      return `<ul>${items}</ul>`;
+    }
+    return `<p>${escapeHtml(section)}</p>`;
+  }).join('');
+  container.innerHTML = html;
+};
+
+const setActiveTimeframe = (timeframe) => {
+  state.timeframe = timeframe;
+  if (!dom.timeframeSwitcher) return;
+  dom.timeframeSwitcher.querySelectorAll('button').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.tf === timeframe);
+  });
+};
+
+const updateChart = (series, timeframe) => {
+  if (!dom.chartCanvas || !window.Chart) return;
+  const ctx = dom.chartCanvas.getContext('2d');
+  const points = (series || []).map((row) => ({ x: new Date(row.date), y: Number(row.close) }));
+  const gradient = ctx.createLinearGradient(0, 0, 0, dom.chartCanvas.height || 320);
+  gradient.addColorStop(0, 'rgba(98, 208, 255, 0.4)');
+  gradient.addColorStop(1, 'rgba(98, 208, 255, 0)');
+
+  if (!state.chart) {
+    state.chart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        datasets: [
+          {
+            label: `${state.symbol} price`,
+            data: points,
+            borderColor: '#62d0ff',
+            backgroundColor: gradient,
+            tension: 0.25,
+            fill: true,
+            borderWidth: 2,
+            pointRadius: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        parsing: false,
+        scales: {
+          x: {
+            type: 'time',
+            time: { tooltipFormat: timeframe === '1D' ? 'MMM d, HH:mm' : 'MMM d, yyyy' },
+            ticks: {
+              maxRotation: 0,
+              color: 'rgba(235,240,255,0.6)',
+            },
+            grid: { color: 'rgba(255,255,255,0.05)' },
+          },
+          y: {
+            ticks: { color: 'rgba(235,240,255,0.6)' },
+            grid: { color: 'rgba(255,255,255,0.05)' },
+          },
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            mode: 'index',
+            intersect: false,
+            callbacks: {
+              label: (ctxPoint) => `${currencyFormatter(state.currency, 2).format(ctxPoint.parsed.y)}`,
+            },
+          },
+        },
+      },
+    });
+  } else {
+    const dataset = state.chart.data.datasets[0];
+    dataset.data = points;
+    dataset.label = `${state.symbol} price`;
+    state.chart.options.scales.x.time.tooltipFormat = timeframe === '1D' ? 'MMM d, HH:mm' : 'MMM d, yyyy';
+    state.chart.update();
+  }
+};
+
+const describeMomentum = (analysis, latestPrice) => {
+  if (!analysis) return { label: '—', detail: 'Insufficient history' };
+  const { sma20, sma50, ema21, rsi } = analysis;
+  if (sma20 == null || sma50 == null) return { label: 'Neutral', detail: 'Not enough data for trend' };
+  const momentum = sma20 > sma50 ? 'Positive' : sma20 < sma50 ? 'Negative' : 'Neutral';
+  let detail = `20d SMA ${sma20?.toFixed(2) ?? '—'} vs 50d ${sma50?.toFixed(2) ?? '—'}`;
+  if (ema21 != null && latestPrice != null) {
+    const bias = latestPrice > ema21 ? 'above' : 'below';
+    detail += ` · Price ${bias} 21d EMA`;
+  }
+  if (rsi != null) {
+    detail += ` · RSI ${rsi.toFixed(1)}`;
+  }
+  return { label: momentum, detail };
+};
+
+const describeRisk = (analysis) => {
+  if (!analysis || analysis.volatility == null) return { label: '—', detail: 'Insufficient data' };
+  const vol = analysis.volatility;
+  const label = vol > 0.6 ? 'Elevated' : vol > 0.35 ? 'Moderate' : 'Calm';
+  const detail = `Ann. vol ${formatPercent(vol)} · Sharpe ${analysis.sharpe != null ? analysis.sharpe.toFixed(2) : '—'}`;
+  return { label, detail };
+};
+
+const updateTechnicalSection = (series, timeframe) => {
+  const config = TIMEFRAME_CONFIG[timeframe] || TIMEFRAME_CONFIG['1M'];
+  const analysis = analyseSeries(series, { periodsPerYear: config.periodsPerYear });
+
+  if (analysis.volatility != null) {
+    dom.metricVolatility.textContent = formatPercent(analysis.volatility);
+    dom.metricVolatilityDetail.textContent = `${config.label} basis`; 
+  } else {
+    dom.metricVolatility.textContent = '—';
+    dom.metricVolatilityDetail.textContent = 'Not enough data';
+  }
+
+  if (analysis.sharpe != null) {
+    dom.metricSharpe.textContent = analysis.sharpe.toFixed(2);
+    dom.metricSharpeDetail.textContent = analysis.sharpe > 1
+      ? 'Risk-adjusted performance >1σ'
+      : 'Subdued risk-adjusted returns';
+  } else {
+    dom.metricSharpe.textContent = '—';
+    dom.metricSharpeDetail.textContent = 'Insufficient history';
+  }
+
+  if (analysis.drawdown != null) {
+    dom.metricDrawdown.textContent = formatPercent(Math.abs(analysis.drawdown));
+    dom.metricDrawdownDetail.textContent = 'Worst peak-to-trough';
+  } else {
+    dom.metricDrawdown.textContent = '—';
+    dom.metricDrawdownDetail.textContent = 'Insufficient history';
+  }
+
+  if (analysis.averageVolume != null) {
+    dom.metricLiquidity.textContent = formatNumber(analysis.averageVolume, 2);
+    dom.metricLiquidityDetail.textContent = '30-bar avg volume';
+  } else {
+    dom.metricLiquidity.textContent = '—';
+    dom.metricLiquidityDetail.textContent = 'Volume unavailable';
+  }
+
+  const latestClose = series?.[series.length - 1]?.close ?? null;
+  const { label: momentumLabel, detail: momentumDetail } = describeMomentum(analysis, latestClose);
+  dom.metricMomentum.textContent = momentumLabel;
+  dom.metricMomentumDetail.textContent = momentumDetail;
+
+  const { label: riskLabel, detail: riskDetail } = describeRisk(analysis);
+  dom.metricRisk.textContent = riskLabel;
+  dom.metricRiskDetail.textContent = riskDetail;
+};
+
+const updateHero = (quote) => {
+  if (!quote) return;
+  const fmt = currencyFormatter(quote.currency || state.currency);
+  dom.heroSymbol.textContent = quote.symbol || state.symbol;
+  dom.heroPrice.textContent = fmt.format(quote.price ?? quote.close ?? quote.last ?? 0);
+  const previous = quote.previousClose ?? quote.open;
+  if (previous != null && quote.price != null) {
+    const change = quote.price - previous;
+    const pct = previous ? change / previous : 0;
+    const sign = change >= 0 ? '+' : '';
+    dom.heroChange.textContent = `${sign}${fmt.format(change)} (${formatPercent(pct)})`;
+    dom.heroChange.style.color = change >= 0 ? '#5fe1a1' : '#ff6b81';
+  } else {
+    dom.heroChange.textContent = '—';
+    dom.heroChange.style.color = 'inherit';
+  }
+};
+
+const updateHeroValuation = (valuations, quote) => {
+  if (!valuations) {
+    dom.heroFairValue.textContent = '—';
+    dom.heroUpside.textContent = '—';
+    dom.heroConfidence.textContent = '—';
+    dom.heroConfidenceDetail.textContent = 'No valuation data yet';
+    return;
+  }
+  const fmt = currencyFormatter((quote && quote.currency) || state.currency);
+  const blended = valuations.blended || {};
+  const fairValue = blended.fairValue ?? valuations.dcf?.fairValue ?? valuations.multiples?.fairValue ?? null;
+  dom.heroFairValue.textContent = fairValue != null ? fmt.format(fairValue) : '—';
+  if (fairValue != null && quote?.price != null) {
+    const diff = fairValue - quote.price;
+    const pct = quote.price ? diff / quote.price : 0;
+    const sign = diff >= 0 ? '+' : '';
+    dom.heroUpside.textContent = `${sign}${formatPercent(pct)} vs spot`;
+    dom.heroUpside.style.color = diff >= 0 ? '#5fe1a1' : '#ff6b81';
+  } else {
+    dom.heroUpside.textContent = '—';
+    dom.heroUpside.style.color = 'inherit';
+  }
+  if (blended.confidence != null) {
+    dom.heroConfidence.textContent = `${Math.round(clamp(blended.confidence, 0, 1) * 100)}%`;
+    dom.heroConfidenceDetail.textContent = blended.rationale || 'Model confidence';
+  } else {
+    dom.heroConfidence.textContent = '—';
+    dom.heroConfidenceDetail.textContent = blended?.rationale || 'Confidence unavailable';
+  }
+};
+
+const updateValuationPanel = (payload, quote) => {
+  state.valuations = payload?.valuations || null;
+  updateHeroValuation(state.valuations, quote);
+
+  if (!payload) {
+    dom.valuationFairValue.textContent = '—';
+    dom.valuationUpside.textContent = '—';
+    dom.valuationDcfRange.textContent = '—';
+    dom.valuationDcfNotes.textContent = 'No DCF data';
+    dom.valuationMultiples.textContent = '—';
+    dom.valuationMultiplesNotes.textContent = 'No comparable data';
+    dom.valuationQuality.textContent = '—';
+    dom.valuationQualityDetail.textContent = '—';
+    dom.fundamentalsTable.innerHTML = '';
+    dom.assumptionList.innerHTML = '';
+    return;
+  }
+
+  const fmt = currencyFormatter((quote && quote.currency) || state.currency);
+  const { valuations = {}, qualityNarrative, table = [], assumptions = [] } = payload;
+  const blended = valuations.blended || {};
+  if (blended.fairValue != null) {
+    dom.valuationFairValue.textContent = fmt.format(blended.fairValue);
+    if (quote?.price != null) {
+      const pct = (blended.fairValue - quote.price) / quote.price;
+      dom.valuationUpside.textContent = `${formatPercent(pct)} vs spot`;
+      dom.valuationUpside.style.color = pct >= 0 ? '#5fe1a1' : '#ff6b81';
+    } else {
+      dom.valuationUpside.textContent = '—';
+      dom.valuationUpside.style.color = 'inherit';
+    }
+  } else {
+    dom.valuationFairValue.textContent = '—';
+    dom.valuationUpside.textContent = '—';
+  }
+
+  if (valuations.dcf) {
+    const { low, high, fairValue, discountRate, terminalGrowth } = valuations.dcf;
+    if (low != null && high != null) {
+      dom.valuationDcfRange.textContent = `${fmt.format(low)} – ${fmt.format(high)}`;
+    } else if (fairValue != null) {
+      dom.valuationDcfRange.textContent = fmt.format(fairValue);
+    } else {
+      dom.valuationDcfRange.textContent = '—';
+    }
+    const dr = discountRate != null ? `${formatPercent(discountRate)}` : '—';
+    const tg = terminalGrowth != null ? `${formatPercent(terminalGrowth)}` : '—';
+    dom.valuationDcfNotes.textContent = `Discount ${dr}, terminal growth ${tg}`;
+  } else {
+    dom.valuationDcfRange.textContent = '—';
+    dom.valuationDcfNotes.textContent = 'DCF unavailable';
+  }
+
+  if (valuations.multiples) {
+    const { fairValue, low, high, notes } = valuations.multiples;
+    if (low != null && high != null) {
+      dom.valuationMultiples.textContent = `${fmt.format(low)} – ${fmt.format(high)}`;
+    } else if (fairValue != null) {
+      dom.valuationMultiples.textContent = fmt.format(fairValue);
+    } else {
+      dom.valuationMultiples.textContent = '—';
+    }
+    dom.valuationMultiplesNotes.textContent = notes || 'Comps blend of P/E, P/S, P/B';
+  } else {
+    dom.valuationMultiples.textContent = '—';
+    dom.valuationMultiplesNotes.textContent = 'No multiples available';
+  }
+
+  if (blended.qualityScore != null) {
+    dom.valuationQuality.textContent = `${Math.round(blended.qualityScore)}/100`;
+    dom.valuationQualityDetail.textContent = blended.rationale || qualityNarrative || 'Composite of profitability, growth, leverage';
+  } else {
+    dom.valuationQuality.textContent = '—';
+    dom.valuationQualityDetail.textContent = qualityNarrative || '—';
+  }
+
+  dom.fundamentalsTable.innerHTML = '';
+  (table || []).forEach((row) => {
+    const tr = document.createElement('tr');
+    const tdMetric = document.createElement('td'); tdMetric.textContent = row.metric || '';
+    const tdValue = document.createElement('td'); tdValue.textContent = row.value || '—';
+    const tdTrend = document.createElement('td'); tdTrend.textContent = row.trend || '—';
+    tr.append(tdMetric, tdValue, tdTrend);
+    dom.fundamentalsTable.appendChild(tr);
+  });
+
+  dom.assumptionList.innerHTML = '';
+  (assumptions || []).forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    dom.assumptionList.appendChild(li);
+  });
+};
+
+const updateEvents = (payload) => {
+  if (!dom.eventStream) return;
+  dom.eventStream.innerHTML = '';
+  if (!payload || !Array.isArray(payload.events) || payload.events.length === 0) {
+    dom.eventStatus.textContent = payload?.warning || 'No recent events detected.';
+    return;
+  }
+  dom.eventStatus.textContent = payload.warning || '';
+  payload.events.forEach((event) => {
+    const clone = dom.eventTemplate.content.firstElementChild.cloneNode(true);
+    const title = clone.querySelector('.event-title');
+    const meta = clone.querySelector('.event-meta');
+    const summary = clone.querySelector('.event-summary');
+    const score = clone.querySelector('.event-score');
+    const footer = clone.querySelector('.event-footer');
+    if (title) {
+      title.textContent = event.title || 'Untitled event';
+      if (event.url) title.href = event.url;
+    }
+    if (meta) {
+      const published = event.date ? new Date(event.date).toLocaleString() : 'Unknown time';
+      const type = event.type ? ` · ${event.type}` : '';
+      const source = event.source ? ` · ${event.source}` : '';
+      meta.textContent = `${published}${type}${source}`;
+    }
+    if (summary) summary.textContent = event.summary || '';
+    if (score) score.textContent = event.impactScore != null ? `Impact ${event.impactScore}/5` : '';
+    if (footer) footer.textContent = event.highlights || (event.tags ? event.tags.join(', ') : '');
+    dom.eventStream.appendChild(clone);
+  });
+};
+
+const buildTiingoUrl = (symbol, timeframe) => {
+  const config = TIMEFRAME_CONFIG[timeframe] || TIMEFRAME_CONFIG['1M'];
+  const params = new URLSearchParams({ symbol, kind: config.kind, limit: String(config.limit) });
+  if (config.interval) params.set('interval', config.interval);
+  return `/api/tiingo?${params.toString()}`;
+};
+
+const fetchJson = async (url, init) => {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Request failed ${response.status}: ${text || response.statusText}`);
+  }
+  return response.json();
+};
+
+const loadSeries = async (symbol, timeframe) => {
+  const cacheKey = `${symbol}::${timeframe}`;
+  if (state.seriesCache.has(cacheKey)) {
+    return state.seriesCache.get(cacheKey);
+  }
+  dom.chartStatus.textContent = 'Loading price history…';
+  const data = await fetchJson(buildTiingoUrl(symbol, timeframe));
+  if (data.warning) {
+    dom.chartStatus.textContent = data.warning;
+  } else {
+    dom.chartStatus.textContent = '';
+  }
+  const series = Array.isArray(data.data) ? data.data : [];
+  state.seriesCache.set(cacheKey, series);
+  return series;
+};
+
+const loadQuote = async (symbol) => {
+  const params = new URLSearchParams({ symbol, kind: 'intraday_latest' });
+  const data = await fetchJson(`/api/tiingo?${params.toString()}`);
+  return Array.isArray(data.data) ? data.data[0] : null;
+};
+
+const loadFundamentals = async (symbol) => {
+  const params = new URLSearchParams({ symbol });
+  return fetchJson(`/api/tiingo-fundamentals?${params.toString()}`);
+};
+
+const loadEvents = async (symbol) => {
+  const params = new URLSearchParams({ symbol, limit: '8' });
+  return fetchJson(`/api/tiingo-events?${params.toString()}`);
+};
+
+const loadDocument = async (url) => {
+  return fetchJson('/api/document-fetch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
+  });
+};
+
+const callAiAnalyst = async (payload) => fetchJson('/api/ai-analyst', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload),
+});
+
+const loadSymbol = async (symbol, timeframe = state.timeframe) => {
+  try {
+    dom.symbolInput.value = symbol;
+    state.symbol = symbol;
+    dom.heroSymbol.textContent = symbol;
+    dom.chartStatus.textContent = 'Loading market data…';
+    const [quote, series] = await Promise.all([
+      loadQuote(symbol).catch((err) => {
+        console.warn('quote fetch failed', err);
+        return null;
+      }),
+      loadSeries(symbol, timeframe).catch((err) => {
+        console.warn('series fetch failed', err);
+        dom.chartStatus.textContent = 'Unable to load price history — showing cached or mock data.';
+        return [];
+      }),
+    ]);
+    state.quote = quote;
+    if (quote?.currency) state.currency = quote.currency;
+    updateChart(series, timeframe);
+    updateTechnicalSection(series, timeframe);
+    if (quote) updateHero(quote);
+
+    loadFundamentals(symbol).then((fundamentals) => {
+      updateValuationPanel(fundamentals, quote);
+    }).catch((err) => {
+      console.warn('fundamentals fetch failed', err);
+      updateValuationPanel(null, quote);
+    });
+
+    loadEvents(symbol).then((events) => {
+      state.events = events?.events || [];
+      updateEvents(events);
+    }).catch((err) => {
+      console.warn('events fetch failed', err);
+      dom.eventStatus.textContent = 'Event feed unavailable';
+    });
+  } catch (error) {
+    console.error('loadSymbol failed', error);
+    dom.chartStatus.textContent = 'Failed to load market data. Check network/API configuration.';
+  }
+};
+
+const onTimeframeClick = (event) => {
+  const button = event.target.closest('button[data-tf]');
+  if (!button) return;
+  const { tf } = button.dataset;
+  if (!tf || tf === state.timeframe) return;
+  setActiveTimeframe(tf);
+  loadSeries(state.symbol, tf)
+    .then((series) => {
+      updateChart(series, tf);
+      updateTechnicalSection(series, tf);
+    })
+    .catch((err) => {
+      console.warn('timeframe load failed', err);
+      dom.chartStatus.textContent = 'Failed to load timeframe data';
+    });
+};
+
+const onSymbolSubmit = (event) => {
+  event.preventDefault();
+  const raw = dom.symbolInput.value.trim().toUpperCase();
+  if (!raw) return;
+  state.seriesCache.clear();
+  loadSymbol(raw, state.timeframe);
+};
+
+const onAiFormSubmit = async (event) => {
+  event.preventDefault();
+  if (!dom.aiStatus) return;
+  dom.aiStatus.textContent = 'Synthesizing screening narrative…';
+  dom.aiOutput.innerHTML = '';
+  const payload = {
+    mode: 'screener',
+    symbol: state.symbol,
+    universe: dom.aiTickers.value,
+    focus: dom.aiFocus.value,
+    riskTolerance: dom.aiRisk.value,
+    horizon: dom.aiHorizon.value,
+    notes: dom.aiNotes.value,
+    quote: state.quote,
+    valuations: state.valuations,
+    events: state.events,
+  };
+  try {
+    const result = await callAiAnalyst(payload);
+    dom.aiStatus.textContent = result.warning || '';
+    dom.aiModel.textContent = result.model ? `Model: ${result.model}` : '';
+    renderMarkdownish(dom.aiOutput, result.analysis || 'No analysis returned.');
+  } catch (error) {
+    console.error('AI screener failed', error);
+    dom.aiStatus.textContent = 'AI module unavailable. Configure OPENAI_API_KEY to enable analysis.';
+    dom.aiOutput.innerHTML = '';
+  }
+};
+
+const onRefreshEvents = () => {
+  dom.eventStatus.textContent = 'Refreshing events…';
+  loadEvents(state.symbol)
+    .then((events) => {
+      state.events = events?.events || [];
+      updateEvents(events);
+    })
+    .catch((err) => {
+      console.warn('refresh events failed', err);
+      dom.eventStatus.textContent = 'Unable to refresh event feed';
+    });
+};
+
+const onFetchDocument = async () => {
+  const url = dom.documentUrl.value.trim();
+  if (!url) {
+    dom.documentStatus.textContent = 'Provide a document URL to fetch.';
+    return;
+  }
+  dom.documentStatus.textContent = 'Fetching and cleaning document…';
+  try {
+    const result = await loadDocument(url);
+    dom.documentStatus.textContent = result.truncated
+      ? 'Document truncated for analysis (size limit).'
+      : 'Document fetched successfully.';
+    dom.documentText.value = result.content || '';
+  } catch (error) {
+    console.error('document fetch failed', error);
+    dom.documentStatus.textContent = 'Unable to fetch document. Ensure CORS-compatible HTTPS URL.';
+  }
+};
+
+const onAnalyzeDocument = async () => {
+  const text = dom.documentText.value.trim();
+  if (!text) {
+    dom.documentStatus.textContent = 'Paste text or fetch a document first.';
+    return;
+  }
+  dom.documentStatus.textContent = 'Running disclosure audit via AI…';
+  dom.documentAnalysis.innerHTML = '';
+  try {
+    const result = await callAiAnalyst({
+      mode: 'document',
+      symbol: state.symbol,
+      documentText: text,
+      quote: state.quote,
+      valuations: state.valuations,
+    });
+    dom.documentStatus.textContent = result.warning || '';
+    dom.documentModel.textContent = result.model ? `Model: ${result.model}` : '';
+    renderMarkdownish(dom.documentAnalysis, result.analysis || 'No insights returned.');
+  } catch (error) {
+    console.error('document analysis failed', error);
+    dom.documentStatus.textContent = 'AI module unavailable. Configure OPENAI_API_KEY to enable document intelligence.';
+  }
+};
+
+const init = () => {
+  setActiveTimeframe(state.timeframe);
+  if (dom.timeframeSwitcher) dom.timeframeSwitcher.addEventListener('click', onTimeframeClick);
+  if (dom.symbolForm) dom.symbolForm.addEventListener('submit', onSymbolSubmit);
+  if (dom.aiForm) dom.aiForm.addEventListener('submit', onAiFormSubmit);
+  if (dom.refreshEvents) dom.refreshEvents.addEventListener('click', onRefreshEvents);
+  if (dom.fetchDocumentBtn) dom.fetchDocumentBtn.addEventListener('click', onFetchDocument);
+  if (dom.analyzeDocumentBtn) dom.analyzeDocumentBtn.addEventListener('click', onAnalyzeDocument);
+  loadSymbol(state.symbol, state.timeframe);
+};
+
+init();

--- a/shared/quant.js
+++ b/shared/quant.js
@@ -1,0 +1,232 @@
+const ensureNumber = (value) => {
+  if (value == null || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const toDate = (value) => {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(d.getTime()) ? d : null;
+};
+
+export const sortByDate = (series = [], key = 'date') =>
+  [...series]
+    .filter((row) => row && row[key] != null)
+    .sort((a, b) => {
+      const da = toDate(a[key]);
+      const db = toDate(b[key]);
+      if (!da && !db) return 0;
+      if (!da) return 1;
+      if (!db) return -1;
+      return da - db;
+    });
+
+export const extractValues = (series = [], key = 'close') =>
+  sortByDate(series).map((row) => ensureNumber(row?.[key])).filter((v) => v != null);
+
+export const mean = (values = []) => {
+  if (!values.length) return null;
+  const total = values.reduce((acc, value) => acc + value, 0);
+  return total / values.length;
+};
+
+export const standardDeviation = (values = []) => {
+  if (!values.length) return null;
+  const avg = mean(values);
+  const variance = mean(values.map((value) => (value - avg) ** 2));
+  return variance == null ? null : Math.sqrt(variance);
+};
+
+export const computeReturns = (series = [], valueKey = 'close', mode = 'log') => {
+  const values = extractValues(series, valueKey);
+  if (values.length < 2) return [];
+  const returns = [];
+  for (let i = 1; i < values.length; i += 1) {
+    const prev = values[i - 1];
+    const curr = values[i];
+    if (prev && curr) {
+      const change = curr / prev;
+      returns.push(mode === 'log' ? Math.log(change) : change - 1);
+    }
+  }
+  return returns;
+};
+
+export const annualizeVolatility = (returns = [], periodsPerYear = 252) => {
+  if (!returns.length) return null;
+  const dailyStd = standardDeviation(returns);
+  if (dailyStd == null) return null;
+  return dailyStd * Math.sqrt(periodsPerYear);
+};
+
+export const movingAverage = (values = [], window = 20) => {
+  if (!Array.isArray(values) || window <= 0) return [];
+  const out = [];
+  let sum = 0;
+  for (let i = 0; i < values.length; i += 1) {
+    const value = ensureNumber(values[i]);
+    if (value == null) {
+      out.push(null);
+      continue;
+    }
+    sum += value;
+    if (i >= window) {
+      const drop = ensureNumber(values[i - window]);
+      if (drop != null) sum -= drop;
+    }
+    if (i >= window - 1) {
+      out.push(sum / window);
+    } else {
+      out.push(null);
+    }
+  }
+  return out;
+};
+
+export const exponentialMovingAverage = (values = [], window = 20) => {
+  if (!Array.isArray(values) || !values.length || window <= 0) return [];
+  const k = 2 / (window + 1);
+  const out = [];
+  let ema = ensureNumber(values[0]);
+  out.push(ema);
+  for (let i = 1; i < values.length; i += 1) {
+    const value = ensureNumber(values[i]);
+    if (value == null || ema == null) {
+      out.push(ema);
+      continue;
+    }
+    ema = value * k + ema * (1 - k);
+    out.push(ema);
+  }
+  return out;
+};
+
+export const maxDrawdown = (values = []) => {
+  let peak = -Infinity;
+  let maxDd = 0;
+  values.forEach((value) => {
+    const num = ensureNumber(value);
+    if (num == null) return;
+    if (num > peak) peak = num;
+    const dd = peak > 0 ? (num - peak) / peak : 0;
+    if (dd < maxDd) maxDd = dd;
+  });
+  return maxDd;
+};
+
+export const relativeStrengthIndex = (values = [], period = 14) => {
+  if (!Array.isArray(values) || values.length <= period) return null;
+  let gains = 0;
+  let losses = 0;
+  for (let i = 1; i <= period; i += 1) {
+    const change = ensureNumber(values[i]) - ensureNumber(values[i - 1]);
+    if (!Number.isFinite(change)) continue;
+    if (change >= 0) gains += change; else losses -= change;
+  }
+  let avgGain = gains / period;
+  let avgLoss = losses / period;
+  for (let i = period + 1; i < values.length; i += 1) {
+    const change = ensureNumber(values[i]) - ensureNumber(values[i - 1]);
+    if (!Number.isFinite(change)) continue;
+    const gain = change > 0 ? change : 0;
+    const loss = change < 0 ? -change : 0;
+    avgGain = ((avgGain * (period - 1)) + gain) / period;
+    avgLoss = ((avgLoss * (period - 1)) + loss) / period;
+  }
+  if (avgLoss === 0) return 100;
+  const rs = avgGain / avgLoss;
+  return 100 - 100 / (1 + rs);
+};
+
+export const sharpeRatio = (returns = [], { periodsPerYear = 252, riskFreeRate = 0.02 } = {}) => {
+  if (!returns.length) return null;
+  const avg = mean(returns);
+  const annualReturn = avg * periodsPerYear;
+  const vol = annualizeVolatility(returns, periodsPerYear);
+  if (!vol || vol === 0) return null;
+  return (annualReturn - riskFreeRate) / vol;
+};
+
+export const valueAtRisk = (returns = [], { confidence = 0.95 } = {}) => {
+  if (!returns.length) return null;
+  const sorted = [...returns].sort((a, b) => a - b);
+  const index = Math.floor((1 - confidence) * sorted.length);
+  return sorted[index] ?? null;
+};
+
+export const analyseSeries = (series = [], options = {}) => {
+  const { periodsPerYear = 252, volumeKey = 'volume', priceKey = 'close' } = options;
+  const sorted = sortByDate(series);
+  const closes = sorted.map((row) => ensureNumber(row?.[priceKey])).filter((v) => v != null);
+  if (!closes.length) {
+    return {
+      closes,
+      volatility: null,
+      sharpe: null,
+      drawdown: null,
+      rsi: null,
+      sma20: null,
+      sma50: null,
+      averageVolume: null,
+    };
+  }
+  const returns = computeReturns(sorted, priceKey);
+  const volatility = annualizeVolatility(returns, periodsPerYear);
+  const sharpe = sharpeRatio(returns, { periodsPerYear });
+  const drawdown = maxDrawdown(closes);
+  const rsi = relativeStrengthIndex(closes);
+  const mas = movingAverage(closes, 20);
+  const sma20 = mas.length ? mas[mas.length - 1] : null;
+  const sma50Series = movingAverage(closes, 50);
+  const sma50 = sma50Series.length ? sma50Series[sma50Series.length - 1] : null;
+  const volumes = sorted.map((row) => ensureNumber(row?.[volumeKey])).filter((v) => v != null);
+  const averageVolume = volumes.length ? mean(volumes.slice(-30)) : null;
+  const ema = exponentialMovingAverage(closes, 21);
+  const ema21 = ema.length ? ema[ema.length - 1] : null;
+
+  return {
+    closes,
+    returns,
+    volatility,
+    sharpe,
+    drawdown,
+    rsi,
+    sma20,
+    sma50,
+    ema21,
+    averageVolume,
+  };
+};
+
+export const formatPercent = (value, digits = 2) => {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const pct = value * 100;
+  return `${pct.toFixed(digits)}%`;
+};
+
+export const formatNumber = (value, digits = 2) => {
+  if (value == null || !Number.isFinite(value)) return '—';
+  if (Math.abs(value) >= 1e12) return `${(value / 1e12).toFixed(digits)}T`;
+  if (Math.abs(value) >= 1e9) return `${(value / 1e9).toFixed(digits)}B`;
+  if (Math.abs(value) >= 1e6) return `${(value / 1e6).toFixed(digits)}M`;
+  if (Math.abs(value) >= 1e3) return `${(value / 1e3).toFixed(digits)}K`;
+  return value.toFixed(digits);
+};
+
+export default {
+  analyseSeries,
+  annualizeVolatility,
+  computeReturns,
+  exponentialMovingAverage,
+  formatNumber,
+  formatPercent,
+  maxDrawdown,
+  mean,
+  movingAverage,
+  relativeStrengthIndex,
+  sharpeRatio,
+  sortByDate,
+  standardDeviation,
+  valueAtRisk,
+};

--- a/tests/ai-analyst.test.mjs
+++ b/tests/ai-analyst.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { handler } = await import('../netlify/functions/ai-analyst.js');
+
+const baseEvent = {
+  httpMethod: 'POST',
+  path: '/api/ai-analyst',
+  headers: { 'content-type': 'application/json' },
+};
+
+const withFetch = async (impl, fn) => {
+  const original = global.fetch;
+  global.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+};
+
+const buildBody = (payload) => JSON.stringify({
+  mode: 'screener',
+  symbol: 'AAPL',
+  focus: 'growth',
+  riskTolerance: 'balanced',
+  horizon: 'medium',
+  quote: { price: 180, previousClose: 177, currency: 'USD' },
+  valuations: { blended: { fairValue: 195, confidence: 0.6 } },
+  events: [{ title: 'Earnings beat', impactScore: 4, summary: 'Upside surprise.' }],
+  ...payload,
+});
+
+test('returns fallback analysis when API key missing', async () => {
+  delete process.env.OPENAI_API_KEY;
+  const response = await handler({ ...baseEvent, body: buildBody() });
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body);
+  assert.equal(payload.fallback, true);
+  assert.match(payload.analysis, /AI analysis offline/i);
+});
+
+test('proxies to OpenAI when API key configured', async () => {
+  process.env.OPENAI_API_KEY = 'demo-key';
+  await withFetch(async (input, init) => {
+    const url = typeof input === 'string' ? new URL(input) : new URL(input.url);
+    assert.equal(url.hostname, 'api.openai.com');
+    const body = JSON.parse(init.body);
+    assert.equal(body.messages[1].role, 'user');
+    return new Response(JSON.stringify({
+      model: 'gpt-5.0-preview',
+      choices: [{ message: { content: 'Analysis ready.' } }],
+      usage: { total_tokens: 300 },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }, async () => {
+    const response = await handler({ ...baseEvent, body: buildBody({ universe: 'MSFT, NVDA' }) });
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.equal(payload.analysis, 'Analysis ready.');
+    assert.equal(payload.model, 'gpt-5.0-preview');
+    assert.ok(payload.warning.includes('OPENAI_ANALYST_MODEL'));
+  });
+});

--- a/tests/document-fetch.test.mjs
+++ b/tests/document-fetch.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { handler } = await import('../netlify/functions/document-fetch.js');
+
+const baseEvent = {
+  httpMethod: 'POST',
+  path: '/api/document-fetch',
+  headers: { 'content-type': 'application/json' },
+};
+
+const withFetch = async (impl, fn) => {
+  const original = global.fetch;
+  global.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+};
+
+test('rejects invalid URLs', async () => {
+  const response = await handler({ ...baseEvent, body: JSON.stringify({ url: 'not-a-url' }) });
+  assert.equal(response.statusCode, 400);
+  const payload = JSON.parse(response.body);
+  assert.equal(payload.error, 'invalid_url');
+});
+
+test('fetches and cleans HTML content', async () => {
+  await withFetch(async () => new Response('<html><body><h1>Title</h1><p>Paragraph</p></body></html>', {
+    status: 200,
+    headers: { 'content-type': 'text/html' },
+  }), async () => {
+    const response = await handler({ ...baseEvent, body: JSON.stringify({ url: 'https://example.com/doc' }) });
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.ok(payload.content.includes('Title'));
+    assert.equal(payload.contentType, 'text/html');
+  });
+});
+
+test('warns on PDF documents', async () => {
+  await withFetch(async () => new Response('', {
+    status: 200,
+    headers: { 'content-type': 'application/pdf' },
+  }), async () => {
+    const response = await handler({ ...baseEvent, body: JSON.stringify({ url: 'https://example.com/file.pdf' }) });
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.ok(payload.warning.includes('PDF'));
+    assert.equal(payload.content, '');
+  });
+});

--- a/tests/quant.test.mjs
+++ b/tests/quant.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  analyseSeries,
+  annualizeVolatility,
+  computeReturns,
+  maxDrawdown,
+  movingAverage,
+  relativeStrengthIndex,
+  formatPercent,
+} from '../shared/quant.js';
+
+const buildSeries = () => {
+  const start = new Date('2024-01-02T00:00:00Z').getTime();
+  const points = [];
+  for (let i = 0; i < 60; i += 1) {
+    const date = new Date(start + i * 24 * 60 * 60 * 1000).toISOString();
+    const close = 100 + Math.sin(i / 6) * 4 + i * 0.4;
+    const volume = 1_000_000 + (i % 5) * 50_000;
+    points.push({ date, close, volume });
+  }
+  return points;
+};
+
+test('analyseSeries returns robust technical metrics', () => {
+  const series = buildSeries();
+  const metrics = analyseSeries(series, { periodsPerYear: 252 });
+  assert.ok(metrics.volatility > 0);
+  assert.ok(Number.isFinite(metrics.sharpe));
+  assert.ok(metrics.drawdown < 0);
+  assert.ok(metrics.averageVolume > 0);
+  assert.ok(metrics.sma20 > 0 && metrics.sma50 > 0);
+  assert.ok(metrics.rsi >= 0 && metrics.rsi <= 100);
+});
+
+test('movingAverage aligns with computeReturns and volatility', () => {
+  const series = buildSeries();
+  const closes = series.map((row) => row.close);
+  const ma = movingAverage(closes, 10);
+  assert.equal(ma.length, closes.length);
+  const returns = computeReturns(series);
+  const vol = annualizeVolatility(returns, 252);
+  assert.ok(vol > 0);
+  const dd = maxDrawdown(closes);
+  assert.ok(dd <= 0);
+  const rsi = relativeStrengthIndex(closes, 14);
+  assert.ok(rsi >= 0 && rsi <= 100);
+});
+
+test('formatPercent handles null safely', () => {
+  assert.equal(formatPercent(0.1234, 1), '12.3%');
+  assert.equal(formatPercent(null), '—');
+});

--- a/tests/tiingo-events.test.mjs
+++ b/tests/tiingo-events.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { handler } = await import('../netlify/functions/tiingo-events.js');
+
+const withFetch = async (impl, fn) => {
+  const original = global.fetch;
+  global.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+};
+
+const sampleArticles = [
+  {
+    id: '1',
+    title: 'Company beats earnings expectations',
+    publishedDate: '2024-04-30T10:00:00Z',
+    tags: ['earnings'],
+    description: 'Revenue and EPS exceeded consensus. Management raised guidance.',
+    sentimentScore: 0.4,
+    url: 'https://example.com/earnings',
+    source: 'Reuters',
+  },
+  {
+    id: '2',
+    title: 'Regulators open antitrust inquiry',
+    publishedDate: '2024-04-28T12:00:00Z',
+    tags: ['regulation'],
+    description: 'Authorities are looking into platform billing practices.',
+    sentimentScore: -0.3,
+    url: 'https://example.com/reg',
+    source: 'Bloomberg',
+  },
+];
+
+test('classifies events when Tiingo news available', async () => {
+  process.env.TIINGO_KEY = 'demo-token';
+  await withFetch(async (input) => {
+    const url = new URL(input);
+    if (url.pathname === '/tiingo/news') {
+      return new Response(JSON.stringify(sampleArticles), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error(`Unexpected fetch ${url}`);
+  }, async () => {
+    const event = { rawQuery: 'symbol=AAPL&limit=2', httpMethod: 'GET', path: '/api/tiingo-events', headers: {} };
+    const response = await handler(event);
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.equal(payload.events.length, 2);
+    assert.equal(payload.events[0].type, 'Earnings');
+    assert.equal(payload.events[1].type, 'Regulatory');
+  });
+});
+
+test('falls back to curated events when token missing', async () => {
+  delete process.env.TIINGO_KEY;
+  const response = await handler({ rawQuery: 'symbol=AAPL&limit=2', httpMethod: 'GET', path: '/api/tiingo-events', headers: {} });
+  const payload = JSON.parse(response.body);
+  assert.equal(payload.fallback, true);
+  assert.ok(payload.events.length > 0);
+  assert.ok(payload.warning);
+});

--- a/tests/tiingo-fundamentals.test.mjs
+++ b/tests/tiingo-fundamentals.test.mjs
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { handler } = await import('../netlify/functions/tiingo-fundamentals.js');
+
+const withFetch = async (impl, fn) => {
+  const original = global.fetch;
+  global.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+};
+
+const sampleRows = [
+  {
+    date: '2021-09-25',
+    revenue: 3.47e11,
+    netIncome: 9.46e10,
+    freeCashFlow: 9.3e10,
+    sharesOutstanding: 16.5e9,
+    marketCap: 2.4e12,
+    totalDebt: 1.1e11,
+    cashAndCashEquivalents: 6.2e10,
+    shareholderEquity: 6.3e10,
+    eps: 5.11,
+    peRatio: 22,
+    psRatio: 6,
+    pbRatio: 8,
+    dividendYield: 0.005,
+    returnOnEquity: 0.35,
+    returnOnInvestedCapital: 0.28,
+    costOfCapital: 0.085,
+  },
+  {
+    date: '2022-09-24',
+    revenue: 3.95e11,
+    netIncome: 9.99e10,
+    freeCashFlow: 9.8e10,
+    sharesOutstanding: 16.1e9,
+    marketCap: 2.5e12,
+    totalDebt: 1.1e11,
+    cashAndCashEquivalents: 5.6e10,
+    shareholderEquity: 6.5e10,
+    eps: 5.89,
+    peRatio: 23,
+    psRatio: 6.2,
+    pbRatio: 8.2,
+    dividendYield: 0.005,
+    returnOnEquity: 0.34,
+    returnOnInvestedCapital: 0.29,
+    costOfCapital: 0.085,
+  },
+  {
+    date: '2023-09-30',
+    revenue: 3.83e11,
+    netIncome: 9.65e10,
+    freeCashFlow: 9.7e10,
+    sharesOutstanding: 15.7e9,
+    marketCap: 2.7e12,
+    totalDebt: 1.07e11,
+    cashAndCashEquivalents: 5.3e10,
+    shareholderEquity: 6.8e10,
+    eps: 6.11,
+    peRatio: 27,
+    psRatio: 7,
+    pbRatio: 9,
+    dividendYield: 0.005,
+    returnOnEquity: 0.32,
+    returnOnInvestedCapital: 0.3,
+    wacc: 0.082,
+  },
+  {
+    date: '2024-03-30',
+    revenue: 3.9e11,
+    netIncome: 9.7e10,
+    freeCashFlow: 9.9e10,
+    sharesOutstanding: 15.6e9,
+    marketCap: 3.0e12,
+    totalDebt: 1.05e11,
+    cashAndCashEquivalents: 5.5e10,
+    shareholderEquity: 7.1e10,
+    eps: 6.25,
+    peRatio: 28,
+    psRatio: 7.2,
+    pbRatio: 9.2,
+    dividendYield: 0.0051,
+    returnOnEquity: 0.31,
+    returnOnInvestedCapital: 0.3,
+    wacc: 0.082,
+  },
+];
+
+test('computes valuations and quality metrics when Tiingo responds', async () => {
+  process.env.TIINGO_KEY = 'demo-token';
+  await withFetch(async (input) => {
+    const url = new URL(input);
+    if (url.pathname.includes('/tiingo/fundamentals')) {
+      return new Response(JSON.stringify(sampleRows), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error(`Unexpected fetch ${url}`);
+  }, async () => {
+    const event = { rawQuery: 'symbol=AAPL', httpMethod: 'GET', path: '/api/tiingo-fundamentals', headers: {} };
+    const response = await handler(event);
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.equal(payload.fallback, false);
+    assert.ok(payload.valuations?.dcf?.fairValue > 0);
+    assert.ok(payload.valuations?.blended?.qualityScore > 0);
+    assert.ok(Array.isArray(payload.table) && payload.table.length >= 3);
+  });
+});
+
+test('falls back to illustrative sample when token missing', async () => {
+  delete process.env.TIINGO_KEY;
+  const response = await handler({ rawQuery: 'symbol=MSFT', httpMethod: 'GET', path: '/api/tiingo-fundamentals', headers: {} });
+  const payload = JSON.parse(response.body);
+  assert.equal(payload.fallback, true);
+  assert.ok(payload.warning);
+  assert.equal(payload.symbol, 'MSFT');
+});

--- a/tests/tiingo-handler.test.mjs
+++ b/tests/tiingo-handler.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { handler } = await import('../netlify/functions/tiingo.js');
+
+const withStubbedFetch = async (impl, fn) => {
+  const original = global.fetch;
+  global.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+};
+
+test('intraday series returns ordered candles when Tiingo token present', async () => {
+  process.env.TIINGO_KEY = 'demo-token';
+  const mockSeries = [
+    { date: '2024-05-01T14:00:00Z', close: 180.1, open: 179.6 },
+    { date: '2024-05-01T14:05:00Z', close: 180.5, open: 180.1 },
+    { date: '2024-05-01T14:10:00Z', close: 181.0, open: 180.5 },
+  ];
+  await withStubbedFetch(async (input) => {
+    const url = new URL(input);
+    if (url.pathname.includes('/iex/AAPL/prices')) {
+      return new Response(JSON.stringify(mockSeries), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error(`Unexpected fetch ${url}`);
+  }, async () => {
+    const event = { rawQuery: 'symbol=AAPL&kind=intraday&interval=5min&limit=3', httpMethod: 'GET', path: '/api/tiingo', headers: {} };
+    const response = await handler(event);
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.equal(payload.data.length, 3);
+    const times = payload.data.map((row) => new Date(row.date).getTime());
+    assert.ok(times[0] < times[1] && times[1] < times[2]);
+  });
+});
+
+test('intraday_latest falls back to EOD when realtime feed fails', async () => {
+  process.env.TIINGO_KEY = 'demo-token';
+  await withStubbedFetch(async (input) => {
+    const url = new URL(input);
+    if (url.pathname === '/iex') {
+      return new Response('error', { status: 500 });
+    }
+    if (url.pathname.includes('/tiingo/daily')) {
+      const eod = [
+        { date: '2024-04-29', close: 175.2, open: 174.8 },
+        { date: '2024-04-30', close: 176.4, open: 175.0 },
+      ];
+      return new Response(JSON.stringify(eod), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error(`Unexpected fetch ${url}`);
+  }, async () => {
+    const event = { rawQuery: 'symbol=AAPL&kind=intraday_latest', httpMethod: 'GET', path: '/api/tiingo', headers: {} };
+    const response = await handler(event);
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.equal(payload.data.length, 1);
+    assert.ok(payload.warning);
+    assert.equal(payload.data[0].close, 176.4);
+  });
+});
+
+test('returns mock data when Tiingo token missing', async () => {
+  delete process.env.TIINGO_KEY;
+  await withStubbedFetch(async () => {
+    throw new Error('fetch should not be called without token');
+  }, async () => {
+    const event = { rawQuery: 'symbol=AAPL&kind=eod&limit=5', httpMethod: 'GET', path: '/api/tiingo', headers: {} };
+    const response = await handler(event);
+    assert.equal(response.statusCode, 200);
+    const payload = JSON.parse(response.body);
+    assert.ok(Array.isArray(payload.data));
+    assert.ok(payload.warning);
+  });
+});


### PR DESCRIPTION
## Summary
- add a standalone pro trading desk interface with AI screening, event intelligence, document review, and valuation workflows
- add Netlify functions for GPT analyst responses, Tiingo fundamentals/events, and secure document ingestion to power the new workflows
- introduce shared quantitative helpers and comprehensive Node tests to validate Tiingo data normalization and fallbacks

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d383ff43888329a870dfa0f26423e6