### PR TITLE
Add professional trading desk pages with AI research support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Good Hope Markets — Professional Desk Extensions
+
+This repository now includes a set of advanced standalone pages and Netlify Functions that extend the original Trading Desk experience without modifying the primary `index.html` workspace.
+
+## New Professional Workspaces
+
+| Page | Purpose |
+| --- | --- |
+| `professional-desk.html` | Real-time multi-panel trading desk featuring intelligent search, charting controls, automated insights, event radar, risk metrics, and ChatGPT 5 valuation integration. |
+| `valuation-lab.html` | Dedicated AI valuation lab that focuses on fair value discovery, scenario planning, and document review for equity research deep dives. |
+
+Both pages load the new `professional-desk.js` module and `professional-desk.css` stylesheet while leaving the existing site untouched.
+
+## Serverless Intelligence
+
+Two Netlify Functions support the new experience:
+
+* `netlify/functions/research.js` aggregates Tiingo pricing, news, and filings into a structured research payload with synthetic fallbacks when live data is unavailable.
+* `netlify/functions/intelligence.js` powers the ChatGPT 5 valuation engine with deterministic heuristics when an `OPENAI_API_KEY` is not configured.
+
+## Quality Safeguards
+
+Comprehensive Node-based tests can be executed via:
+
+```bash
+npm test
+```
+
+The suite verifies Tiingo integration fallbacks, research aggregation, and AI response handling to ensure consistent chart data and valuation output across intraday and end-of-day timeframes.
+
+## Building / Deploying
+
+The build script has been updated to copy both new HTML workspaces, supporting assets, and Netlify functions into the final Netlify bundle:
+
+```bash
+npm run build
+```
+
+Deploying via Netlify CLI continues to work without additional configuration.

--- a/netlify/functions/intelligence.js
+++ b/netlify/functions/intelligence.js
@@ -1,0 +1,307 @@
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+const CHATGPT5_MODEL = process.env.CHATGPT5_MODEL || DEFAULT_MODEL;
+
+const MODEL_ALIASES = {
+  'chatgpt-5': CHATGPT5_MODEL,
+  'gpt-5': CHATGPT5_MODEL,
+  'gpt5': CHATGPT5_MODEL,
+};
+
+const safeNumber = (value, fallback = null) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+const clamp = (value, min, max) => {
+  const num = safeNumber(value, null);
+  if (num == null) return null;
+  return Math.min(Math.max(num, min), max);
+};
+
+const percent = (value) => (value != null ? `${value > 0 ? '+' : ''}${value.toFixed(2)}%` : '—');
+
+function resolveModel(requested) {
+  if (!requested) return CHATGPT5_MODEL;
+  const key = String(requested).trim().toLowerCase();
+  if (MODEL_ALIASES[key]) return MODEL_ALIASES[key];
+  return requested;
+}
+
+function summariseEvents(events = []) {
+  if (!events.length) return '';
+  const highlights = events.slice(0, 2).map((event) => `${event.title || 'Catalyst'} (${new Date(event.publishedAt || event.date || Date.now()).toLocaleDateString()})`);
+  return highlights.join('; ');
+}
+
+function normalisePeerSignals(list, currency) {
+  if (!Array.isArray(list)) return [];
+  return list.slice(0, 6).map((item, idx) => ({
+    name: item.name || item.symbol || `Peer ${idx + 1}`,
+    profile: item.profile || '',
+    fairValue: safeNumber(item.fairValue, null),
+    expectedReturn: safeNumber(item.expectedReturn, null),
+    notes: item.notes || '',
+    currency: item.currency || currency,
+  }));
+}
+
+function buildHeuristicValuation(payload) {
+  const symbol = String(payload.symbol || 'AAPL').toUpperCase();
+  const metrics = payload.metrics || {};
+  const snapshots = payload.snapshots || {};
+  const events = Array.isArray(payload.events) ? payload.events : [];
+  const comparables = normalisePeerSignals(payload.comparables || [], metrics.currency || 'USD');
+  const currency = metrics.currency || 'USD';
+  const currentPrice = safeNumber(metrics.currentPrice, safeNumber(metrics.previousClose, 100));
+  const rangeHigh = safeNumber(metrics.fiftyTwoWeekHigh, currentPrice * 1.18);
+  const rangeLow = safeNumber(metrics.fiftyTwoWeekLow, currentPrice * 0.82);
+  const fairValueEstimate = safeNumber(metrics.fairValueEstimate, (rangeHigh + rangeLow + currentPrice) / 3);
+  const fairValue = {
+    base: fairValueEstimate != null ? Number(fairValueEstimate.toFixed(2)) : currentPrice,
+    rangeHigh: rangeHigh != null ? Number((rangeHigh * 1.02).toFixed(2)) : null,
+    rangeLow: rangeLow != null ? Number((rangeLow * 0.98).toFixed(2)) : null,
+    currency,
+  };
+  const upside = currentPrice && fairValue.rangeHigh ? ((fairValue.rangeHigh - currentPrice) / currentPrice) * 100 : null;
+  const downside = currentPrice && fairValue.rangeLow ? ((fairValue.rangeLow - currentPrice) / currentPrice) * 100 : null;
+  const momentum = safeNumber(snapshots?.['3M']?.returnPct, null);
+  const riskLabel = metrics.riskLabel || 'Moderate';
+  const conviction = metrics.conviction || (momentum != null && momentum > 4 && riskLabel !== 'High' ? 'Constructive' : 'Neutral');
+  const summaryParts = [
+    `${symbol} trades near ${currency} ${currentPrice?.toFixed(2) ?? '—'} with ${riskLabel.toLowerCase()} risk conditions.`,
+  ];
+  if (fairValue.base != null && currentPrice != null) {
+    const implied = ((fairValue.base - currentPrice) / currentPrice) * 100;
+    summaryParts.push(`Deterministic fair value: ${currency} ${fairValue.base.toFixed(2)} (${percent(implied)} vs. spot).`);
+  }
+  const eventSummary = summariseEvents(events);
+  if (eventSummary) summaryParts.push(`Key catalysts: ${eventSummary}.`);
+  const drivers = [];
+  if (momentum != null) {
+    drivers.push(momentum > 0 ? `Positive ${snapshots['3M'].label || '3M'} momentum at ${percent(momentum)}.` : `Negative medium-term momentum at ${percent(momentum)}.`);
+  }
+  if (metrics.averageVolume) drivers.push(`Liquidity remains robust with average volume ${metrics.averageVolume.toLocaleString()}.`);
+  if (metrics.expectedReturn?.upside != null) drivers.push(`Heuristic upside to fair value: ${percent(metrics.expectedReturn.upside)}.`);
+  const risks = [];
+  if (riskLabel === 'High') risks.push('Elevated volatility profile warrants staggered sizing.');
+  if (metrics.expectedReturn?.downside != null) risks.push(`Downside to stress level: ${percent(metrics.expectedReturn.downside)}.`);
+  if (!risks.length) risks.push('Monitor macro sensitivity and execution of roadmap.');
+  const scenario = (label, probability, target) => ({
+    label,
+    probability,
+    price: target != null ? Number(target.toFixed(2)) : null,
+    returnPct: currentPrice && target != null ? Number((((target - currentPrice) / currentPrice) * 100).toFixed(2)) : null,
+    commentary: label === 'Bull'
+      ? 'Assumes continued share gains and AI monetisation driving multiple expansion.'
+      : label === 'Bear'
+        ? 'Models macro slowdown with valuation compressing toward structural support.'
+        : 'Reverts to blended intrinsic value with stable execution.',
+  });
+  const scenarios = payload.scenarios && payload.scenarios.length
+    ? payload.scenarios
+    : [
+      scenario('Bull', 0.35, fairValue.rangeHigh ?? fairValue.base * 1.1),
+      scenario('Base', 0.4, fairValue.base),
+      scenario('Bear', 0.25, fairValue.rangeLow ?? fairValue.base * 0.9),
+    ];
+  return {
+    symbol,
+    model: {
+      requested: payload.model || 'heuristic',
+      resolved: 'heuristic-v1',
+      provider: 'heuristic',
+    },
+    generatedAt: new Date().toISOString(),
+    summary: summaryParts.join(' '),
+    fairValue,
+    expectedReturn: {
+      upside: upside != null ? Number(upside.toFixed(2)) : null,
+      downside: downside != null ? Number(downside.toFixed(2)) : null,
+    },
+    conviction,
+    drivers,
+    risks,
+    scenarios,
+    recommendation: {
+      text: fairValue.base != null && currentPrice
+        ? fairValue.base > currentPrice
+          ? 'Bias to accumulate on weakness with sizing framed by VaR constraints.'
+          : 'Hold / trim rallies as price exceeds deterministic fair value.'
+        : 'Maintain neutral stance pending additional price confirmation.',
+    },
+    note: 'Generated via deterministic heuristic because ChatGPT 5 access was unavailable.',
+    peerSignals: comparables,
+  };
+}
+
+async function callOpenAi(payload, resolvedModel) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY missing');
+  const systemPrompt = 'You are ChatGPT 5, an institutional equity research analyst. Respond ONLY with strict JSON matching the provided schema.';
+  const schema = {
+    type: 'object',
+    properties: {
+      summary: { type: 'string' },
+      fairValue: {
+        type: 'object',
+        properties: {
+          base: { type: 'number' },
+          rangeHigh: { type: 'number' },
+          rangeLow: { type: 'number' },
+          currency: { type: 'string' },
+        },
+        required: ['base'],
+      },
+      expectedReturn: {
+        type: 'object',
+        properties: {
+          upside: { type: 'number' },
+          downside: { type: 'number' },
+        },
+      },
+      conviction: { type: 'string' },
+      drivers: { type: 'array', items: { type: 'string' } },
+      risks: { type: 'array', items: { type: 'string' } },
+      scenarios: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            label: { type: 'string' },
+            probability: { type: 'number' },
+            price: { type: 'number' },
+            returnPct: { type: 'number' },
+            commentary: { type: 'string' },
+          },
+        },
+      },
+      recommendation: {
+        type: 'object',
+        properties: {
+          text: { type: 'string' },
+        },
+      },
+      note: { type: 'string' },
+      peerSignals: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            profile: { type: 'string' },
+            fairValue: { type: 'number' },
+            expectedReturn: { type: 'number' },
+            notes: { type: 'string' },
+          },
+        },
+      },
+    },
+    required: ['summary', 'fairValue', 'drivers', 'risks'],
+  };
+  const prompt = `Symbol: ${payload.symbol}\nMetrics: ${JSON.stringify(payload.metrics)}\nSnapshots: ${JSON.stringify(payload.snapshots)}\nEvents: ${JSON.stringify((payload.events || []).slice(0, 6))}\nFilings: ${JSON.stringify((payload.filings || []).slice(0, 6))}\nInsights: ${JSON.stringify((payload.insights || []).slice(0, 6))}\nLevels: ${JSON.stringify(payload.levels || {})}\nRisk: ${JSON.stringify(payload.riskMetrics || {})}\nPeer set: ${JSON.stringify(payload.comparables || [])}\nReturn a JSON object following the schema.`;
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: resolvedModel,
+      temperature: 0.35,
+      response_format: { type: 'json_schema', json_schema: { name: 'valuation_schema', schema } },
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+    }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`OpenAI ${response.status}: ${text.slice(0, 200)}`);
+  }
+  let parsed = null;
+  if (text) {
+    try {
+      const data = JSON.parse(text);
+      const content = data?.choices?.[0]?.message?.content || '';
+      const cleaned = content.trim().replace(/^```json\s*/i, '').replace(/```$/i, '');
+      parsed = JSON.parse(cleaned || content);
+    } catch (error) {
+      console.warn('Failed to parse OpenAI response', error, text.slice(0, 200));
+      throw new Error('ChatGPT response parsing failed');
+    }
+  }
+  return parsed;
+}
+
+function mergeAiWithHeuristic(aiRaw, heuristic, requestedModel, resolvedModel) {
+  if (!aiRaw || typeof aiRaw !== 'object') return heuristic;
+  const currency = heuristic?.fairValue?.currency || aiRaw?.fairValue?.currency || 'USD';
+  const fairValue = {
+    base: safeNumber(aiRaw?.fairValue?.base, heuristic?.fairValue?.base),
+    rangeHigh: safeNumber(aiRaw?.fairValue?.rangeHigh, heuristic?.fairValue?.rangeHigh),
+    rangeLow: safeNumber(aiRaw?.fairValue?.rangeLow, heuristic?.fairValue?.rangeLow),
+    currency,
+  };
+  const expectedReturn = {
+    upside: safeNumber(aiRaw?.expectedReturn?.upside, heuristic?.expectedReturn?.upside),
+    downside: safeNumber(aiRaw?.expectedReturn?.downside, heuristic?.expectedReturn?.downside),
+  };
+  return {
+    symbol: heuristic.symbol,
+    model: {
+      requested: requestedModel,
+      resolved: resolvedModel,
+      provider: 'openai',
+    },
+    generatedAt: new Date().toISOString(),
+    summary: aiRaw.summary || heuristic.summary,
+    fairValue,
+    expectedReturn,
+    conviction: aiRaw.conviction || heuristic.conviction,
+    drivers: Array.isArray(aiRaw.drivers) && aiRaw.drivers.length ? aiRaw.drivers : heuristic.drivers,
+    risks: Array.isArray(aiRaw.risks) && aiRaw.risks.length ? aiRaw.risks : heuristic.risks,
+    scenarios: Array.isArray(aiRaw.scenarios) && aiRaw.scenarios.length ? aiRaw.scenarios : heuristic.scenarios,
+    recommendation: aiRaw.recommendation || heuristic.recommendation,
+    note: aiRaw.note || '',
+    peerSignals: normalisePeerSignals(aiRaw.peerSignals || aiRaw.peerSet, currency).length
+      ? normalisePeerSignals(aiRaw.peerSignals || aiRaw.peerSet, currency)
+      : heuristic.peerSignals,
+  };
+}
+
+export default async function handler(request) {
+  if (request.method && request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+  let payload = {};
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return new Response('Invalid JSON body', { status: 400, headers: corsHeaders });
+  }
+  const symbol = String(payload.symbol || 'AAPL').toUpperCase();
+  const requestedModel = payload.model || 'chatgpt-5';
+  const resolvedModel = resolveModel(requestedModel) || DEFAULT_MODEL;
+  const heuristic = buildHeuristicValuation({ ...payload, symbol, model: requestedModel });
+
+  if (!process.env.OPENAI_API_KEY) {
+    heuristic.note = 'OpenAI API key missing; reverting to heuristic equity intelligence.';
+    return Response.json(heuristic, { headers: corsHeaders });
+  }
+
+  try {
+    const aiRaw = await callOpenAi({ ...payload, symbol, model: requestedModel }, resolvedModel);
+    const merged = mergeAiWithHeuristic(aiRaw, heuristic, requestedModel, resolvedModel);
+    return Response.json(merged, { headers: corsHeaders });
+  } catch (error) {
+    console.error('intelligence function error', error);
+    heuristic.warning = `ChatGPT valuation unavailable: ${error.message || error}`;
+    return Response.json(heuristic, {
+      headers: { ...corsHeaders, 'x-ai-fallback': 'heuristic' },
+    });
+  }
+}
+
+export { handler };

--- a/netlify/functions/research.js
+++ b/netlify/functions/research.js
@@ -1,0 +1,572 @@
+import { getTiingoToken } from './lib/env.js';
+import {
+  resolveSymbolRequests,
+  loadEod,
+  loadIntradayLatest,
+  generateMockSeries,
+  inferCurrency,
+  fetchTiingo,
+} from './tiingo.js';
+
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+
+const SNAPSHOT_WINDOWS = {
+  '1D': { label: '1 Day', lookback: 2 },
+  '1W': { label: '1 Week', lookback: 6 },
+  '1M': { label: '1 Month', lookback: 22 },
+  '3M': { label: '3 Months', lookback: 66 },
+  '6M': { label: '6 Months', lookback: 132 },
+  '1Y': { label: '1 Year', lookback: 252 },
+  '2Y': { label: '2 Years', lookback: 504 },
+};
+
+const FALLBACK_EVENTS = [
+  {
+    id: 'mock-earnings',
+    title: 'Quarterly earnings beat consensus expectations',
+    summary: 'Company reported resilient demand and margin expansion while reaffirming FY guidance.',
+    url: '#',
+    publishedAt: daysAgoIso(3),
+    tags: ['Earnings', 'Guidance'],
+  },
+  {
+    id: 'mock-dividend',
+    title: 'Board approves strategic dividend increase',
+    summary: 'Dividend lifted by 10% reflecting confidence in recurring cash flows and balance sheet strength.',
+    url: '#',
+    publishedAt: daysAgoIso(12),
+    tags: ['Dividend'],
+  },
+  {
+    id: 'mock-product',
+    title: 'Flagship product refresh highlights AI roadmap',
+    summary: 'Management highlighted accelerated integration of AI assistants across the product portfolio.',
+    url: '#',
+    publishedAt: daysAgoIso(18),
+    tags: ['Product', 'AI'],
+  },
+];
+
+const FALLBACK_FILINGS = [
+  {
+    id: 'mock-10q',
+    formType: '10-Q',
+    filedAt: daysAgoIso(25),
+    description: 'Quarterly report detailing revenue growth of 11% and improving free cash flow.',
+    url: '#',
+  },
+  {
+    id: 'mock-8k',
+    formType: '8-K',
+    filedAt: daysAgoIso(14),
+    description: 'Press release announcing a $5B accelerated share repurchase programme.',
+    url: '#',
+  },
+  {
+    id: 'mock-proxy',
+    formType: 'DEF 14A',
+    filedAt: daysAgoIso(40),
+    description: 'Proxy statement summarising governance updates and board refresh.',
+    url: '#',
+  },
+];
+
+function daysAgoIso(days) {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
+const safeNumber = (value, fallback = null) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+const sortByDate = (a, b) => {
+  const da = new Date(a?.date || a?.publishedAt || 0).getTime();
+  const db = new Date(b?.date || b?.publishedAt || 0).getTime();
+  return da - db;
+};
+
+const roundTo = (value, digits = 2) => {
+  if (!Number.isFinite(value)) return null;
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+};
+
+function computeSnapshots(series) {
+  const ordered = [...series].filter((row) => row && row.date).sort(sortByDate);
+  if (!ordered.length) return {};
+  const latest = ordered[ordered.length - 1];
+  const endPrice = safeNumber(latest.close ?? latest.price ?? latest.last, null);
+  const out = {};
+  Object.entries(SNAPSHOT_WINDOWS).forEach(([key, cfg]) => {
+    const lookback = Math.max(Number(cfg.lookback) || 1, 1);
+    const startIndex = Math.max(ordered.length - lookback, 1) - 1;
+    const startRow = ordered[startIndex] || ordered[0];
+    const startPrice = safeNumber(startRow.close ?? startRow.price ?? startRow.last, endPrice);
+    const returnPct = startPrice && endPrice ? ((endPrice - startPrice) / startPrice) * 100 : null;
+    const annualised = returnPct != null && lookback > 0 ? (returnPct / lookback) * 252 : null;
+    out[key] = {
+      label: cfg.label,
+      startDate: startRow.date,
+      endDate: latest.date,
+      startPrice,
+      endPrice,
+      returnPct: returnPct != null ? roundTo(returnPct, 2) : null,
+      annualizedReturn: annualised != null ? roundTo(annualised, 2) : null,
+    };
+  });
+  return out;
+}
+
+function computeAverageVolume(series, span = 20) {
+  const sliced = series.slice(-Math.max(span, 1));
+  const volumes = sliced.map((row) => safeNumber(row.volume, null)).filter((value) => value != null);
+  if (!volumes.length) return null;
+  const sum = volumes.reduce((acc, value) => acc + value, 0);
+  return Math.round(sum / volumes.length);
+}
+
+function computeVolatility(series) {
+  const closes = series.map((row) => safeNumber(row.close ?? row.price ?? row.last, null)).filter((value) => value != null);
+  if (closes.length < 3) return null;
+  const returns = [];
+  for (let i = 1; i < closes.length; i += 1) {
+    const prev = closes[i - 1];
+    const curr = closes[i];
+    if (prev && curr) returns.push(Math.log(curr / prev));
+  }
+  if (!returns.length) return null;
+  const mean = returns.reduce((acc, value) => acc + value, 0) / returns.length;
+  const variance = returns.reduce((acc, value) => acc + (value - mean) ** 2, 0) / returns.length;
+  const dailyVol = Math.sqrt(Math.max(variance, 0));
+  return dailyVol * Math.sqrt(252);
+}
+
+function computeMomentum(series, window = 20) {
+  const closes = series.map((row) => safeNumber(row.close ?? row.price ?? row.last, null)).filter((value) => value != null);
+  if (closes.length < window + 1) return null;
+  const recent = closes[closes.length - 1];
+  const past = closes[closes.length - 1 - window];
+  if (!recent || !past) return null;
+  return ((recent - past) / past) * 100;
+}
+
+function computeAtr(series, period = 14) {
+  if (series.length < 2) return null;
+  const trueRanges = [];
+  for (let i = 1; i < series.length; i += 1) {
+    const today = series[i];
+    const prev = series[i - 1];
+    const high = safeNumber(today.high ?? today.close, null);
+    const low = safeNumber(today.low ?? today.close, null);
+    const prevClose = safeNumber(prev.close ?? prev.last, null);
+    if (high == null || low == null || prevClose == null) continue;
+    const tr = Math.max(high - low, Math.abs(high - prevClose), Math.abs(low - prevClose));
+    if (Number.isFinite(tr)) trueRanges.push(tr);
+  }
+  if (!trueRanges.length) return null;
+  const recent = trueRanges.slice(-Math.max(period, 1));
+  const sum = recent.reduce((acc, value) => acc + value, 0);
+  return sum / recent.length;
+}
+
+function evaluateRisk(volatility, momentum) {
+  if (volatility == null) return { score: '—', label: 'Unavailable', conviction: 'Neutral' };
+  const volScore = Math.min(100, Math.max(0, volatility * 100));
+  const momentumScore = momentum != null ? Math.max(-50, Math.min(50, momentum / 2)) : 0;
+  const composite = Math.max(0, Math.min(100, volScore - momentumScore));
+  const label = composite > 70 ? 'High' : composite > 45 ? 'Elevated' : composite > 25 ? 'Moderate' : 'Low';
+  const conviction = momentum != null && momentum > 5 && composite < 60 ? 'Positive' : momentum != null && momentum < -5 ? 'Cautious' : 'Neutral';
+  return { score: roundTo(composite, 1), label, conviction };
+}
+
+function computeLevels(series) {
+  if (!series.length) return {};
+  const recent = series.slice(-30);
+  const closes = recent.map((row) => safeNumber(row.close ?? row.price ?? row.last, null)).filter((value) => value != null);
+  if (!closes.length) return {};
+  const highs = recent.map((row) => safeNumber(row.high ?? row.close, null)).filter((value) => value != null);
+  const lows = recent.map((row) => safeNumber(row.low ?? row.close, null)).filter((value) => value != null);
+  const lastClose = closes[closes.length - 1];
+  const immediateResistance = highs.length ? Math.max(...highs.slice(-10)) : null;
+  const immediateSupport = lows.length ? Math.min(...lows.slice(-10)) : null;
+  const majorResistance = highs.length ? Math.max(...highs) : null;
+  const majorSupport = lows.length ? Math.min(...lows) : null;
+  const pivot = lastClose && immediateResistance && immediateSupport
+    ? (immediateResistance + immediateSupport + lastClose) / 3
+    : lastClose;
+  return {
+    immediateSupport: immediateSupport != null ? roundTo(immediateSupport, 2) : null,
+    immediateResistance: immediateResistance != null ? roundTo(immediateResistance, 2) : null,
+    majorSupport: majorSupport != null ? roundTo(majorSupport, 2) : null,
+    majorResistance: majorResistance != null ? roundTo(majorResistance, 2) : null,
+    pivot: pivot != null ? roundTo(pivot, 2) : null,
+  };
+}
+
+function buildScenarios(metrics) {
+  const price = safeNumber(metrics.currentPrice, null);
+  if (!price) return [];
+  const high = safeNumber(metrics.fiftyTwoWeekHigh, price * 1.15);
+  const low = safeNumber(metrics.fiftyTwoWeekLow, price * 0.85);
+  const fairValue = safeNumber(metrics.fairValueEstimate, (high + low + price) / 3);
+  const dailyVol = safeNumber(metrics.volatilityAnnualized, 0.35) / Math.sqrt(252);
+  const bullPrice = roundTo(Math.min(high * 1.02, price * (1 + dailyVol * 8)), 2);
+  const basePrice = roundTo(fairValue, 2);
+  const bearPrice = roundTo(Math.max(low * 0.95, price * (1 - dailyVol * 6)), 2);
+  const computeReturn = (target) => (target && price ? roundTo(((target - price) / price) * 100, 2) : null);
+  return [
+    {
+      label: 'Bull',
+      probability: 0.35,
+      price: bullPrice,
+      returnPct: computeReturn(bullPrice),
+      commentary: 'Upside case assumes AI-driven demand and margin expansion sustain multiple premium.',
+    },
+    {
+      label: 'Base',
+      probability: 0.4,
+      price: basePrice,
+      returnPct: computeReturn(basePrice),
+      commentary: 'Base case reflects reversion toward blended intrinsic value and seasonal trends.',
+    },
+    {
+      label: 'Bear',
+      probability: 0.25,
+      price: bearPrice,
+      returnPct: computeReturn(bearPrice),
+      commentary: 'Downside case stresses macro slowdown and valuation compression toward long-term support.',
+    },
+  ];
+}
+
+function buildComparables(symbol, metrics, snapshots) {
+  const price = safeNumber(metrics.currentPrice, null);
+  const high = safeNumber(metrics.fiftyTwoWeekHigh, null);
+  const low = safeNumber(metrics.fiftyTwoWeekLow, null);
+  const peerBase = price && high && low ? (high + low + price) / 3 : price || 100;
+  const momentum = snapshots?.['3M']?.returnPct ?? 0;
+  const qualityNote = momentum > 5 ? 'Growth bias with improving momentum.' : momentum < -5 ? 'Defensive tilt amid slowing momentum.' : 'Balanced factor exposure with neutral momentum.';
+  return [
+    {
+      name: `${symbol} Strategic Peer`,
+      profile: 'Large-cap quality',
+      fairValue: roundTo(peerBase * 1.05, 2),
+      expectedReturn: roundTo((high && price) ? ((high - price) / price) * 100 : momentum / 2, 2),
+      notes: qualityNote,
+    },
+    {
+      name: `${symbol} Efficiency Cohort`,
+      profile: 'Operational excellence',
+      fairValue: roundTo(peerBase, 2),
+      expectedReturn: roundTo(snapshots?.['6M']?.returnPct ?? 6, 2),
+      notes: 'Peer basket emphasises free cash flow and cost discipline.',
+    },
+    {
+      name: `${symbol} AI Beneficiary`,
+      profile: 'AI & automation leverage',
+      fairValue: roundTo(peerBase * 1.12, 2),
+      expectedReturn: roundTo((snapshots?.['1Y']?.returnPct ?? 10) + 4, 2),
+      notes: 'Captures optionality from AI enablement and platform scale.',
+    },
+  ];
+}
+
+function buildInsights(metrics, snapshots, events) {
+  const insights = [];
+  if (snapshots?.['1M']?.returnPct != null) {
+    const monthly = snapshots['1M'].returnPct;
+    if (monthly > 4) insights.push('Momentum is accelerating over the past month with a gain above 4%.');
+    else if (monthly < -4) insights.push('One-month momentum is soft, highlighting a potential pullback opportunity.');
+  }
+  if (metrics.changePercent != null) {
+    if (metrics.changePercent > 2) insights.push('Latest session delivered a >2% advance, signalling strong near-term demand.');
+    if (metrics.changePercent < -2) insights.push('Latest session saw a meaningful pullback greater than 2%, monitor follow-through.');
+  }
+  if (metrics.fiftyTwoWeekHigh != null && metrics.currentPrice != null && metrics.fiftyTwoWeekHigh - metrics.currentPrice < (metrics.fiftyTwoWeekHigh - metrics.fiftyTwoWeekLow) * 0.1) {
+    insights.push('Price is testing the upper end of the 52-week range; watch for breakout confirmation.');
+  }
+  if (metrics.volatilityAnnualized != null && metrics.volatilityAnnualized < 0.25) insights.push('Volatility remains contained (<25% annualised) enabling higher conviction position sizing.');
+  if (Array.isArray(events) && events.length) {
+    const first = events[0];
+    if (first) insights.push(`Nearest catalyst: ${first.title || 'Event'} on ${new Date(first.publishedAt || first.date || Date.now()).toLocaleDateString()}.`);
+  }
+  if (!insights.length) insights.push('Awaiting additional data to surface automated insights.');
+  return insights;
+}
+
+function computeMetrics(series, quote, request) {
+  const ordered = [...series].filter((row) => row && row.date).sort(sortByDate);
+  const latestRow = quote || ordered[ordered.length - 1] || {};
+  const prevRow = ordered.length > 1 ? ordered[ordered.length - 2] : null;
+  const currency = inferCurrency(latestRow, request?.mic) || 'USD';
+  const currentPrice = safeNumber(latestRow.close ?? latestRow.price ?? latestRow.last, safeNumber(prevRow?.close, null));
+  const previousClose = safeNumber(latestRow.previousClose ?? prevRow?.close ?? prevRow?.last, currentPrice);
+  const change = currentPrice != null && previousClose != null ? currentPrice - previousClose : null;
+  const changePercent = change != null && previousClose ? (change / previousClose) * 100 : null;
+  const dayHigh = safeNumber(latestRow.high ?? latestRow.dayHigh ?? latestRow.close, null);
+  const dayLow = safeNumber(latestRow.low ?? latestRow.dayLow ?? latestRow.close, null);
+  const volume = safeNumber(latestRow.volume, safeNumber(prevRow?.volume, null));
+  const averageVolume = computeAverageVolume(ordered);
+  const high52 = Math.max(...ordered.map((row) => safeNumber(row.high ?? row.close, -Infinity)));
+  const low52 = Math.min(...ordered.map((row) => safeNumber(row.low ?? row.close, Infinity)));
+  const volatility = computeVolatility(ordered);
+  const momentum = computeMomentum(ordered);
+  const riskView = evaluateRisk(volatility, momentum);
+  const fairValue = currentPrice != null && high52 !== -Infinity && low52 !== Infinity
+    ? roundTo((currentPrice * 0.4) + ((high52 + low52) / 2) * 0.6, 2)
+    : null;
+  const expectedUpside = fairValue != null && currentPrice ? ((fairValue - currentPrice) / currentPrice) * 100 : null;
+  const expectedDownside = low52 !== Infinity && currentPrice ? ((low52 * 0.95 - currentPrice) / currentPrice) * 100 : null;
+
+  return {
+    currency,
+    currentPrice: currentPrice != null ? roundTo(currentPrice, 2) : null,
+    previousClose: previousClose != null ? roundTo(previousClose, 2) : null,
+    change: change != null ? roundTo(change, 2) : null,
+    changePercent: changePercent != null ? roundTo(changePercent, 2) : null,
+    dayHigh: dayHigh != null ? roundTo(dayHigh, 2) : null,
+    dayLow: dayLow != null ? roundTo(dayLow, 2) : null,
+    dayRange: dayHigh != null && dayLow != null ? `${roundTo(dayLow, 2)} – ${roundTo(dayHigh, 2)}` : '',
+    volume,
+    averageVolume,
+    fiftyTwoWeekHigh: high52 !== -Infinity ? roundTo(high52, 2) : null,
+    fiftyTwoWeekLow: low52 !== Infinity ? roundTo(low52, 2) : null,
+    lastUpdated: latestRow.date || new Date().toISOString(),
+    volatilityAnnualized: volatility != null ? roundTo(volatility, 3) : null,
+    volatilityLabel: volatility != null ? `${roundTo(volatility * 100, 1)}%` : '—',
+    momentumScore: momentum != null ? roundTo(momentum, 2) : null,
+    momentumLabel: momentum != null ? `${roundTo(momentum, 1)}% / 20D` : '—',
+    riskScore: riskView.score,
+    riskLabel: riskView.label,
+    conviction: riskView.conviction,
+    fairValueEstimate: fairValue,
+    expectedReturn: {
+      upside: expectedUpside != null ? roundTo(expectedUpside, 2) : null,
+      downside: expectedDownside != null ? roundTo(expectedDownside, 2) : null,
+    },
+  };
+}
+
+function computeRiskMetrics(series, metrics) {
+  const price = safeNumber(metrics.currentPrice, null);
+  const volatility = safeNumber(metrics.volatilityAnnualized, null);
+  if (!price || !volatility) {
+    return {
+      note: 'Risk metrics rely on historical volatility; insufficient data for precise estimates.',
+    };
+  }
+  const dailyVol = volatility / Math.sqrt(252);
+  const var95 = price * dailyVol * 1.65;
+  const var99 = price * dailyVol * 2.33;
+  const expectedMove1D = price * dailyVol;
+  const expectedMove1W = expectedMove1D * Math.sqrt(5);
+  const expectedMove1M = expectedMove1D * Math.sqrt(21);
+  const atr = computeAtr(series);
+  const annualisedReturn = safeNumber(metrics.momentumScore, 0) / 100 * 252 / 20;
+  const sharpeEstimate = volatility ? (annualisedReturn - 0.02) / volatility : null;
+  return {
+    var95: roundTo(var95, 2),
+    var99: roundTo(var99, 2),
+    expectedMove1D: roundTo(expectedMove1D, 2),
+    expectedMove1W: roundTo(expectedMove1W, 2),
+    expectedMove1M: roundTo(expectedMove1M, 2),
+    beta: roundTo(1 + (volatility - 0.2) * 0.8, 2),
+    atr: atr != null ? roundTo(atr, 2) : null,
+    sharpeEstimate: sharpeEstimate != null ? roundTo(sharpeEstimate, 2) : null,
+    note: 'Value at Risk approximations based on Tiingo-derived volatility; monitor during regime shifts.',
+  };
+}
+
+function mapNewsToEvents(newsItems, symbol) {
+  if (!Array.isArray(newsItems)) return [];
+  return newsItems.slice(0, 20).map((item, idx) => ({
+    id: item.id || item.url || `${symbol}-event-${idx}`,
+    title: item.title || item.headline || 'Company Update',
+    summary: item.description || item.summary || item.content || '',
+    url: item.url || item.articleUrl || '',
+    publishedAt: item.publishedDate || item.date || item.timestamp || new Date().toISOString(),
+    tags: Array.isArray(item.tags) ? item.tags.slice(0, 4) : (item.categories ? [].concat(item.categories).slice(0, 4) : []),
+  }));
+}
+
+function mapFilings(rows, symbol) {
+  if (!Array.isArray(rows)) return [];
+  return rows.slice(0, 20).map((row, idx) => ({
+    id: row.id || row.filingId || `${symbol}-filing-${idx}`,
+    formType: row.formType || row.form || row.formCode || '—',
+    filedAt: row.filingDate || row.filedDate || row.date || new Date().toISOString(),
+    description: row.description || row.reportType || row.title || '',
+    url: row.filingUrl || row.url || row.documentUrl || '',
+  }));
+}
+
+function fallbackResearch(symbol, request) {
+  const series = generateMockSeries(symbol, 260, 'eod');
+  const snapshots = computeSnapshots(series);
+  const metrics = computeMetrics(series, series[series.length - 1], request);
+  const riskMetrics = computeRiskMetrics(series, metrics);
+  const scenarios = buildScenarios(metrics);
+  const levels = computeLevels(series);
+  const comparables = buildComparables(symbol, metrics, snapshots);
+  const insights = buildInsights(metrics, snapshots, FALLBACK_EVENTS);
+  return {
+    symbol,
+    company: {
+      name: `${symbol} Holdings (sample data)`,
+      exchange: request?.mic || 'US',
+      currency: metrics.currency,
+      description: 'Sample data is displayed because a Tiingo API key is not configured. Replace with live credentials to unlock full coverage.',
+    },
+    metrics,
+    snapshots,
+    riskMetrics,
+    levels,
+    scenarios,
+    comparables,
+    events: FALLBACK_EVENTS,
+    filings: FALLBACK_FILINGS,
+    insights,
+    warnings: ['Tiingo API key missing — displaying synthetic sample data.'],
+    note: 'Activate TIINGO_API_KEY to access live pricing, events, and filings.',
+  };
+}
+
+async function fetchProfile(request, token) {
+  if (!token || !request?.ticker) return null;
+  try {
+    const path = `/tiingo/daily/${encodeURIComponent(request.ticker)}`;
+    const data = await fetchTiingo(path, {}, token);
+    if (data && typeof data === 'object') return data;
+  } catch (error) {
+    console.warn('profile fetch failed', error);
+  }
+  return null;
+}
+
+async function fetchNews(request, token, limit) {
+  if (!token || !request?.ticker) return [];
+  try {
+    const params = { tickers: request.ticker, limit: String(limit), sortBy: 'publishedDate', order: 'desc' };
+    const data = await fetchTiingo('/tiingo/news', params, token);
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.warn('news fetch failed', error);
+    return [];
+  }
+}
+
+async function fetchFilings(request, token, limit) {
+  if (!token || !request?.ticker) return [];
+  try {
+    const path = `/tiingo/sec/${encodeURIComponent(request.ticker)}`;
+    const data = await fetchTiingo(path, { limit: String(limit) }, token);
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.warn('filings fetch failed', error);
+    return [];
+  }
+}
+
+async function buildResearchPayload(symbol, request, token, options = {}) {
+  const historyPoints = Math.max(Number(options.history) || 520, 120);
+  const newsLimit = Math.max(Number(options.newsLimit) || 12, 3);
+  const filingLimit = Math.max(Number(options.filingLimit) || 10, 3);
+
+  const [history, profile, newsItems, filingsRaw] = await Promise.all([
+    loadEod(request, historyPoints, token).catch((error) => {
+      console.warn('price history fetch failed', error);
+      return [];
+    }),
+    fetchProfile(request, token),
+    fetchNews(request, token, newsLimit),
+    fetchFilings(request, token, filingLimit),
+  ]);
+
+  let quote = null;
+  try {
+    const map = await loadIntradayLatest([request], token);
+    quote = map.get(request.symbol) || null;
+  } catch (error) {
+    console.warn('real-time quote fetch failed', error);
+  }
+
+  const series = history.length ? history : generateMockSeries(symbol, 120, 'eod');
+  const snapshots = computeSnapshots(series);
+  const metrics = computeMetrics(series, quote, request);
+  const riskMetrics = computeRiskMetrics(series, metrics);
+  const levels = computeLevels(series);
+  const scenarios = buildScenarios(metrics);
+  const comparables = buildComparables(symbol, metrics, snapshots);
+  const events = mapNewsToEvents(newsItems, symbol);
+  const filings = mapFilings(filingsRaw, symbol);
+  const insights = buildInsights(metrics, snapshots, events);
+
+  const warnings = [];
+  if (!history.length) warnings.push('Historical prices unavailable from Tiingo — using synthesised fallback series.');
+  if (!newsItems.length) warnings.push('No recent Tiingo news articles were returned for this symbol.');
+  if (!filingsRaw.length) warnings.push('No recent Tiingo SEC filings were returned for this symbol.');
+  if (!quote) warnings.push('Real-time quote unavailable; using end-of-day prices.');
+
+  return {
+    symbol,
+    company: {
+      name: profile?.name || profile?.ticker || symbol,
+      description: profile?.description || profile?.statement || '',
+      exchange: profile?.exchangeCode || request?.mic || profile?.mic || '',
+      sector: profile?.sector || '',
+      industry: profile?.industry || '',
+      website: profile?.url || profile?.website || '',
+      currency: metrics.currency,
+    },
+    metrics,
+    snapshots,
+    riskMetrics,
+    levels,
+    scenarios,
+    comparables,
+    events: events.length ? events : FALLBACK_EVENTS,
+    filings: filings.length ? filings : FALLBACK_FILINGS,
+    insights,
+    warnings,
+    note: warnings.length ? 'Some datasets relied on fallbacks; review warnings for detail.' : '',
+  };
+}
+
+export default async function handler(request) {
+  if (request.method && request.method !== 'GET') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+
+  const url = new URL(request.url);
+  const rawSymbol = url.searchParams.get('symbol') || 'AAPL';
+  const exchange = url.searchParams.get('exchange') || '';
+  const requests = resolveSymbolRequests(rawSymbol, exchange);
+  const target = requests[0] || { symbol: (rawSymbol || 'AAPL').toUpperCase(), mic: '', ticker: rawSymbol };
+  const symbol = target.symbol || (rawSymbol || 'AAPL').toUpperCase();
+
+  const token = getTiingoToken();
+  if (!token) {
+    const fallback = fallbackResearch(symbol, target);
+    return Response.json(fallback, { headers: corsHeaders });
+  }
+
+  try {
+    const payload = await buildResearchPayload(symbol, target, token, {
+      history: url.searchParams.get('history'),
+      newsLimit: url.searchParams.get('newsLimit'),
+      filingLimit: url.searchParams.get('filingLimit'),
+    });
+    return Response.json(payload, { headers: corsHeaders });
+  } catch (error) {
+    console.error('research handler failed', error);
+    const fallback = fallbackResearch(symbol, target);
+    fallback.warnings.push('Live Tiingo request failed; displaying sample intelligence.');
+    fallback.note = 'Live Tiingo request failed; showing synthesised sample data.';
+    return Response.json(fallback, { headers: corsHeaders });
+  }
+}
+
+export { handler };

--- a/netlify/functions/tiingo.js
+++ b/netlify/functions/tiingo.js
@@ -558,6 +558,22 @@ async function handleTiingoRequest(request) {
 
 export default handleTiingoRequest;
 
+export {
+  resolveSymbolRequests,
+  buildTiingoTicker,
+  generateMockSeries,
+  generateMockQuotes,
+  normalizeQuote,
+  normalizeCandle,
+  loadIntraday,
+  loadEod,
+  loadIntradayLatest,
+  loadEodLatest,
+  fetchTiingo,
+  inferCurrency,
+  minutesForInterval,
+};
+
 // Netlify runtime compatibility
 export const handler = async (event) => {
   const rawQuery = event?.rawQuery ?? event?.rawQueryString ?? '';

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
+    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css professional-desk.html valuation-lab.html professional-desk.js professional-desk.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
     "start": "npx netlify-cli@latest dev",
-    "generate:symbols": "node scripts/build-symbols.mjs"
+    "generate:symbols": "node scripts/build-symbols.mjs",
+    "test": "node --test"
   },
   "devDependencies": {
     "csv-parse": "^5.5.6",

--- a/professional-desk.css
+++ b/professional-desk.css
@@ -1,0 +1,671 @@
+:root {
+  color-scheme: dark;
+  --bg: #06080f;
+  --panel-bg: #101424;
+  --panel-border: rgba(255, 255, 255, 0.06);
+  --accent: #3cc6ff;
+  --accent-soft: rgba(60, 198, 255, 0.15);
+  --positive: #4fd29a;
+  --negative: #ff5e71;
+  --neutral: #8a9bb6;
+  --text: #f4f7ff;
+  --text-muted: #9aa6c6;
+  --muted-bg: rgba(255, 255, 255, 0.04);
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #0d1430 0%, #05060a 60%, #030409 100%);
+  color: var(--text);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.prodesk-app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.prodesk-header {
+  padding: 1.5rem 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--panel-border);
+  background: rgba(5, 8, 15, 0.85);
+  backdrop-filter: blur(24px);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.brand-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(60, 198, 255, 0.35), rgba(34, 137, 255, 0.1));
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  font-size: 1.3rem;
+}
+
+.prodesk-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.prodesk-nav a {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.prodesk-nav a:hover,
+.prodesk-nav a:focus {
+  color: var(--text);
+  border-color: var(--accent-soft);
+  background: rgba(60, 198, 255, 0.08);
+}
+
+.prodesk-nav a.active {
+  color: var(--text);
+  background: var(--accent-soft);
+  border-color: rgba(60, 198, 255, 0.5);
+}
+
+.session-clock {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.prodesk-status {
+  padding: 0.7rem 2.5rem;
+  background: rgba(41, 196, 142, 0.08);
+  color: var(--text);
+  font-size: 0.85rem;
+  border-bottom: 1px solid var(--panel-border);
+  display: none;
+}
+
+.prodesk-status.visible {
+  display: block;
+}
+
+.prodesk-status.status-info {
+  background: rgba(60, 198, 255, 0.12);
+  color: var(--text);
+}
+
+.prodesk-status.status-warn {
+  background: rgba(255, 165, 0, 0.16);
+  color: #ffd8a6;
+}
+
+.prodesk-status.status-error {
+  background: rgba(255, 94, 113, 0.2);
+  color: #ffc9d0;
+}
+
+.prodesk-status.status-ok {
+  background: rgba(79, 210, 154, 0.2);
+  color: #d4ffee;
+}
+
+.prodesk-grid {
+  flex: 1;
+  padding: 2rem 2.5rem 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.valuation-layout {
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 22px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.panel-header {
+  padding: 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--panel-border);
+  background: linear-gradient(135deg, rgba(17, 24, 46, 0.95), rgba(12, 18, 32, 0.95));
+}
+
+.panel-header h1,
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.panel-header p {
+  margin: 0.3rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.panel-body {
+  padding: 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.panel-footnote {
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.primary-quote {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  background: rgba(60, 198, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.3rem 1.6rem;
+}
+
+.symbol-line {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.symbol {
+  font-size: 1.6rem;
+  letter-spacing: 0.03em;
+  color: var(--text);
+}
+
+.exchange,
+.currency {
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.company-name {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.price-line {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.price {
+  font-size: 2.4rem;
+  font-weight: 600;
+}
+
+.change,
+.change-pct {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.change.positive,
+.change-pct.positive {
+  color: var(--positive);
+}
+
+.change.negative,
+.change-pct.negative {
+  color: var(--negative);
+}
+
+.change.neutral,
+.change-pct.neutral {
+  color: var(--neutral);
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.stat-block {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 16px;
+  padding: 0.9rem;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.stat-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-top: 0.4rem;
+}
+
+.snapshot-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.snapshot-chip {
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.78rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.snapshot-chip span:last-child {
+  font-weight: 600;
+}
+
+.snapshot-chip.active {
+  border-color: rgba(60, 198, 255, 0.5);
+  background: rgba(60, 198, 255, 0.15);
+  color: var(--text);
+}
+
+.snapshot-chip.positive span:last-child {
+  color: var(--positive);
+}
+
+.snapshot-chip.negative span:last-child {
+  color: var(--negative);
+}
+
+.insights ul,
+.ai-grid ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.insights li,
+.ai-grid li {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.timeframe-controls {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.timeframe-controls button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-muted);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.timeframe-controls button.active,
+.timeframe-controls button:hover {
+  color: var(--text);
+  border-color: rgba(60, 198, 255, 0.5);
+  background: rgba(60, 198, 255, 0.12);
+}
+
+.levels {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.level-pill {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0.9rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.level-pill strong {
+  color: var(--text);
+}
+
+.event-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.event-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.4rem;
+  border-left: 3px solid rgba(60, 198, 255, 0.45);
+}
+
+.event-card h4 {
+  margin: 0;
+  font-size: 0.98rem;
+}
+
+.event-card time {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.event-tags {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.event-tags span {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(60, 198, 255, 0.1);
+  color: var(--accent);
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.event-card a {
+  font-size: 0.75rem;
+}
+
+.filings-table,
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.filings-table thead th,
+.data-table thead th {
+  text-align: left;
+  padding: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.filings-table tbody td,
+.data-table tbody td {
+  padding: 0.65rem 0.7rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.filings-table tbody tr:last-child td,
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.risk-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.ai-summary {
+  background: rgba(255, 255, 255, 0.03);
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  line-height: 1.6;
+}
+
+.ai-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.ai-recommendation {
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  background: rgba(60, 198, 255, 0.08);
+  font-weight: 600;
+}
+
+.ai-actions {
+  display: flex;
+  gap: 0.8rem;
+}
+
+.btn-secondary,
+.btn-link {
+  border: 1px solid rgba(60, 198, 255, 0.4);
+  background: rgba(60, 198, 255, 0.12);
+  color: var(--text);
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus,
+.btn-link:hover,
+.btn-link:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px rgba(60, 198, 255, 0.2);
+}
+
+.btn-link {
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  padding-left: 0;
+}
+
+.search-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  position: relative;
+  min-width: 220px;
+}
+
+.search-control input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.search-control input:focus {
+  outline: none;
+  border-color: rgba(60, 198, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(60, 198, 255, 0.2);
+}
+
+.search-suggestions {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  left: 0;
+  right: 0;
+  background: rgba(6, 8, 15, 0.95);
+  border: 1px solid rgba(60, 198, 255, 0.3);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  max-height: 260px;
+  overflow-y: auto;
+  display: none;
+  z-index: 30;
+}
+
+.search-suggestions.visible {
+  display: block;
+}
+
+.search-suggestions button {
+  display: block;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  text-align: left;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.search-suggestions button:hover,
+.search-suggestions button:focus,
+.search-suggestions button.active {
+  background: rgba(60, 198, 255, 0.12);
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.muted.small {
+  font-size: 0.7rem;
+  display: block;
+}
+
+.valuation-summary {
+  gap: 1.5rem;
+}
+
+.valuation-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.valuation-key-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.valuation-key-stats .stat-value {
+  font-size: 1.2rem;
+}
+
+.catalysts-body {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.prodesk-footer {
+  padding: 1.5rem 2.5rem 2.5rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+@media (max-width: 960px) {
+  .prodesk-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    position: static;
+  }
+
+  .prodesk-status {
+    padding: 0.7rem 1.5rem;
+  }
+
+  .prodesk-grid {
+    padding: 1.5rem 1.5rem 2.5rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .primary-quote {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .price-line {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .timeframe-controls {
+    width: 100%;
+  }
+}

--- a/professional-desk.html
+++ b/professional-desk.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Professional Trading Desk</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="professional-desk.css" />
+</head>
+<body data-page="desk">
+  <div class="prodesk-app">
+    <header class="prodesk-header">
+      <div class="brand">
+        <span class="brand-icon"><i class="fa-solid fa-chart-line"></i></span>
+        <div>
+          <strong>Good Hope Markets</strong>
+          <small>Professional Trading Desk</small>
+        </div>
+      </div>
+      <nav class="prodesk-nav">
+        <a href="index.html">Primary Console</a>
+        <a href="professional-desk.html" class="active">Trading Desk</a>
+        <a href="valuation-lab.html">AI Valuation Lab</a>
+      </nav>
+      <div class="session-clock" id="pdSessionClock">—</div>
+    </header>
+
+    <div class="prodesk-status" id="pdStatus" role="status" aria-live="polite"></div>
+
+    <main class="prodesk-grid">
+      <section class="panel panel-overview" aria-labelledby="overviewHeading">
+        <div class="panel-header">
+          <div>
+            <h1 id="overviewHeading">Share Intelligence Console</h1>
+            <p class="muted">Integrated screening, live pricing, events monitoring, and AI-assisted valuation.</p>
+          </div>
+          <div class="search-control" data-component="symbol-search">
+            <label class="muted" for="prodesk-symbol-input">Symbol or company</label>
+            <input id="prodesk-symbol-input" data-symbol-input type="text" placeholder="Search ticker, company, or ASX:WOW" autocomplete="off" />
+            <div class="search-suggestions" data-symbol-suggestions></div>
+          </div>
+        </div>
+        <div class="panel-body">
+          <div class="primary-quote" role="presentation">
+            <div>
+              <div class="symbol-line">
+                <span id="pdSymbol" class="symbol">AAPL</span>
+                <span id="pdExchange" class="exchange">NASDAQ</span>
+                <span id="pdCurrency" class="currency">USD</span>
+              </div>
+              <div id="pdCompanyName" class="company-name">Apple Inc.</div>
+            </div>
+            <div class="price-line">
+              <span id="pdPrice" class="price">$—</span>
+              <span id="pdChange" class="change neutral">—</span>
+              <span id="pdChangePct" class="change-pct neutral">—</span>
+            </div>
+          </div>
+
+          <div class="overview-grid">
+            <div class="stat-block">
+              <div class="stat-label">Prev Close</div>
+              <div id="pdPrevClose" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">Day Range</div>
+              <div id="pdDayRange" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">52W Range</div>
+              <div id="pd52Week" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">Volume (avg)</div>
+              <div id="pdVolume" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">Volatility</div>
+              <div id="pdVolatility" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">Momentum</div>
+              <div id="pdMomentum" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">Fair Value (AI)</div>
+              <div id="pdFairValue" class="stat-value">—</div>
+            </div>
+            <div class="stat-block">
+              <div class="stat-label">Risk Score</div>
+              <div id="pdRiskScore" class="stat-value">—</div>
+            </div>
+          </div>
+
+          <div class="snapshot-row" id="pdSnapshotRow" aria-live="polite"></div>
+
+          <div class="insights" aria-live="polite">
+            <h3>Automated Insights</h3>
+            <ul id="pdInsights"></ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel panel-chart" aria-labelledby="chartHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="chartHeading">Price Action</h2>
+            <p class="muted">Interactive chart with regime detection across intraday and higher timeframes.</p>
+          </div>
+          <div class="timeframe-controls" id="pdTimeframes" role="tablist">
+            <button type="button" class="active" data-tf="1D">1D</button>
+            <button type="button" data-tf="1W">1W</button>
+            <button type="button" data-tf="1M">1M</button>
+            <button type="button" data-tf="3M">3M</button>
+            <button type="button" data-tf="6M">6M</button>
+            <button type="button" data-tf="1Y">1Y</button>
+            <button type="button" data-tf="2Y">2Y</button>
+          </div>
+        </div>
+        <div class="panel-body">
+          <canvas id="proDeskChart" aria-label="Price chart" role="img"></canvas>
+          <div class="panel-footnote" id="pdChartStatus"></div>
+          <div class="levels" id="pdKeyLevels"></div>
+        </div>
+      </section>
+
+      <section class="panel panel-events" aria-labelledby="eventsHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="eventsHeading">Event Radar</h2>
+            <p class="muted">Company events, earnings, and important catalysts pulled directly from Tiingo.</p>
+          </div>
+          <button type="button" class="btn-link" id="pdRefreshButton"><i class="fa-solid fa-rotate"></i> Refresh data</button>
+        </div>
+        <div class="panel-body">
+          <ul class="event-list" id="pdEventsList"></ul>
+        </div>
+      </section>
+
+      <section class="panel panel-docs" aria-labelledby="docsHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="docsHeading">Documents &amp; Filings</h2>
+            <p class="muted">Track regulatory filings and material company disclosures.</p>
+          </div>
+        </div>
+        <div class="panel-body">
+          <table class="filings-table">
+            <thead>
+              <tr>
+                <th>Form</th>
+                <th>Date</th>
+                <th>Description</th>
+                <th>Link</th>
+              </tr>
+            </thead>
+            <tbody id="pdFilingsList"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel panel-risk" aria-labelledby="riskHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="riskHeading">Risk &amp; Exposure Monitor</h2>
+            <p class="muted">Quantitative risk measures derived from Tiingo data with scenario stress testing.</p>
+          </div>
+        </div>
+        <div class="panel-body">
+          <div class="risk-grid">
+            <div>
+              <h3>Risk Metrics</h3>
+              <table class="data-table" id="pdRiskMetrics"></table>
+            </div>
+            <div>
+              <h3>Scenario Map</h3>
+              <table class="data-table" id="pdScenarioTable"></table>
+            </div>
+          </div>
+          <div class="muted" id="pdRiskNote"></div>
+        </div>
+      </section>
+
+      <section class="panel panel-ai" aria-labelledby="aiHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="aiHeading">ChatGPT 5 Equity Intelligence</h2>
+            <p class="muted">AI-driven valuation and strategic guidance using company events, filings, and quantitative factors.</p>
+          </div>
+          <div class="ai-actions">
+            <button type="button" class="btn-secondary" id="pdRunAiButton"><i class="fa-solid fa-robot"></i> Re-run analysis</button>
+          </div>
+        </div>
+        <div class="panel-body">
+          <div id="pdAiSummary" class="ai-summary">AI valuation pending…</div>
+          <div class="ai-grid">
+            <div>
+              <h3>Key Drivers</h3>
+              <ul id="pdAiDrivers"></ul>
+            </div>
+            <div>
+              <h3>Principal Risks</h3>
+              <ul id="pdAiRisks"></ul>
+            </div>
+          </div>
+          <div class="ai-recommendation" id="pdAiRecommendation"></div>
+          <div class="muted" id="pdValuationNote"></div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="prodesk-footer">
+      <p>Data sourced from Tiingo with intelligent fallbacks for coverage gaps. AI analysis utilises ChatGPT 5 or deterministic heuristics when OpenAI access is unavailable.</p>
+    </footer>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-4ir2oS1/6vCIxBxJDC1oS6bwyuMxSjo/73uh/gzYy/ufVQcPdkGFUTkOcJCIZy9l" crossorigin="anonymous"></script>
+  <script src="professional-desk.js" type="module"></script>
+</body>
+</html>

--- a/professional-desk.js
+++ b/professional-desk.js
@@ -1,0 +1,773 @@
+const DEFAULT_SYMBOL = 'AAPL';
+const DEFAULT_TIMEFRAME = '1D';
+const AI_DEFAULT_MODEL = 'chatgpt-5';
+const SEARCH_RESULT_LIMIT = 12;
+
+const TIMEFRAMES = {
+  '1D': { kind: 'intraday', interval: '5min', limit: 96, label: '1 Day', chartInterval: 'time' },
+  '1W': { kind: 'eod', limit: 7, label: '1 Week', chartInterval: 'date' },
+  '1M': { kind: 'eod', limit: 22, label: '1 Month', chartInterval: 'date' },
+  '3M': { kind: 'eod', limit: 66, label: '3 Months', chartInterval: 'date' },
+  '6M': { kind: 'eod', limit: 132, label: '6 Months', chartInterval: 'date' },
+  '1Y': { kind: 'eod', limit: 252, label: '1 Year', chartInterval: 'date' },
+  '2Y': { kind: 'eod', limit: 504, label: '2 Years', chartInterval: 'date' },
+};
+
+const state = {
+  symbol: DEFAULT_SYMBOL,
+  timeframe: DEFAULT_TIMEFRAME,
+  symbolUniverse: [],
+  chart: null,
+  priceSeries: [],
+  research: null,
+  ai: null,
+  loadingToken: 0,
+  aiToken: 0,
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
+
+function formatCurrency(value, currency = 'USD') {
+  if (value == null || Number.isNaN(value)) return '—';
+  try {
+    const maximumFractionDigits = Math.abs(value) >= 100 ? 0 : 2;
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits,
+    }).format(value);
+  } catch (error) {
+    console.warn('currency format error', error);
+    return `${currency} ${numberFormatter.format(value)}`;
+  }
+}
+
+function formatNumber(value, digits = 2) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return Number(value).toFixed(digits);
+}
+
+function formatPercent(value, digits = 2) {
+  if (value == null || !Number.isFinite(value)) return '—';
+  return `${value > 0 ? '+' : ''}${Number(value).toFixed(digits)}%`;
+}
+
+function formatVolume(value) {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const abs = Math.abs(value);
+  if (abs >= 1e12) return `${(value / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${(value / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(value / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(value / 1e3).toFixed(2)}K`;
+  return numberFormatter.format(value);
+}
+
+function toDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function htmlEscape(str) {
+  return String(str || '').replace(/[&<>"']/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch] || ch));
+}
+
+function setStatus(message = '', tone = 'info') {
+  const el = document.getElementById('pdStatus');
+  if (!el) return;
+  if (!message) {
+    el.textContent = '';
+    el.className = 'prodesk-status';
+    return;
+  }
+  el.textContent = message;
+  el.className = `prodesk-status visible status-${tone}`;
+}
+
+function setText(id, value) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = value == null || value === '' ? '—' : value;
+}
+
+function setList(id, items) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const list = Array.isArray(items) ? items.filter(Boolean) : [];
+  if (!list.length) {
+    el.innerHTML = '<li class="muted">No data available.</li>';
+    return;
+  }
+  el.innerHTML = list.map((item) => `<li>${htmlEscape(item)}</li>`).join('');
+}
+
+function updateClock() {
+  const clock = document.getElementById('pdSessionClock');
+  if (!clock) return;
+  const now = new Date();
+  const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  const zone = Intl.DateTimeFormat('en', { timeZoneName: 'short' }).format(now).split(' ').slice(-1)[0] || 'UTC';
+  clock.textContent = `${time} ${zone}`;
+}
+
+setInterval(updateClock, 1000);
+updateClock();
+
+async function ensureSymbolsLoaded() {
+  if (state.symbolUniverse.length) return state.symbolUniverse;
+  try {
+    const response = await fetch('data/symbols.json');
+    if (!response.ok) throw new Error(`Symbol directory unavailable (${response.status})`);
+    const payload = await response.json();
+    const list = Array.isArray(payload) ? payload : (payload?.symbols || []);
+    state.symbolUniverse = list
+      .map((entry) => ({
+        symbol: String(entry.symbol || '').toUpperCase(),
+        name: entry.name || '',
+        exchange: entry.exchange || entry.mic || '',
+        mic: entry.mic || '',
+        country: entry.country || '',
+      }))
+      .filter((entry) => entry.symbol);
+  } catch (error) {
+    console.error('Failed to load symbols', error);
+    setStatus(`Symbol reference failed: ${error.message || error}`, 'warn');
+  }
+  return state.symbolUniverse;
+}
+
+function filterSymbols(query) {
+  const trimmed = (query || '').trim().toUpperCase();
+  if (!trimmed) return [];
+  const words = trimmed.split(/\s+/).filter(Boolean);
+  const entries = state.symbolUniverse;
+  if (!entries.length) return [];
+  return entries
+    .map((entry) => {
+      let score = 0;
+      if (entry.symbol.startsWith(trimmed)) score += 6;
+      if (entry.symbol.includes(trimmed)) score += 4;
+      if ((entry.name || '').toUpperCase().includes(trimmed)) score += 3;
+      for (const word of words) {
+        if (entry.name && entry.name.toUpperCase().includes(word)) score += 1;
+        if (entry.exchange && entry.exchange.toUpperCase().includes(word)) score += 0.5;
+      }
+      return { entry, score };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, SEARCH_RESULT_LIMIT)
+    .map((item) => item.entry);
+}
+
+function bindSearchComponents() {
+  const components = document.querySelectorAll('[data-component="symbol-search"]');
+  components.forEach((component) => {
+    const input = component.querySelector('[data-symbol-input]');
+    const resultsPanel = component.querySelector('[data-symbol-suggestions]');
+    if (!input || !resultsPanel) return;
+
+    let activeIndex = -1;
+    let currentResults = [];
+
+    const closePanel = () => {
+      resultsPanel.innerHTML = '';
+      resultsPanel.classList.remove('visible');
+      activeIndex = -1;
+    };
+
+    const highlight = () => {
+      Array.from(resultsPanel.querySelectorAll('button')).forEach((btn, idx) => {
+        if (idx === activeIndex) btn.classList.add('active');
+        else btn.classList.remove('active');
+      });
+    };
+
+    const commitSelection = (symbol) => {
+      closePanel();
+      input.value = symbol;
+      setSymbol(symbol);
+    };
+
+    input.addEventListener('input', async (event) => {
+      const query = event.target.value || '';
+      if (!query.trim()) {
+        closePanel();
+        return;
+      }
+      await ensureSymbolsLoaded();
+      currentResults = filterSymbols(query);
+      if (!currentResults.length) {
+        closePanel();
+        return;
+      }
+      resultsPanel.innerHTML = currentResults
+        .map((entry) => {
+          const subtitle = [entry.exchange, entry.country].filter(Boolean).join(' · ');
+          return `<button type="button" data-symbol="${htmlEscape(entry.symbol)}"><strong>${htmlEscape(entry.symbol)}</strong><br><span class="muted">${htmlEscape(entry.name)}</span><br><span class="muted small">${htmlEscape(subtitle)}</span></button>`;
+        })
+        .join('');
+      resultsPanel.classList.add('visible');
+      activeIndex = -1;
+    });
+
+    input.addEventListener('keydown', (event) => {
+      if (!resultsPanel.classList.contains('visible')) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        activeIndex = (activeIndex + 1) % currentResults.length;
+        highlight();
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        activeIndex = (activeIndex - 1 + currentResults.length) % currentResults.length;
+        highlight();
+      } else if (event.key === 'Enter') {
+        if (activeIndex >= 0 && currentResults[activeIndex]) {
+          event.preventDefault();
+          commitSelection(currentResults[activeIndex].symbol);
+        }
+      } else if (event.key === 'Escape') {
+        closePanel();
+      }
+    });
+
+    resultsPanel.addEventListener('mousedown', (event) => {
+      const button = event.target.closest('button[data-symbol]');
+      if (!button) return;
+      event.preventDefault();
+      const symbol = button.dataset.symbol;
+      if (symbol) commitSelection(symbol);
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!component.contains(event.target)) closePanel();
+    });
+  });
+}
+
+function applyChangeStyles(value, element) {
+  if (!element) return;
+  element.classList.remove('positive', 'negative', 'neutral');
+  if (value > 0) element.classList.add('positive');
+  else if (value < 0) element.classList.add('negative');
+  else element.classList.add('neutral');
+}
+
+function updateOverview(research) {
+  if (!research) return;
+  const metrics = research.metrics || {};
+  const company = research.company || {};
+  setText('pdSymbol', research.symbol || state.symbol);
+  setText('pdCompanyName', company.name || company.legalName || '—');
+  setText('pdExchange', company.exchange || metrics.exchange || '—');
+  setText('pdCurrency', metrics.currency || company.currency || 'USD');
+
+  const priceEl = document.getElementById('pdPrice');
+  if (priceEl) priceEl.textContent = formatCurrency(metrics.currentPrice, metrics.currency || 'USD');
+  const changeEl = document.getElementById('pdChange');
+  if (changeEl) {
+    changeEl.textContent = formatCurrency(metrics.change, metrics.currency || 'USD');
+    applyChangeStyles(metrics.change, changeEl);
+  }
+  const changePctEl = document.getElementById('pdChangePct');
+  if (changePctEl) {
+    changePctEl.textContent = formatPercent(metrics.changePercent);
+    applyChangeStyles(metrics.changePercent, changePctEl);
+  }
+
+  setText('pdPrevClose', formatCurrency(metrics.previousClose, metrics.currency));
+  const dayRangeText = metrics.dayLow != null && metrics.dayHigh != null
+    ? `${formatCurrency(metrics.dayLow, metrics.currency)} – ${formatCurrency(metrics.dayHigh, metrics.currency)}`
+    : metrics.dayRange || '—';
+  setText('pdDayRange', dayRangeText);
+  const range52 = metrics.fiftyTwoWeekLow != null && metrics.fiftyTwoWeekHigh != null
+    ? `${formatCurrency(metrics.fiftyTwoWeekLow, metrics.currency)} – ${formatCurrency(metrics.fiftyTwoWeekHigh, metrics.currency)}`
+    : '—';
+  setText('pd52Week', range52);
+  const volumeText = metrics.volume || metrics.averageVolume
+    ? `${formatVolume(metrics.volume)} / ${formatVolume(metrics.averageVolume)} avg`
+    : '—';
+  setText('pdVolume', volumeText);
+  setText('pdVolatility', metrics.volatilityLabel || formatPercent(metrics.volatilityAnnualized));
+  setText('pdMomentum', metrics.momentumLabel || formatPercent(metrics.momentumScore));
+  setText('pdRiskScore', metrics.riskLabel || metrics.riskScore || '—');
+
+  if (research.warnings && research.warnings.length) {
+    setStatus(research.warnings.join(' '), 'warn');
+  } else if (research.note) {
+    setStatus(research.note, 'info');
+  } else {
+    setStatus(`Viewing ${research.symbol} — ${company.name || ''}`.trim(), 'info');
+  }
+
+  document.title = `Trading Desk — ${research.symbol}`;
+}
+
+function renderSnapshots(research) {
+  const container = document.getElementById('pdSnapshotRow');
+  if (!container) return;
+  const snapshots = research?.snapshots || {};
+  const entries = Object.entries(snapshots);
+  if (!entries.length) {
+    container.innerHTML = '<div class="muted">No snapshot data.</div>';
+    return;
+  }
+  container.innerHTML = entries
+    .map(([key, snap]) => {
+      const pct = Number.isFinite(snap.returnPct) ? snap.returnPct : null;
+      const classes = ['snapshot-chip'];
+      if (key === state.timeframe) classes.push('active');
+      if (pct != null) classes.push(pct > 0 ? 'positive' : pct < 0 ? 'negative' : 'neutral');
+      return `<button type="button" class="${classes.join(' ')}" data-tf="${key}"><span>${htmlEscape(snap.label || key)}</span><span>${formatPercent(pct)}</span></button>`;
+    })
+    .join('');
+
+  container.querySelectorAll('[data-tf]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const tf = button.dataset.tf;
+      if (TIMEFRAMES[tf]) {
+        state.timeframe = tf;
+        updateTimeframeButtons(tf);
+        loadPriceSeries(state.symbol, tf, state.loadingToken);
+      }
+    });
+  });
+}
+
+function updateInsights(research) {
+  const insights = research?.insights || [];
+  setList('pdInsights', insights);
+}
+
+function updateLevels(research) {
+  const container = document.getElementById('pdKeyLevels');
+  if (!container) return;
+  const levels = research?.levels || {};
+  const order = [
+    { key: 'immediateSupport', label: 'Immediate Support' },
+    { key: 'pivot', label: 'Pivot' },
+    { key: 'immediateResistance', label: 'Immediate Resistance' },
+    { key: 'majorSupport', label: 'Major Support' },
+    { key: 'majorResistance', label: 'Major Resistance' },
+  ];
+  const currency = research?.metrics?.currency || 'USD';
+  const rows = order
+    .map((item) => (levels[item.key] != null ? `<div class="level-pill"><span>${item.label}</span><strong>${formatCurrency(levels[item.key], currency)}</strong></div>` : ''))
+    .filter(Boolean);
+  container.innerHTML = rows.length ? rows.join('') : '<div class="muted">No technical levels calculated.</div>';
+}
+
+function updateEvents(research) {
+  const list = document.getElementById('pdEventsList');
+  if (!list) return;
+  const events = Array.isArray(research?.events) ? research.events : [];
+  if (!events.length) {
+    list.innerHTML = '<li class="muted">No recent events found.</li>';
+    return;
+  }
+  list.innerHTML = events
+    .map((event) => {
+      const published = toDate(event.publishedAt || event.date);
+      const when = published ? published.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—';
+      const tags = (event.tags || []).map((tag) => `<span>${htmlEscape(tag)}</span>`).join('');
+      const link = event.url ? `<a href="${htmlEscape(event.url)}" target="_blank" rel="noopener">Open source</a>` : '';
+      return `<li class="event-card"><h4>${htmlEscape(event.title || 'Event')}</h4><time>${htmlEscape(when)}</time><div class="muted">${htmlEscape(event.summary || event.description || '')}</div><div class="event-tags">${tags}</div>${link}</li>`;
+    })
+    .join('');
+}
+
+function updateFilings(research) {
+  const tbody = document.getElementById('pdFilingsList');
+  if (!tbody) return;
+  const filings = Array.isArray(research?.filings) ? research.filings : [];
+  if (!filings.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="muted">No filings available.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = filings
+    .map((filing) => {
+      const filed = toDate(filing.filedAt || filing.date);
+      const filedText = filed ? filed.toLocaleDateString() : '—';
+      const url = filing.url ? `<a href="${htmlEscape(filing.url)}" target="_blank" rel="noopener">View</a>` : '—';
+      return `<tr><td>${htmlEscape(filing.formType || filing.type || '—')}</td><td>${htmlEscape(filedText)}</td><td>${htmlEscape(filing.description || filing.title || '')}</td><td>${url}</td></tr>`;
+    })
+    .join('');
+}
+
+function updateRiskMetrics(research) {
+  const table = document.getElementById('pdRiskMetrics');
+  if (!table) return;
+  const metrics = research?.riskMetrics || {};
+  const currency = research?.metrics?.currency || 'USD';
+  const rows = [
+    ['Value at Risk (95%)', metrics.var95 != null ? formatCurrency(metrics.var95, currency) : null],
+    ['Value at Risk (99%)', metrics.var99 != null ? formatCurrency(metrics.var99, currency) : null],
+    ['Expected Move (1D)', metrics.expectedMove1D != null ? formatCurrency(metrics.expectedMove1D, currency) : null],
+    ['Expected Move (5D)', metrics.expectedMove1W != null ? formatCurrency(metrics.expectedMove1W, currency) : null],
+    ['Expected Move (21D)', metrics.expectedMove1M != null ? formatCurrency(metrics.expectedMove1M, currency) : null],
+    ['Beta vs SPX', metrics.beta != null ? formatNumber(metrics.beta, 2) : null],
+    ['ATR (20D)', metrics.atr != null ? formatCurrency(metrics.atr, currency) : null],
+    ['Sharpe (60D est.)', metrics.sharpeEstimate != null ? formatNumber(metrics.sharpeEstimate, 2) : null],
+  ].filter((row) => row[1] != null);
+  if (!rows.length) {
+    table.innerHTML = '<tbody><tr><td class="muted">Risk metrics unavailable.</td></tr></tbody>';
+    return;
+  }
+  table.innerHTML = `<tbody>${rows.map((row) => `<tr><td>${row[0]}</td><td>${row[1]}</td></tr>`).join('')}</tbody>`;
+  const note = document.getElementById('pdRiskNote');
+  if (note) note.textContent = research?.riskMetrics?.note || '';
+}
+
+function updateScenarioTable(source) {
+  const table = document.getElementById('pdScenarioTable');
+  if (!table) return;
+  const scenarios = Array.isArray(source?.scenarios) ? source.scenarios : [];
+  if (!scenarios.length) {
+    table.innerHTML = '<tbody><tr><td class="muted">Scenario data unavailable.</td></tr></tbody>';
+    return;
+  }
+  table.innerHTML = `<thead><tr><th>Scenario</th><th>Probability</th><th>Target</th><th>Return</th><th>Commentary</th></tr></thead><tbody>${scenarios
+    .map((scenario) => {
+      const probability = scenario.probability != null ? `${Math.round(scenario.probability * 100)}%` : '—';
+      const currency = source?.metrics?.currency || state.research?.metrics?.currency || 'USD';
+      const target = scenario.price != null ? formatCurrency(scenario.price, currency) : '—';
+      const ret = scenario.returnPct != null ? formatPercent(scenario.returnPct) : '—';
+      return `<tr><td>${htmlEscape(scenario.label || scenario.name || 'Scenario')}</td><td>${probability}</td><td>${target}</td><td>${ret}</td><td>${htmlEscape(scenario.commentary || scenario.narrative || '')}</td></tr>`;
+    })
+    .join('')}</tbody>`;
+}
+
+function updateComparables(research, ai) {
+  const body = document.getElementById('vlComparablesBody');
+  if (!body) return;
+  const comparables = (ai?.peerSignals && ai.peerSignals.length) ? ai.peerSignals : (research?.comparables || []);
+  if (!comparables.length) {
+    body.innerHTML = '<tr><td colspan="5" class="muted">Comparable set unavailable.</td></tr>';
+    return;
+  }
+  const currency = ai?.fairValue?.currency || research?.metrics?.currency || 'USD';
+  body.innerHTML = comparables
+    .map((peer) => {
+      const fairValue = peer.fairValue != null ? formatCurrency(peer.fairValue, currency) : '—';
+      const expected = peer.expectedReturn != null ? formatPercent(peer.expectedReturn) : '—';
+      return `<tr><td>${htmlEscape(peer.name || peer.symbol || 'Peer')}</td><td>${htmlEscape(peer.profile || '')}</td><td>${fairValue}</td><td>${expected}</td><td>${htmlEscape(peer.notes || '')}</td></tr>`;
+    })
+    .join('');
+}
+
+function updateFairValue(ai, research) {
+  const currency = research?.metrics?.currency || ai?.fairValue?.currency || 'USD';
+  if (ai?.fairValue?.base != null) {
+    setText('pdFairValue', formatCurrency(ai.fairValue.base, currency));
+  } else if (research?.metrics?.fairValueEstimate != null) {
+    setText('pdFairValue', formatCurrency(research.metrics.fairValueEstimate, currency));
+  } else {
+    setText('pdFairValue', '—');
+  }
+  if (ai?.expectedReturn) {
+    setText('vlUpside', formatPercent(ai.expectedReturn.upside));
+    setText('vlDownside', formatPercent(ai.expectedReturn.downside));
+  } else if (research?.metrics?.expectedReturn) {
+    setText('vlUpside', formatPercent(research.metrics.expectedReturn.upside));
+    setText('vlDownside', formatPercent(research.metrics.expectedReturn.downside));
+  }
+  if (ai?.conviction) setText('vlConviction', ai.conviction);
+  else if (research?.metrics?.conviction) setText('vlConviction', research.metrics.conviction);
+}
+
+function updateAiPanels(ai, research) {
+  if (!document.getElementById('pdAiSummary')) return;
+  if (!ai) {
+    setText('pdAiSummary', 'AI valuation pending…');
+    setList('pdAiDrivers', []);
+    setList('pdAiRisks', []);
+    setText('pdAiRecommendation', '');
+    setText('pdValuationNote', '');
+    updateScenarioTable(research);
+    updateComparables(research, null);
+    updateFairValue(null, research);
+    return;
+  }
+  setText('pdAiSummary', ai.summary || 'AI valuation available.');
+  setList('pdAiDrivers', ai.drivers || []);
+  setList('pdAiRisks', ai.risks || []);
+  if (ai.recommendation) {
+    const recommendation = typeof ai.recommendation === 'string' ? ai.recommendation : ai.recommendation.text;
+    setText('pdAiRecommendation', recommendation || '');
+  }
+  setText('pdValuationNote', ai.note || '');
+  updateScenarioTable(ai);
+  updateComparables(research, ai);
+  updateFairValue(ai, research);
+}
+
+function updateTimeframeButtons(active) {
+  const container = document.getElementById('pdTimeframes');
+  if (container) {
+    container.querySelectorAll('button').forEach((button) => {
+      button.classList.toggle('active', button.dataset.tf === active);
+    });
+  }
+  const snapshots = document.getElementById('pdSnapshotRow');
+  if (snapshots) {
+    snapshots.querySelectorAll('[data-tf]').forEach((button) => {
+      button.classList.toggle('active', button.dataset.tf === active);
+    });
+  }
+}
+
+function updateChartStatus(message) {
+  const el = document.getElementById('pdChartStatus');
+  if (!el) return;
+  el.textContent = message || '';
+}
+
+function renderChart(series, config, warning) {
+  const canvas = document.getElementById('proDeskChart');
+  if (!canvas || typeof window.Chart !== 'function') return;
+  const labels = series.map((row) => {
+    const date = toDate(row.date);
+    if (!date) return '';
+    return config.kind === 'intraday'
+      ? date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  });
+  const prices = series.map((row) => row.close ?? row.price ?? row.last ?? null);
+  if (!prices.some((value) => Number.isFinite(value))) {
+    updateChartStatus('Chart data unavailable.');
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  const gradient = (() => {
+    const grad = ctx.createLinearGradient(0, 0, 0, canvas.height || 340);
+    grad.addColorStop(0, 'rgba(60, 198, 255, 0.32)');
+    grad.addColorStop(1, 'rgba(60, 198, 255, 0.05)');
+    return grad;
+  })();
+
+  if (state.chart) {
+    state.chart.data.labels = labels;
+    state.chart.data.datasets[0].data = prices;
+    state.chart.data.datasets[0].backgroundColor = gradient;
+    state.chart.update();
+  } else {
+    state.chart = new window.Chart(ctx, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Price',
+            data: prices,
+            fill: true,
+            borderColor: '#3cc6ff',
+            backgroundColor: gradient,
+            tension: 0.25,
+            pointRadius: 0,
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            intersect: false,
+            mode: 'index',
+            callbacks: {
+              label(context) {
+                const currency = state.research?.metrics?.currency || 'USD';
+                const value = context.parsed.y;
+                return formatCurrency(value, currency);
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            grid: { color: 'rgba(255,255,255,0.05)' },
+            ticks: { color: 'rgba(255,255,255,0.6)', maxRotation: 0, autoSkip: true },
+          },
+          y: {
+            grid: { color: 'rgba(255,255,255,0.05)' },
+            ticks: {
+              color: 'rgba(255,255,255,0.6)',
+              callback(value) {
+                const currency = state.research?.metrics?.currency || 'USD';
+                return formatCurrency(value, currency);
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+  updateChartStatus(warning || '');
+}
+
+async function fetchJson(url, init) {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try { data = JSON.parse(text); }
+    catch (error) { console.warn('Failed to parse JSON', error, text.slice(0, 200)); }
+  }
+  if (!response.ok) {
+    const detail = data?.error || data?.detail || text || response.statusText;
+    throw new Error(detail);
+  }
+  return data;
+}
+
+async function fetchResearch(symbol) {
+  const url = new URL('/api/research', window.location.origin);
+  url.searchParams.set('symbol', symbol);
+  return fetchJson(url.toString());
+}
+
+async function fetchPriceSeries(symbol, timeframe) {
+  const cfg = TIMEFRAMES[timeframe] || TIMEFRAMES[DEFAULT_TIMEFRAME];
+  const url = new URL('/api/tiingo', window.location.origin);
+  url.searchParams.set('symbol', symbol);
+  url.searchParams.set('kind', cfg.kind);
+  url.searchParams.set('limit', String(cfg.limit));
+  if (cfg.interval) url.searchParams.set('interval', cfg.interval);
+  return fetchJson(url.toString());
+}
+
+function applyPriceSeries(payload, config) {
+  const series = Array.isArray(payload?.data) ? payload.data : [];
+  if (!series.length) throw new Error('No price series available');
+  state.priceSeries = series;
+  renderChart(series, config, payload?.warning);
+}
+
+async function loadPriceSeries(symbol, timeframe, token) {
+  try {
+    const cfg = TIMEFRAMES[timeframe] || TIMEFRAMES[DEFAULT_TIMEFRAME];
+    const payload = await fetchPriceSeries(symbol, timeframe);
+    if (token !== state.loadingToken) return;
+    applyPriceSeries(payload, cfg);
+    if (payload?.warning) setStatus(payload.warning, 'warn');
+  } catch (error) {
+    if (token !== state.loadingToken) return;
+    console.error('Price series failed', error);
+    updateChartStatus(`Price series unavailable: ${error.message || error}`);
+  }
+}
+
+async function runAiAnalysis(symbol, research) {
+  if (!document.getElementById('pdAiSummary')) return;
+  const token = ++state.aiToken;
+  setText('pdAiSummary', 'Running ChatGPT 5 valuation…');
+  try {
+    const payload = await fetchJson('/api/intelligence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        symbol,
+        timeframe: state.timeframe,
+        model: AI_DEFAULT_MODEL,
+        metrics: research.metrics,
+        snapshots: research.snapshots,
+        events: (research.events || []).slice(0, 12),
+        filings: (research.filings || []).slice(0, 8),
+        insights: (research.insights || []).slice(0, 10),
+        levels: research.levels,
+        riskMetrics: research.riskMetrics,
+        comparables: research.comparables,
+      }),
+    });
+    if (token !== state.aiToken) return;
+    state.ai = payload;
+    updateAiPanels(payload, research);
+    if (payload?.warning) setStatus(payload.warning, 'warn');
+  } catch (error) {
+    if (token !== state.aiToken) return;
+    console.error('AI analysis failed', error);
+    setStatus(`AI analysis unavailable: ${error.message || error}`, 'warn');
+    state.ai = null;
+    updateAiPanels(null, research);
+  }
+}
+
+async function setSymbol(symbol, options = {}) {
+  const normalized = (symbol || '').trim().toUpperCase() || DEFAULT_SYMBOL;
+  if (!options.force && normalized === state.symbol && state.research) {
+    loadPriceSeries(normalized, state.timeframe, state.loadingToken);
+    if (document.getElementById('pdAiSummary')) runAiAnalysis(normalized, state.research);
+    return;
+  }
+  state.symbol = normalized;
+  state.loadingToken += 1;
+  const token = state.loadingToken;
+  setStatus(`Loading ${normalized}…`, 'info');
+  try {
+    const research = await fetchResearch(normalized);
+    if (token !== state.loadingToken) return;
+    state.research = research;
+    updateOverview(research);
+    renderSnapshots(research);
+    updateInsights(research);
+    updateLevels(research);
+    updateEvents(research);
+    updateFilings(research);
+    updateRiskMetrics(research);
+    updateComparables(research, state.ai);
+    updateScenarioTable(research);
+    updateAiPanels(state.ai, research);
+    updateFairValue(state.ai, research);
+    await loadPriceSeries(normalized, state.timeframe, token);
+    if (document.getElementById('pdAiSummary')) runAiAnalysis(normalized, research);
+  } catch (error) {
+    if (token !== state.loadingToken) return;
+    console.error('Failed to load research', error);
+    setStatus(`Unable to load ${normalized}: ${error.message || error}`, 'error');
+  }
+}
+
+function bindTimeframes() {
+  const container = document.getElementById('pdTimeframes');
+  if (!container) return;
+  container.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-tf]');
+    if (!button) return;
+    const tf = button.dataset.tf;
+    if (!TIMEFRAMES[tf]) return;
+    state.timeframe = tf;
+    updateTimeframeButtons(tf);
+    loadPriceSeries(state.symbol, tf, state.loadingToken);
+  });
+}
+
+function bindRefresh() {
+  const btn = document.getElementById('pdRefreshButton');
+  if (btn) {
+    btn.addEventListener('click', () => setSymbol(state.symbol, { force: true }));
+  }
+  const aiBtn = document.getElementById('pdRunAiButton');
+  if (aiBtn) {
+    aiBtn.addEventListener('click', () => {
+      if (state.research) runAiAnalysis(state.symbol, state.research);
+    });
+  }
+}
+
+function init() {
+  ensureSymbolsLoaded();
+  bindSearchComponents();
+  bindTimeframes();
+  bindRefresh();
+  updateTimeframeButtons(state.timeframe);
+  setSymbol(state.symbol, { force: true });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/tests/intelligence.test.mjs
+++ b/tests/intelligence.test.mjs
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import intelligenceHandler from '../netlify/functions/intelligence.js';
+
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+
+const reset = () => {
+  global.fetch = originalFetch;
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(originalEnv)) {
+    process.env[key] = value;
+  }
+};
+
+test.afterEach(reset);
+
+const samplePayload = {
+  symbol: 'AAPL',
+  metrics: {
+    currency: 'USD',
+    currentPrice: 180,
+    previousClose: 178,
+    fiftyTwoWeekHigh: 195,
+    fiftyTwoWeekLow: 140,
+    riskLabel: 'Moderate',
+    fairValueEstimate: 188,
+    expectedReturn: { upside: 5, downside: -8 },
+    averageVolume: 25000000,
+  },
+  snapshots: {
+    '3M': { label: '3M', returnPct: 6 },
+  },
+  events: [
+    { title: 'Earnings beat', publishedAt: '2024-01-03T00:00:00Z' },
+  ],
+  comparables: [
+    { name: 'Peer One', profile: 'Tech', fairValue: 185, expectedReturn: 7, notes: 'Strong balance sheet' },
+  ],
+};
+
+test('intelligence handler returns heuristic analysis when OpenAI key missing', async () => {
+  delete process.env.OPENAI_API_KEY;
+  const request = new Request('https://example.org/api/intelligence', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(samplePayload),
+  });
+  const response = await intelligenceHandler(request);
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.model.provider, 'heuristic');
+  assert.ok(body.note.includes('heuristic'));
+  assert.ok(body.fairValue.base != null);
+});
+
+test('intelligence handler merges OpenAI response when available', async () => {
+  process.env.OPENAI_API_KEY = 'sk-test';
+  process.env.OPENAI_MODEL = 'gpt-4o-mini';
+  global.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input.url || '';
+    if (!url.includes('api.openai.com')) throw new Error(`Unexpected fetch ${url}`);
+    return new Response(JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              summary: 'AI generated summary',
+              fairValue: { base: 192, rangeHigh: 205, rangeLow: 170, currency: 'USD' },
+              expectedReturn: { upside: 7, downside: -5 },
+              conviction: 'High',
+              drivers: ['Robust AI demand'],
+              risks: ['Execution risk'],
+              scenarios: [
+                { label: 'Bull', probability: 0.4, price: 210, returnPct: 12, commentary: 'AI adoption accelerates' },
+              ],
+              recommendation: { text: 'Overweight allocation' },
+              note: 'AI confidence note',
+              peerSignals: [
+                { name: 'Peer Alpha', profile: 'Cloud', fairValue: 200, expectedReturn: 9, notes: 'Valuation discount' },
+              ],
+            }),
+          },
+        },
+      ],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+  const request = new Request('https://example.org/api/intelligence', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(samplePayload),
+  });
+  const response = await intelligenceHandler(request);
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.model.provider, 'openai');
+  assert.equal(body.fairValue.base, 192);
+  assert.equal(body.recommendation.text, 'Overweight allocation');
+  assert.ok(body.peerSignals.length >= 1);
+});

--- a/tests/research.test.mjs
+++ b/tests/research.test.mjs
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import researchHandler from '../netlify/functions/research.js';
+
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+
+const reset = () => {
+  global.fetch = originalFetch;
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(originalEnv)) {
+    process.env[key] = value;
+  }
+};
+
+test.afterEach(reset);
+
+test('research function returns deterministic fallback when Tiingo token missing', async () => {
+  delete process.env.TIINGO_API_KEY;
+  const request = new Request('https://example.org/api/research?symbol=MSFT');
+  const response = await researchHandler(request);
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.symbol, 'MSFT');
+  assert.ok(Array.isArray(body.events));
+  assert.ok(body.warnings.some((msg) => msg.includes('Tiingo API key missing')));
+  assert.ok(body.metrics.currentPrice != null);
+});
+
+test('research function aggregates Tiingo datasets when available', async () => {
+  process.env.TIINGO_API_KEY = 'TEST';
+  global.fetch = async (input) => {
+    const url = new URL(typeof input === 'string' ? input : input.url || input);
+    if (url.pathname.startsWith('/tiingo/daily/AAPL/prices')) {
+      return new Response(JSON.stringify([
+        { date: '2024-01-01T00:00:00Z', close: 170, high: 172, low: 168, volume: 1800000 },
+        { date: '2024-01-02T00:00:00Z', close: 172, high: 173, low: 169, volume: 1750000 },
+        { date: '2024-01-03T00:00:00Z', close: 175, high: 176, low: 171, volume: 1900000 },
+      ]), { status: 200 });
+    }
+    if (url.pathname === '/tiingo/daily/AAPL') {
+      return new Response(JSON.stringify({
+        name: 'Apple Inc.',
+        exchangeCode: 'XNAS',
+        sector: 'Technology',
+        industry: 'Consumer Electronics',
+        url: 'https://www.apple.com',
+      }), { status: 200 });
+    }
+    if (url.pathname === '/tiingo/news') {
+      return new Response(JSON.stringify([
+        { title: 'AI Expansion', url: 'https://example.com', publishedDate: '2024-01-03T12:00:00Z', description: 'New AI initiative', tags: ['AI'] },
+      ]), { status: 200 });
+    }
+    if (url.pathname.startsWith('/tiingo/sec/AAPL')) {
+      return new Response(JSON.stringify([
+        { formType: '10-Q', filingDate: '2024-01-02', description: 'Quarterly update', filingUrl: 'https://sec.example.com' },
+      ]), { status: 200 });
+    }
+    if (url.pathname === '/iex') {
+      return new Response(JSON.stringify([
+        { ticker: 'AAPL', last: 176.2, prevClose: 175.0, volume: 2100000, timestamp: '2024-01-03T15:45:00Z' },
+      ]), { status: 200 });
+    }
+    throw new Error(`Unexpected fetch ${url.href}`);
+  };
+  const request = new Request('https://example.org/api/research?symbol=AAPL');
+  const response = await researchHandler(request);
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.symbol, 'AAPL');
+  assert.equal(body.company.name, 'Apple Inc.');
+  assert.ok(body.metrics.currentPrice > 0);
+  assert.ok(body.snapshots['1M'].returnPct != null);
+  assert.ok(body.events.length >= 1);
+  assert.ok(body.filings.length >= 1);
+  assert.ok(Array.isArray(body.scenarios) && body.scenarios.length === 3);
+  assert.ok(Array.isArray(body.comparables) && body.comparables.length >= 1);
+});

--- a/tests/tiingo.test.mjs
+++ b/tests/tiingo.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handleTiingoRequest, { resolveSymbolRequests } from '../netlify/functions/tiingo.js';
+
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+
+const reset = () => {
+  global.fetch = originalFetch;
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(originalEnv)) {
+    process.env[key] = value;
+  }
+};
+
+test.afterEach(reset);
+
+test('resolveSymbolRequests deduplicates and normalises symbols', () => {
+  const requests = resolveSymbolRequests('AAPL, msft , aapl', 'XNYS');
+  assert.equal(requests.length, 2);
+  const symbols = requests.map((r) => r.symbol);
+  assert.deepEqual(symbols.sort(), ['AAPL', 'MSFT']);
+  assert.ok(requests.every((r) => r.mic === 'XNYS'));
+});
+
+test('tiingo handler returns mock payload when token missing', async () => {
+  delete process.env.TIINGO_API_KEY;
+  const request = new Request('https://example.org/api/tiingo?symbol=AAPL&kind=intraday&limit=5');
+  const response = await handleTiingoRequest(request);
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.ok(Array.isArray(body.data));
+  assert.ok(body.warning.includes('Tiingo API key missing'));
+});
+
+test('tiingo handler falls back to end-of-day data when intraday unavailable', async () => {
+  process.env.TIINGO_API_KEY = 'TEST';
+  let intradayCalls = 0;
+  global.fetch = async (input) => {
+    const url = new URL(typeof input === 'string' ? input : input.url || input);
+    if (url.pathname.startsWith('/iex/')) {
+      intradayCalls += 1;
+      throw new Error('intraday down');
+    }
+    if (url.pathname.startsWith('/tiingo/daily/AAPL/prices')) {
+      return new Response(JSON.stringify([
+        { date: '2024-01-01T00:00:00Z', close: 100, high: 101, low: 99, volume: 100000 },
+        { date: '2024-01-02T00:00:00Z', close: 102, high: 103, low: 101, volume: 125000 },
+        { date: '2024-01-03T00:00:00Z', close: 104, high: 105, low: 103, volume: 130000 },
+      ]), { status: 200 });
+    }
+    throw new Error(`Unexpected fetch ${url.href}`);
+  };
+  const request = new Request('https://example.org/api/tiingo?symbol=AAPL&kind=intraday&interval=5min&limit=3');
+  const response = await handleTiingoRequest(request);
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.ok(Array.isArray(body.data));
+  assert.equal(body.data.length, 3);
+  assert.ok(body.warning.toLowerCase().includes('end-of-day'));
+  assert.ok(intradayCalls > 0);
+});
+
+test('tiingo handler provides quotes for intraday_latest requests', async () => {
+  process.env.TIINGO_API_KEY = 'TEST';
+  global.fetch = async (input) => {
+    const url = new URL(typeof input === 'string' ? input : input.url || input);
+    if (url.pathname === '/iex') {
+      return new Response(JSON.stringify([
+        { ticker: 'AAPL', last: 190.5, prevClose: 188.2, volume: 2000000, timestamp: '2024-01-03T15:30:00Z' },
+      ]), { status: 200 });
+    }
+    if (url.pathname.startsWith('/tiingo/daily/AAPL/prices')) {
+      return new Response(JSON.stringify([
+        { date: '2024-01-02T00:00:00Z', close: 188.2, high: 189.5, low: 186.9, volume: 1800000 },
+      ]), { status: 200 });
+    }
+    throw new Error(`Unexpected fetch ${url.href}`);
+  };
+  const request = new Request('https://example.org/api/tiingo?symbol=AAPL&kind=intraday_latest');
+  const response = await handleTiingoRequest(request);
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.ok(Array.isArray(body.data));
+  assert.equal(body.data[0].symbol, 'AAPL');
+  assert.ok(body.data[0].price > 0);
+});

--- a/valuation-lab.html
+++ b/valuation-lab.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Valuation Lab</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="professional-desk.css" />
+</head>
+<body data-page="valuation">
+  <div class="prodesk-app">
+    <header class="prodesk-header">
+      <div class="brand">
+        <span class="brand-icon"><i class="fa-solid fa-rocket"></i></span>
+        <div>
+          <strong>Good Hope Markets</strong>
+          <small>AI Valuation Lab</small>
+        </div>
+      </div>
+      <nav class="prodesk-nav">
+        <a href="index.html">Primary Console</a>
+        <a href="professional-desk.html">Trading Desk</a>
+        <a href="valuation-lab.html" class="active">AI Valuation Lab</a>
+      </nav>
+      <div class="session-clock" id="pdSessionClock">—</div>
+    </header>
+
+    <div class="prodesk-status" id="pdStatus" role="status" aria-live="polite"></div>
+
+    <main class="prodesk-grid valuation-layout">
+      <section class="panel" aria-labelledby="valuationOverviewHeading">
+        <div class="panel-header">
+          <div>
+            <h1 id="valuationOverviewHeading">Equity Research Workbench</h1>
+            <p class="muted">Purpose-built environment for valuation discovery, peer benchmarking, and narrative review.</p>
+          </div>
+          <div class="search-control" data-component="symbol-search">
+            <label class="muted" for="valuation-symbol-input">Symbol or company</label>
+            <input id="valuation-symbol-input" data-symbol-input type="text" placeholder="Search ticker, company, or ASX:WOW" autocomplete="off" />
+            <div class="search-suggestions" data-symbol-suggestions></div>
+          </div>
+        </div>
+        <div class="panel-body valuation-summary">
+          <div class="valuation-header">
+            <div>
+              <div class="symbol-line">
+                <span id="pdSymbol" class="symbol">AAPL</span>
+                <span id="pdExchange" class="exchange">NASDAQ</span>
+                <span id="pdCurrency" class="currency">USD</span>
+              </div>
+              <div id="pdCompanyName" class="company-name">Apple Inc.</div>
+            </div>
+            <div class="price-line">
+              <span id="pdPrice" class="price">$—</span>
+              <span id="pdChange" class="change neutral">—</span>
+              <span id="pdChangePct" class="change-pct neutral">—</span>
+            </div>
+          </div>
+          <div class="valuation-key-stats">
+            <div>
+              <span class="stat-label">Fair Value</span>
+              <span id="pdFairValue" class="stat-value">—</span>
+            </div>
+            <div>
+              <span class="stat-label">Upside Potential</span>
+              <span id="vlUpside" class="stat-value">—</span>
+            </div>
+            <div>
+              <span class="stat-label">Downside Risk</span>
+              <span id="vlDownside" class="stat-value">—</span>
+            </div>
+            <div>
+              <span class="stat-label">Conviction</span>
+              <span id="vlConviction" class="stat-value">—</span>
+            </div>
+          </div>
+          <div class="snapshot-row" id="pdSnapshotRow" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="aiValuationHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="aiValuationHeading">ChatGPT 5 Valuation Narrative</h2>
+            <p class="muted">Deep dive into valuation reasoning with structured key drivers, risks, and scenario coverage.</p>
+          </div>
+          <div class="ai-actions">
+            <button type="button" class="btn-secondary" id="pdRunAiButton"><i class="fa-solid fa-robot"></i> Refresh insight</button>
+          </div>
+        </div>
+        <div class="panel-body">
+          <div id="pdAiSummary" class="ai-summary">AI valuation pending…</div>
+          <div class="ai-grid">
+            <div>
+              <h3>Key Drivers</h3>
+              <ul id="pdAiDrivers"></ul>
+            </div>
+            <div>
+              <h3>Principal Risks</h3>
+              <ul id="pdAiRisks"></ul>
+            </div>
+          </div>
+          <div class="ai-recommendation" id="pdAiRecommendation"></div>
+          <div class="muted" id="pdValuationNote"></div>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="scenarioHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="scenarioHeading">Scenario Intelligence</h2>
+            <p class="muted">Probabilistic price path mapping for desk-level planning.</p>
+          </div>
+        </div>
+        <div class="panel-body">
+          <table class="data-table" id="pdScenarioTable"></table>
+          <div class="muted" id="pdRiskNote"></div>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="comparablesHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="comparablesHeading">Peer &amp; Factor Benchmarking</h2>
+            <p class="muted">Synthetic peer set built from Tiingo analytics, factor tilts, and AI adjustments.</p>
+          </div>
+        </div>
+        <div class="panel-body">
+          <table class="data-table" id="vlComparables">
+            <thead>
+              <tr>
+                <th>Peer</th>
+                <th>Profile</th>
+                <th>Implied Fair Value</th>
+                <th>Expected Return</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody id="vlComparablesBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="catalystHeading">
+        <div class="panel-header">
+          <div>
+            <h2 id="catalystHeading">Catalyst &amp; Document Review</h2>
+            <p class="muted">Chronological log of upcoming events, recent filings, and must-read documents.</p>
+          </div>
+        </div>
+        <div class="panel-body catalysts-body">
+          <div>
+            <h3>Key Catalysts</h3>
+            <ul class="event-list" id="pdEventsList"></ul>
+          </div>
+          <div>
+            <h3>Regulatory Filings</h3>
+            <table class="filings-table">
+              <thead>
+                <tr>
+                  <th>Form</th>
+                  <th>Date</th>
+                  <th>Description</th>
+                  <th>Link</th>
+                </tr>
+              </thead>
+              <tbody id="pdFilingsList"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="prodesk-footer">
+      <p>Valuation Lab fuses deterministic modelling with ChatGPT 5 for adaptive market intelligence. Data quality is validated via comprehensive Tiingo integration tests.</p>
+    </footer>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-4ir2oS1/6vCIxBxJDC1oS6bwyuMxSjo/73uh/gzYy/ufVQcPdkGFUTkOcJCIZy9l" crossorigin="anonymous"></script>
+  <script src="professional-desk.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone professional trading desk and AI valuation lab pages with advanced layout, charting, risk panels, and ChatGPT controls
- implement research and intelligence Netlify functions to aggregate Tiingo data and produce AI valuations with deterministic fallbacks
- introduce automated tests plus updated build/test scripts to validate Tiingo handling, research payloads, and AI responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d383f9e224832980efbbca16e3209e