### PR TITLE
Add AI intelligence desk pages with GPT integration and Tiingo test coverage

### DIFF
--- a/netlify/functions/aiAnalyst.js
+++ b/netlify/functions/aiAnalyst.js
@@ -1,0 +1,205 @@
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+
+const OPENAI_KEY_ALIASES = [
+  'OPENAI_API_KEY',
+  'OPENAI_KEY',
+  'GPT5_API_KEY',
+  'CHATGPT5_API_KEY',
+  'AI_ANALYST_KEY',
+];
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
+
+function pickOpenAiKey() {
+  for (const key of OPENAI_KEY_ALIASES) {
+    const value = (process.env?.[key] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+async function readJsonBody(request) {
+  try {
+    const text = await request.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    console.error('aiAnalyst invalid JSON body', err);
+    throw new Error('Request body must be valid JSON.');
+  }
+}
+
+function summariseIntel(intel) {
+  if (!intel || typeof intel !== 'object') return 'No supplemental intelligence provided.';
+  const snapshot = intel.snapshot || {};
+  const valuations = intel.valuations || {};
+  const events = Array.isArray(intel.events) ? intel.events.slice(0, 8) : [];
+  const documents = Array.isArray(intel.documents) ? intel.documents.slice(0, 8) : [];
+
+  return {
+    snapshot: {
+      sector: snapshot.sector || '',
+      industry: snapshot.industry || '',
+      country: snapshot.country || '',
+      marketCap: snapshot.marketCap || null,
+      revenueGrowth: snapshot.revenueGrowth || null,
+      ebitMargin: snapshot.ebitMargin || snapshot.operatingMargin || null,
+      returnOnEquity: snapshot.returnOnEquity || null,
+      freeCashFlow: snapshot.freeCashFlow || null,
+      netDebt: snapshot.netDebt || null,
+      currency: snapshot.currency || 'USD',
+    },
+    valuations: {
+      intrinsicValue: valuations.intrinsicValue || null,
+      marginOfSafety: valuations.marginOfSafety || null,
+      forwardPe: valuations.forwardPe || valuations.trailingPe || null,
+      evToEbitda: valuations.evToEbitda || null,
+      riskPremium: valuations.riskPremium || null,
+    },
+    events: events.map((event) => ({
+      type: event.type || 'Event',
+      headline: event.headline || '',
+      summary: event.summary || '',
+      publishedAt: event.publishedAt || '',
+    })),
+    documents: documents.map((doc) => ({
+      category: doc.category || 'Document',
+      title: doc.title || '',
+      summary: doc.summary || '',
+      publishedAt: doc.publishedAt || '',
+    })),
+  };
+}
+
+function buildPrompt(payload) {
+  const intelSummary = summariseIntel(payload?.intel);
+  const objectives = payload?.objectives?.focus || [];
+  const directives = payload?.objectives?.directives || '';
+  const symbol = payload?.symbol || 'Unknown';
+  const timeframe = payload?.timeframe || '1Y';
+  const priceSummary = payload?.priceSummary || {};
+
+  return `You are ChatGPT-5, an elite equity analyst. Produce a decisive fair value view.
+Requirements:
+- Respond strictly in JSON with keys narrative, valuation, checklist, meta.
+- Valuation must include fairValue (number), confidence (0-1), bias (Bullish/Bearish/Neutral), marginOfSafety (decimal), and catalysts (array of strings).
+- Checklist must include at least five bullet points with signal rating (Positive/Neutral/Negative).
+- Narrative should be concise paragraphs referencing catalysts, risks, and public filings when available.
+- Assume Tiingo market data is authoritative.
+
+Inputs:
+Symbol: ${symbol}
+Timeframe: ${timeframe}
+Price: ${priceSummary.lastPrice ?? 'unknown'}
+Objectives: ${objectives.join(', ') || 'standard valuation'}
+Directives: ${directives || 'None'}
+Intel: ${JSON.stringify(intelSummary)}
+`;
+}
+
+function fallbackResponse(symbol) {
+  return Response.json({
+    analysis: `ChatGPT-5 staging mode: Provide an OPENAI_API_KEY to activate live valuations for ${symbol}. The current build ships with a qualitative template you can extend once the key is configured.`,
+    valuation: {
+      fairValue: null,
+      confidence: 0.4,
+      bias: 'Neutral',
+      marginOfSafety: 0,
+    },
+    message: 'AI analyst operating with mock data. Configure OPENAI_API_KEY to enable live responses.',
+    mock: true,
+  }, { headers: corsHeaders });
+}
+
+function parseAiContent(content) {
+  if (!content || typeof content !== 'string') return null;
+  try {
+    return JSON.parse(content);
+  } catch (err) {
+    console.warn('aiAnalyst response was not valid JSON', content);
+    return { narrative: content };
+  }
+}
+
+export default async function aiAnalyst(request) {
+  if (request.method && request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+
+  let payload = {};
+  try {
+    payload = await readJsonBody(request);
+  } catch (err) {
+    return Response.json({ error: 'invalid_body', detail: err.message }, { status: 400, headers: corsHeaders });
+  }
+
+  const apiKey = pickOpenAiKey();
+  if (!apiKey) {
+    return fallbackResponse(payload?.symbol || 'the selected company');
+  }
+
+  const prompt = buildPrompt(payload);
+  const body = {
+    model: DEFAULT_MODEL,
+    temperature: 0.35,
+    response_format: { type: 'json_object' },
+    messages: [
+      {
+        role: 'system',
+        content: 'You are ChatGPT-5, a disciplined equity research analyst that writes institutional-grade briefs.',
+      },
+      { role: 'user', content: prompt },
+    ],
+  };
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      console.error('aiAnalyst upstream error', response.status, text);
+      throw new Error(`OpenAI responded with ${response.status}`);
+    }
+
+    let parsed = null;
+    try {
+      const parsedBody = JSON.parse(text);
+      const content = parsedBody?.choices?.[0]?.message?.content;
+      parsed = parseAiContent(content);
+    } catch (err) {
+      console.error('aiAnalyst: failed to parse response body', err);
+    }
+
+    const result = parsed || {};
+    return Response.json({
+      analysis: result.narrative || result.analysis || 'No analysis returned by ChatGPT-5.',
+      valuation: result.valuation || {},
+      checklist: result.checklist || [],
+      message: result?.meta?.message || 'ChatGPT-5 valuation complete.',
+      raw: result,
+    }, { headers: corsHeaders });
+  } catch (err) {
+    console.error('aiAnalyst fatal error', err);
+    return Response.json({
+      error: 'ai_request_failed',
+      detail: String(err),
+      analysis: 'ChatGPT-5 could not be reached. Please try again later.',
+      valuation: {},
+    }, { status: 502, headers: corsHeaders });
+  }
+}
+
+export const handler = async (event) => {
+  const url = event?.rawUrl || `https://${event?.headers?.host || 'example.org'}${event?.path || '/api/aiAnalyst'}`;
+  const request = new Request(url, { method: event?.httpMethod || 'POST', headers: event?.headers || {}, body: event?.body });
+  const response = await aiAnalyst(request);
+  const headers = {}; response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};
+

--- a/netlify/functions/companyIntel.js
+++ b/netlify/functions/companyIntel.js
@@ -1,0 +1,248 @@
+import { getTiingoToken } from './lib/env.js';
+
+const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
+const API_BASE = 'https://api.tiingo.com/';
+const DEFAULT_LIMIT = 200;
+
+const fallbackIntel = {
+  symbol: 'AAPL',
+  snapshot: {
+    currency: 'USD',
+    sector: 'Technology',
+    industry: 'Consumer Electronics',
+    marketCap: 2.5e12,
+    revenueGrowth: 0.08,
+    ebitMargin: 0.29,
+    freeCashFlow: 9.8e10,
+    returnOnEquity: 0.52,
+    netDebt: -5.5e10,
+    country: 'United States',
+  },
+  valuations: {
+    intrinsicValue: 215,
+    marginOfSafety: 0.12,
+    forwardPe: 21.3,
+    evToEbitda: 17.6,
+    riskPremium: 0.045,
+    alphaOutlook: 'Moderate Outperform',
+  },
+  events: [
+    {
+      type: 'Earnings',
+      headline: 'Apple posts resilient services growth despite hardware softness',
+      summary: 'Services revenue reached a new high while iPhone sales softened against macro headwinds.',
+      publishedAt: new Date(Date.now() - 12 * 24 * 60 * 60 * 1000).toISOString(),
+      url: 'https://example.com/earnings',
+      tags: ['Earnings', 'Services'],
+      severity: 'success',
+    },
+    {
+      type: 'Regulation',
+      headline: 'EU opens follow-on investigation into App Store payments',
+      summary: 'Regulators are reviewing pricing policies for digital goods following DMA enforcement.',
+      publishedAt: new Date(Date.now() - 32 * 24 * 60 * 60 * 1000).toISOString(),
+      url: 'https://example.com/regulation',
+      tags: ['Regulation', 'DMA'],
+      severity: 'warning',
+    },
+  ],
+  documents: [
+    {
+      title: 'Form 10-Q — Fiscal Q2 2025',
+      category: 'SEC Filing',
+      summary: 'Highlights resilience in subscription revenues and outlines share repurchase authorisation.',
+      publishedAt: new Date(Date.now() - 26 * 24 * 60 * 60 * 1000).toISOString(),
+      url: 'https://example.com/10q',
+      tags: ['Filing', 'Financials'],
+      impact: 'success',
+    },
+    {
+      title: 'WWDC Keynote Recap',
+      category: 'Corporate Event',
+      summary: 'Introduced on-device AI roadmap and new developer incentives.',
+      publishedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      url: 'https://example.com/wwdc',
+      tags: ['Product', 'AI'],
+      impact: 'success',
+    },
+  ],
+  fetchedAt: new Date().toISOString(),
+  source: 'fallback',
+  warning: 'Tiingo API key missing. Showing curated sample intelligence.',
+};
+
+async function fetchTiingo(path, token, params = {}) {
+  const url = new URL(path, API_BASE);
+  url.searchParams.set('token', token);
+  url.searchParams.set('limit', params.limit || DEFAULT_LIMIT);
+  Object.entries(params).forEach(([key, value]) => {
+    if (key === 'limit') return;
+    if (value === undefined || value === null || value === '') return;
+    url.searchParams.set(key, value);
+  });
+  const response = await fetch(url);
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Tiingo ${response.status}: ${detail.slice(0, 200)}`);
+  }
+  const text = await response.text();
+  return text ? JSON.parse(text) : [];
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function computeIntrinsicValue(snapshot, valuations) {
+  if (valuations?.intrinsicValue) return Number(valuations.intrinsicValue);
+  const earnings = toNumber(snapshot?.earningsPerShare) || toNumber(snapshot?.eps) || 0;
+  const growth = snapshot?.revenueGrowth ?? 0.05;
+  if (!earnings) return null;
+  return Number((earnings * (1 + growth) * 15).toFixed(2));
+}
+
+function determineAlphaOutlook(marginOfSafety) {
+  if (typeof marginOfSafety !== 'number') return 'Neutral';
+  if (marginOfSafety > 0.2) return 'Strong Outperform';
+  if (marginOfSafety > 0.1) return 'Moderate Outperform';
+  if (marginOfSafety < -0.1) return 'Underperform';
+  if (marginOfSafety < 0) return 'Hold';
+  return 'Neutral';
+}
+
+function normaliseSnapshot(symbol, rows = []) {
+  const latest = rows.at(-1) || rows[0] || {};
+  const currency = latest?.currency || latest?.priceCurrency || latest?.quoteCurrency || 'USD';
+  return {
+    symbol,
+    currency,
+    sector: latest?.sector || latest?.sectorCode || '',
+    industry: latest?.industry || latest?.industryCode || '',
+    marketCap: toNumber(latest?.marketCap || latest?.marketcap),
+    revenueGrowth: toNumber(latest?.revenueGrowth || latest?.revenueGrowth1Y || latest?.revenueGrowth3Y),
+    ebitMargin: toNumber(latest?.ebitdaMargin || latest?.operatingMargin || latest?.netMargin),
+    freeCashFlow: toNumber(latest?.freeCashFlow || latest?.freeCashFlowTTM),
+    returnOnEquity: toNumber(latest?.returnOnEquity || latest?.roe),
+    netDebt: toNumber(latest?.netDebt || latest?.totalDebt) || 0,
+    currentRatio: toNumber(latest?.currentRatio),
+    interestCoverage: toNumber(latest?.interestCoverage),
+    country: latest?.country || latest?.countryCode || '',
+    earningsPerShare: toNumber(latest?.eps || latest?.earningsPerShare),
+    closePrice: toNumber(latest?.closePrice || latest?.adjClose || latest?.price),
+  };
+}
+
+function normaliseValuations(snapshot, rows = []) {
+  const latest = rows.at(-1) || rows[0] || {};
+  const price = snapshot.closePrice || toNumber(latest?.closePrice) || null;
+  const valuations = {
+    trailingPe: toNumber(latest?.peRatio || latest?.trailingPERatio),
+    forwardPe: toNumber(latest?.forwardPe || latest?.forwardPERatio),
+    priceToSales: toNumber(latest?.priceToSales),
+    evToEbitda: toNumber(latest?.evToEbitda || latest?.evToEbitdaRatio),
+    riskPremium: toNumber(latest?.riskPremium || latest?.equityRiskPremium),
+  };
+  const intrinsic = computeIntrinsicValue(snapshot, valuations);
+  if (intrinsic) valuations.intrinsicValue = intrinsic;
+  if (intrinsic && price) {
+    valuations.marginOfSafety = Number(((intrinsic - price) / price).toFixed(4));
+  }
+  valuations.alphaOutlook = determineAlphaOutlook(valuations.marginOfSafety);
+  return valuations;
+}
+
+function mapNewsToEvents(news = []) {
+  return news.map((item) => ({
+    type: item?.categories?.[0] || item?.tags?.[0] || item?.source || 'News',
+    headline: item?.title || '',
+    summary: item?.description || '',
+    url: item?.url || '',
+    publishedAt: item?.publishedDate || item?.publishedUTC || item?.date || new Date().toISOString(),
+    tags: item?.tags || [],
+    severity: item?.sentimentScore != null
+      ? item.sentimentScore > 0.2 ? 'success' : item.sentimentScore < -0.2 ? 'danger' : 'warning'
+      : '',
+  }));
+}
+
+function extractDocuments(news = []) {
+  return news
+    .filter((item) => (item?.tags || []).some((tag) => /filing|sec|transcript/i.test(tag)))
+    .map((item) => ({
+      title: item.title || '',
+      category: (item.tags || []).find((tag) => /filing|sec/i.test(tag)) || 'Document',
+      summary: item.description || '',
+      url: item.url || '',
+      publishedAt: item.publishedDate || item.date || new Date().toISOString(),
+      tags: item.tags || [],
+      impact: item.sentimentScore != null
+        ? item.sentimentScore > 0.2 ? 'success' : item.sentimentScore < -0.2 ? 'danger' : 'warning'
+        : '',
+    }));
+}
+
+export default async function companyIntel(request) {
+  if (request.method && request.method !== 'GET') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+
+  const url = new URL(request.url);
+  const symbol = (url.searchParams.get('symbol') || '').trim().toUpperCase();
+  const exchange = (url.searchParams.get('exchange') || '').trim();
+
+  if (!symbol) {
+    return Response.json({ error: 'missing_symbol', detail: 'Query parameter "symbol" is required.' }, { status: 400, headers: corsHeaders });
+  }
+
+  const token = getTiingoToken();
+  if (!token) {
+    return Response.json({ ...fallbackIntel, symbol, exchange, source: 'fallback' }, { headers: corsHeaders });
+  }
+
+  try {
+    const [fundamentals, news] = await Promise.all([
+      fetchTiingo(`/tiingo/fundamentals/${encodeURIComponent(symbol)}/daily`, token, { limit: DEFAULT_LIMIT }),
+      fetchTiingo('/tiingo/news', token, { tickers: symbol, limit: 100 }),
+    ]);
+
+    const snapshot = normaliseSnapshot(symbol, Array.isArray(fundamentals) ? fundamentals : []);
+    const valuations = normaliseValuations(snapshot, Array.isArray(fundamentals) ? fundamentals : []);
+    const events = mapNewsToEvents(Array.isArray(news) ? news : []);
+    const documents = extractDocuments(Array.isArray(news) ? news : []);
+
+    return Response.json({
+      symbol,
+      exchange,
+      snapshot,
+      valuations,
+      events,
+      documents,
+      fetchedAt: new Date().toISOString(),
+      source: 'tiingo',
+    }, { headers: corsHeaders });
+  } catch (err) {
+    console.error('companyIntel error', err);
+    return Response.json({
+      ...fallbackIntel,
+      symbol,
+      exchange,
+      source: 'fallback',
+      warning: 'Tiingo request failed. Returning cached intelligence.',
+      detail: String(err),
+    }, { headers: corsHeaders });
+  }
+}
+
+export const handler = async (event) => {
+  const path = event?.path || '/api/companyIntel';
+  const host = event?.headers?.host || 'example.org';
+  const rawQuery = event?.rawQuery || event?.rawQueryString || '';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'GET';
+  const request = new Request(url, { method, headers: event?.headers || {}, body: event?.body });
+  const response = await companyIntel(request);
+  const headers = {}; response.headers.forEach((value, key) => { headers[key] = value; });
+  return { statusCode: response.status, headers, body: await response.text() };
+};
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "csv-parse": "^5.5.6",
         "rimraf": "^6.0.1",
         "shx": "^0.4.0",
+        "vitest": "^2.1.2",
         "xlsx": "^0.18.5"
       }
     },
@@ -19,6 +20,397 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -61,6 +453,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -99,6 +498,434 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/adler-32": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
@@ -135,6 +962,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -144,6 +981,16 @@
       "dependencies": {
         "fill-range": "^7.1.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -160,6 +1007,33 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/codepage": {
@@ -245,6 +1119,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -267,6 +1169,62 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/execa": {
@@ -358,6 +1316,16 @@
         "which": "bin/which"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -423,6 +1391,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -600,6 +1583,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
@@ -608,6 +1598,16 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -668,6 +1668,32 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/nice-try": {
@@ -761,6 +1787,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -772,6 +1822,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pump": {
@@ -870,6 +1949,48 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -963,6 +2084,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -974,6 +2102,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ssf": {
@@ -988,6 +2126,20 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -1116,6 +2268,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1127,6 +2323,155 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -1143,6 +2488,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/package.json
+++ b/package.json
@@ -4,15 +4,17 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf build",
-    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
+    "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r pro build/pro && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
     "start": "npx netlify-cli@latest dev",
-    "generate:symbols": "node scripts/build-symbols.mjs"
+    "generate:symbols": "node scripts/build-symbols.mjs",
+    "test": "vitest run"
   },
   "devDependencies": {
     "csv-parse": "^5.5.6",
     "cross-env": "^10.0.0",
     "rimraf": "^6.0.1",
     "shx": "^0.4.0",
+    "vitest": "^2.1.2",
     "xlsx": "^0.18.5"
   }
 }

--- a/pro/ai-desk.html
+++ b/pro/ai-desk.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Desk — Quantitative Research Terminal</title>
+  <link rel="stylesheet" href="../app.css">
+  <link rel="stylesheet" href="pro.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+</head>
+<body>
+  <div class="pro-shell">
+    <header class="pro-header">
+      <h1>AI Equity Intelligence Desk</h1>
+      <nav class="pro-nav">
+        <a href="ai-desk.html" class="active">AI Desk</a>
+        <a href="market-intel.html">Market Intel</a>
+        <a href="risk-lab.html">Risk Lab</a>
+        <a href="../index.html" target="_blank" rel="noopener">Legacy Terminal</a>
+      </nav>
+    </header>
+
+    <main class="pro-content">
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Symbol Discovery</h2>
+            <p class="pro-status" id="searchStatus">Start typing a ticker or company name to begin.</p>
+          </div>
+          <div class="actions">
+            <select class="pro-select" id="deskTimeframe">
+              <option value="1D">1 Day</option>
+              <option value="1W">1 Week</option>
+              <option value="1M">1 Month</option>
+              <option value="3M">3 Months</option>
+              <option value="6M">6 Months</option>
+              <option value="1Y" selected>1 Year</option>
+              <option value="3Y">3 Years</option>
+              <option value="5Y">5 Years</option>
+            </select>
+          </div>
+        </div>
+        <div style="position: relative;">
+          <input id="deskSearch" type="search" class="pro-input" placeholder="Search ticker or company e.g. NVDA, ASX:WOW" autocomplete="off">
+          <div id="deskSearchResults" class="pro-search-results" hidden></div>
+        </div>
+        <div class="pro-divider"></div>
+        <div class="pro-grid-2">
+          <div>
+            <h3 id="deskSelectedName">Apple Inc. — NASDAQ:AAPL</h3>
+            <div class="pro-chip-row" id="deskSnapshotChips"></div>
+            <div class="pro-metric-grid" id="deskHeadlineMetrics"></div>
+          </div>
+          <div>
+            <canvas id="deskChart" style="height:320px"></canvas>
+            <p class="pro-status" id="deskChartStatus"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>AI Fair Value & Narrative Engine</h2>
+            <p class="pro-status" id="aiStatus">Configure the objectives for the ChatGPT-5 analyst and request a valuation.</p>
+          </div>
+          <button class="pro-btn" id="aiRunButton">Run ChatGPT-5 Analyst</button>
+        </div>
+        <form id="aiObjectivesForm" class="pro-grid">
+          <label>
+            <span class="pro-subtitle">Focus Areas</span>
+            <select class="pro-select" id="aiFocus" multiple size="5">
+              <option value="valuation" selected>Intrinsic Valuation</option>
+              <option value="quality">Business Quality & Moat</option>
+              <option value="events">Catalysts & Events</option>
+              <option value="risk">Risk Scoring</option>
+              <option value="sentiment">Market Sentiment</option>
+              <option value="esg">ESG & Governance Signals</option>
+            </select>
+          </label>
+          <label>
+            <span class="pro-subtitle">Custom Directives</span>
+            <textarea class="pro-textarea" id="aiDirectives" placeholder="E.g. Emphasise balance sheet strength and cross-check with the latest 10-Q"></textarea>
+          </label>
+        </form>
+        <div class="pro-divider"></div>
+        <article id="aiResult" class="pro-scroll pro-status pro-empty">Awaiting analysis…</article>
+      </section>
+
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Key Drivers & Intelligence Stack</h2>
+            <p class="pro-status">ChatGPT-5 uses these contextual layers to support the valuation call.</p>
+          </div>
+        </div>
+        <div class="pro-grid-2">
+          <div>
+            <h3>Operational Snapshot</h3>
+            <div id="deskOperational" class="pro-metric-grid"></div>
+          </div>
+          <div>
+            <h3>Strategic Signals</h3>
+            <div id="deskStrategic" class="pro-metric-grid"></div>
+          </div>
+        </div>
+        <div class="pro-divider"></div>
+        <div class="pro-grid-2">
+          <div>
+            <h3>Event Timeline</h3>
+            <div id="deskEvents" class="pro-timeline pro-scroll"></div>
+          </div>
+          <div>
+            <h3>Critical Documents</h3>
+            <div id="deskDocuments" class="pro-timeline pro-scroll"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="./js/ai-desk.js"></script>
+</body>
+</html>

--- a/pro/js/ai-desk.js
+++ b/pro/js/ai-desk.js
@@ -1,0 +1,359 @@
+import {
+  searchSymbols,
+  fetchPriceSeries,
+  fetchCompanyIntel,
+  requestAiInsight,
+  formatCurrency,
+  formatNumber,
+  formatPercent,
+  formatDate,
+  debounce,
+  computeVolatility,
+  computeMaxDrawdown,
+  compoundGrowthRate,
+} from './apiClient.js';
+import { buildLineChart } from './charting.js';
+
+const timeframeToSeries = {
+  '1D': { mode: 'intraday', interval: '5min', limit: 78 },
+  '1W': { mode: 'intraday', interval: '30min', limit: 65 },
+  '1M': { mode: 'eod', limit: 30 },
+  '3M': { mode: 'eod', limit: 90 },
+  '6M': { mode: 'eod', limit: 180 },
+  '1Y': { mode: 'eod', limit: 365 },
+  '3Y': { mode: 'eod', limit: 365 * 3 },
+  '5Y': { mode: 'eod', limit: 365 * 5 },
+};
+
+const state = {
+  symbol: 'AAPL',
+  name: 'Apple Inc.',
+  exchange: 'XNAS',
+  timeframe: '1Y',
+  chart: null,
+  series: [],
+  intel: null,
+  aiInFlight: false,
+  aiResult: null,
+};
+
+const dom = {};
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function setStatus(el, text, tone = '') {
+  if (!el) return;
+  el.textContent = text;
+  el.classList.remove('ok', 'warn', 'error');
+  if (tone) el.classList.add(tone);
+}
+
+function renderMetrics(container, metrics = []) {
+  if (!container) return;
+  if (!metrics.length) {
+    container.innerHTML = '<p class="pro-empty">No data available.</p>';
+    return;
+  }
+  container.innerHTML = metrics
+    .map((metric) => `
+      <div class="pro-metric">
+        <span class="label">${metric.label}</span>
+        <span class="value">${metric.value}</span>
+        ${metric.detail ? `<span class="pro-status">${metric.detail}</span>` : ''}
+      </div>
+    `)
+    .join('');
+}
+
+function renderTimeline(container, items = [], emptyMessage = 'No recent items recorded.') {
+  if (!container) return;
+  if (!items.length) {
+    container.innerHTML = `<div class="pro-empty">${emptyMessage}</div>`;
+    return;
+  }
+  container.innerHTML = items
+    .map((item) => `
+      <article class="pro-timeline-item">
+        <div class="pro-chip-row">
+          <span class="pro-chip ${item.tone || ''}">${item.type || 'Update'}</span>
+          ${item.tags?.map((tag) => `<span class="pro-chip">${tag}</span>`).join('') || ''}
+        </div>
+        <strong>${item.headline || item.title}</strong>
+        <p>${item.summary || ''}</p>
+        <p class="pro-status">${formatDate(item.publishedAt)} — <a href="${item.url}" target="_blank" rel="noopener">Source</a></p>
+      </article>
+    `)
+    .join('');
+}
+
+async function updateChart() {
+  const canvas = dom.chart;
+  if (!canvas) return;
+  if (!state.series.length) {
+    setStatus(dom.chartStatus, 'No pricing data available for the selected timeframe.', 'warn');
+    canvas.replaceWith(canvas.cloneNode(true));
+    dom.chart = $('deskChart');
+    return;
+  }
+  setStatus(dom.chartStatus, '', '');
+  state.chart = buildLineChart(canvas, state.series);
+}
+
+function buildHeadlineMetrics() {
+  const latest = state.series.at(-1);
+  const first = state.series[0];
+  const currency = state.intel?.snapshot?.currency || 'USD';
+  const price = formatCurrency(Number(latest?.close ?? latest?.price ?? 0), currency);
+  const change = latest && first && Number(first.close) > 0
+    ? ((latest.close - first.close) / first.close)
+    : 0;
+  const vol = computeVolatility(state.series);
+  const drawdown = computeMaxDrawdown(state.series);
+  const cagr = compoundGrowthRate(state.series);
+
+  return [
+    { label: 'Last Price', value: price },
+    { label: 'Period Change', value: formatPercent(change || 0) },
+    { label: 'Annualised Volatility', value: formatPercent(vol || 0) },
+    { label: 'Max Drawdown', value: formatPercent(drawdown || 0) },
+    { label: 'Compound Growth', value: formatPercent(cagr || 0) },
+  ];
+}
+
+function renderSnapshotChips() {
+  const container = dom.snapshotChips;
+  if (!container) return;
+  const chips = [];
+  const { intel } = state;
+  if (intel?.snapshot?.sector) {
+    chips.push(`<span class="pro-chip">${intel.snapshot.sector}</span>`);
+  }
+  if (intel?.snapshot?.industry) {
+    chips.push(`<span class="pro-chip">${intel.snapshot.industry}</span>`);
+  }
+  if (intel?.snapshot?.marketCap) {
+    chips.push(`<span class="pro-chip">Mkt Cap ${formatNumber(intel.snapshot.marketCap, { maximumFractionDigits: 0 })}</span>`);
+  }
+  if (intel?.snapshot?.country) {
+    chips.push(`<span class="pro-chip">${intel.snapshot.country}</span>`);
+  }
+  container.innerHTML = chips.join('');
+}
+
+function renderOperationalMetrics() {
+  const block = [];
+  const snap = state.intel?.snapshot;
+  if (!snap) return block;
+  block.push({ label: 'Revenue Growth', value: formatPercent(snap.revenueGrowth ?? 0) });
+  block.push({ label: 'EBIT Margin', value: formatPercent(snap.ebitMargin ?? 0) });
+  block.push({ label: 'Free Cash Flow', value: formatCurrency(snap.freeCashFlow ?? 0, snap.currency) });
+  block.push({ label: 'Return on Equity', value: formatPercent(snap.returnOnEquity ?? 0) });
+  block.push({ label: 'Net Debt', value: formatCurrency(snap.netDebt ?? 0, snap.currency) });
+  block.push({ label: 'Liquidity Ratio', value: formatNumber(snap.currentRatio ?? 0, { maximumFractionDigits: 2 }) });
+  return block;
+}
+
+function renderStrategicMetrics() {
+  const metrics = [];
+  const valuations = state.intel?.valuations;
+  if (!valuations) return metrics;
+  metrics.push({ label: 'Intrinsic Value', value: formatCurrency(valuations.intrinsicValue ?? 0, state.intel?.snapshot?.currency) });
+  metrics.push({ label: 'Margin of Safety', value: formatPercent(valuations.marginOfSafety ?? 0) });
+  metrics.push({ label: 'Forward PE', value: formatNumber(valuations.forwardPe ?? valuations.trailingPe ?? 0, { maximumFractionDigits: 1 }) });
+  metrics.push({ label: 'EV / EBITDA', value: formatNumber(valuations.evToEbitda ?? 0, { maximumFractionDigits: 1 }) });
+  metrics.push({ label: 'Alpha Outlook', value: valuations.alphaOutlook || 'Neutral' });
+  metrics.push({ label: 'Risk Premium', value: formatPercent(valuations.riskPremium ?? 0) });
+  return metrics;
+}
+
+function renderDocuments(documents = []) {
+  return documents.map((doc) => ({
+    type: doc.category || 'Filing',
+    tone: doc.impact || '',
+    headline: doc.title,
+    summary: doc.summary || '',
+    publishedAt: doc.publishedAt,
+    url: doc.url,
+    tags: doc.tags,
+  }));
+}
+
+function renderEvents(events = []) {
+  return events.map((event) => ({
+    type: event.type || 'Event',
+    tone: event.severity || '',
+    headline: event.headline,
+    summary: event.summary,
+    publishedAt: event.publishedAt,
+    url: event.url,
+    tags: event.tags,
+  }));
+}
+
+async function loadSymbol(symbol, opts = {}) {
+  state.symbol = symbol || state.symbol;
+  state.exchange = opts.exchange || state.exchange;
+  state.name = opts.name || state.name;
+  const label = `${state.name || symbol} — ${state.exchange || ''}:${symbol}`;
+  dom.selectedName.textContent = label;
+  try {
+    setStatus(dom.searchStatus, 'Loading price action…');
+    const tfConfig = timeframeToSeries[state.timeframe] || timeframeToSeries['1Y'];
+    const { series, warning } = await fetchPriceSeries(state.symbol, { ...tfConfig, exchange: state.exchange });
+    state.series = series || [];
+    if (warning) setStatus(dom.chartStatus, warning, 'warn');
+    renderMetrics(dom.headlineMetrics, buildHeadlineMetrics());
+    await updateChart();
+    setStatus(dom.searchStatus, `Loaded ${state.symbol} market data.`, 'ok');
+  } catch (err) {
+    console.error(err);
+    setStatus(dom.searchStatus, err.message || 'Failed to load market data.', 'error');
+  }
+
+  try {
+    setStatus(dom.aiStatus, 'Refreshing corporate intelligence layers…');
+    state.intel = await fetchCompanyIntel(state.symbol, state.exchange);
+    renderSnapshotChips();
+    renderMetrics(dom.operational, renderOperationalMetrics());
+    renderMetrics(dom.strategic, renderStrategicMetrics());
+    renderTimeline(dom.events, renderEvents(state.intel?.events), 'No strategic events in the past quarter.');
+    renderTimeline(dom.documents, renderDocuments(state.intel?.documents), 'No high-priority filings or transcripts detected.');
+    setStatus(dom.aiStatus, 'ChatGPT-5 will combine valuation science with the intelligence layers above.');
+  } catch (err) {
+    console.error(err);
+    setStatus(dom.aiStatus, err.message || 'Failed to load company intelligence.', 'warn');
+  }
+}
+
+async function handleAiRequest() {
+  if (state.aiInFlight) return;
+  state.aiInFlight = true;
+  dom.aiRunButton.disabled = true;
+  setStatus(dom.aiStatus, 'ChatGPT-5 is reviewing filings, events, and valuation drivers…');
+  const focusSelect = dom.aiFocus;
+  const selected = Array.from(focusSelect?.selectedOptions || []).map((opt) => opt.value);
+  const directives = dom.aiDirectives.value.trim();
+
+  try {
+    const pricePoint = state.series.at(-1);
+    const priceSummary = {
+      lastPrice: pricePoint?.close ?? pricePoint?.price ?? null,
+      timeframe: state.timeframe,
+      change: buildHeadlineMetrics()?.[1]?.value || '',
+    };
+
+    const payload = await requestAiInsight({
+      symbol: state.symbol,
+      timeframe: state.timeframe,
+      objectives: { focus: selected, directives },
+      intel: state.intel,
+      priceSummary,
+    });
+    state.aiResult = payload;
+    dom.aiResult.classList.remove('pro-empty');
+    dom.aiResult.innerHTML = `
+      <div class="pro-chip-row">
+        <span class="pro-chip success">True Value ${payload?.valuation?.fairValue ? formatCurrency(payload.valuation.fairValue, state.intel?.snapshot?.currency) : 'Unavailable'}</span>
+        <span class="pro-chip">Confidence ${formatPercent(payload?.valuation?.confidence ?? 0)}</span>
+        <span class="pro-chip">Bias ${payload?.valuation?.bias ?? 'Neutral'}</span>
+      </div>
+      <div>${(payload?.analysis || '').replace(/\n/g, '<br>')}</div>
+    `;
+    setStatus(dom.aiStatus, payload?.message || 'AI valuation completed.', 'ok');
+  } catch (err) {
+    console.error(err);
+    dom.aiResult.classList.add('pro-empty');
+    dom.aiResult.textContent = err.message || 'The analyst could not complete the request.';
+    setStatus(dom.aiStatus, err.message || 'ChatGPT-5 could not evaluate the company.', 'error');
+  } finally {
+    state.aiInFlight = false;
+    dom.aiRunButton.disabled = false;
+  }
+}
+
+async function handleSearchInput(value) {
+  const query = value.trim();
+  if (!query) {
+    dom.searchResults.hidden = true;
+    dom.searchResults.innerHTML = '';
+    return;
+  }
+  setStatus(dom.searchStatus, 'Scanning global exchanges…');
+  try {
+    const results = await searchSymbols(query, { limit: 15 });
+    if (!results.length) {
+      dom.searchResults.hidden = true;
+      dom.searchResults.innerHTML = '';
+      setStatus(dom.searchStatus, 'No matches found.', 'warn');
+      return;
+    }
+    dom.searchResults.hidden = false;
+    dom.searchResults.innerHTML = results
+      .map((item) => `
+        <button type="button" data-symbol="${item.symbol}" data-exchange="${item.mic || item.exchange}" data-name="${item.name || item.symbol}">
+          <span style="flex:1 1 auto;">
+            <strong>${item.symbol}</strong> — ${item.name || ''}
+          </span>
+          <span>${item.exchange || item.mic || ''}</span>
+        </button>
+      `)
+      .join('');
+  } catch (err) {
+    dom.searchResults.hidden = true;
+    setStatus(dom.searchStatus, err.message || 'Search failed.', 'error');
+  }
+}
+
+function attachListeners() {
+  dom.search.addEventListener('input', debounce((event) => handleSearchInput(event.target.value), 250));
+  dom.searchResults.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-symbol]');
+    if (!button) return;
+    dom.searchResults.hidden = true;
+    const symbol = button.dataset.symbol;
+    const exchange = button.dataset.exchange;
+    const name = button.dataset.name;
+    dom.search.value = symbol;
+    loadSymbol(symbol, { exchange, name });
+  });
+  dom.timeframe.addEventListener('change', (event) => {
+    state.timeframe = event.target.value;
+    loadSymbol(state.symbol);
+  });
+  dom.aiRunButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    handleAiRequest();
+  });
+}
+
+function captureDom() {
+  dom.search = $('deskSearch');
+  dom.searchResults = $('deskSearchResults');
+  dom.searchStatus = $('searchStatus');
+  dom.selectedName = $('deskSelectedName');
+  dom.chart = $('deskChart');
+  dom.chartStatus = $('deskChartStatus');
+  dom.snapshotChips = $('deskSnapshotChips');
+  dom.headlineMetrics = $('deskHeadlineMetrics');
+  dom.operational = $('deskOperational');
+  dom.strategic = $('deskStrategic');
+  dom.events = $('deskEvents');
+  dom.documents = $('deskDocuments');
+  dom.timeframe = $('deskTimeframe');
+  dom.aiStatus = $('aiStatus');
+  dom.aiRunButton = $('aiRunButton');
+  dom.aiResult = $('aiResult');
+  dom.aiFocus = $('aiFocus');
+  dom.aiDirectives = $('aiDirectives');
+}
+
+async function bootstrap() {
+  captureDom();
+  attachListeners();
+  await loadSymbol(state.symbol, { exchange: state.exchange, name: state.name });
+}
+
+document.addEventListener('DOMContentLoaded', bootstrap);
+

--- a/pro/js/apiClient.js
+++ b/pro/js/apiClient.js
@@ -1,0 +1,198 @@
+const DEFAULT_HEADERS = { 'content-type': 'application/json' };
+const BASE_PATH = '';
+
+const errorMessages = {
+  network: 'We were unable to reach the market data service. Please check your connection and try again.',
+  generic: 'The trading desk encountered an unexpected issue. Please retry in a moment.',
+};
+
+async function parseJsonResponse(resp) {
+  if (!resp) throw new Error('Response missing');
+  const text = await resp.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    console.error('Failed to parse JSON payload', err, text.slice(0, 200));
+    throw new Error('Invalid response received from the server.');
+  }
+}
+
+function buildUrl(path, params = {}) {
+  const url = new URL(path, window.location.origin);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    url.searchParams.set(key, value);
+  });
+  return url;
+}
+
+async function safeFetch(url, init) {
+  try {
+    const resp = await fetch(url, init);
+    if (!resp.ok) {
+      const message = await resp.text();
+      throw new Error(message || `Request failed with ${resp.status}`);
+    }
+    return resp;
+  } catch (err) {
+    console.error('API client fetch failed', err);
+    throw new Error(errorMessages.network);
+  }
+}
+
+export async function searchSymbols(query, { exchange = '', limit = 15 } = {}) {
+  if (!query || query.trim().length < 1) return [];
+  const url = buildUrl(`${BASE_PATH}/.netlify/functions/search`, { q: query.trim(), exchange, limit });
+  const resp = await safeFetch(url);
+  const payload = await parseJsonResponse(resp);
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+export async function fetchPriceSeries(symbol, { mode = 'eod', interval = '1day', limit = 120, exchange = '' } = {}) {
+  const params = { symbol, limit };
+  if (mode === 'intraday') {
+    params.kind = 'intraday';
+    params.interval = interval;
+  } else if (mode === 'intraday_latest') {
+    params.kind = 'intraday_latest';
+  } else if (mode === 'eod_latest') {
+    params.kind = 'eod_latest';
+  } else {
+    params.kind = 'eod';
+  }
+  if (exchange) params.exchange = exchange;
+  const url = buildUrl(`${BASE_PATH}/.netlify/functions/tiingo`, params);
+  const resp = await safeFetch(url);
+  const payload = await parseJsonResponse(resp);
+  return {
+    series: Array.isArray(payload?.data) ? payload.data : [],
+    warning: payload?.warning || '',
+    raw: payload,
+  };
+}
+
+export async function fetchCompanyIntel(symbol, exchange = '') {
+  const url = buildUrl(`${BASE_PATH}/.netlify/functions/companyIntel`, { symbol, exchange });
+  const resp = await safeFetch(url);
+  const payload = await parseJsonResponse(resp);
+  return payload;
+}
+
+export async function requestAiInsight({ symbol, timeframe, objectives, intel, priceSummary }) {
+  const url = `${BASE_PATH}/.netlify/functions/aiAnalyst`;
+  const body = JSON.stringify({ symbol, timeframe, objectives, intel, priceSummary });
+  const resp = await safeFetch(url, { method: 'POST', headers: DEFAULT_HEADERS, body });
+  const payload = await parseJsonResponse(resp);
+  return payload;
+}
+
+export function formatCurrency(value, currency = 'USD') {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  try {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: value >= 100 ? 0 : 2 }).format(value);
+  } catch (err) {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+  }
+}
+
+export function formatNumber(value, options = {}) {
+  if (value === undefined || value === null || Number.isNaN(Number(value))) return '—';
+  const { maximumFractionDigits = 2, minimumFractionDigits, style } = options;
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits, minimumFractionDigits, style }).format(value);
+}
+
+export function formatPercent(value, fractionDigits = 2) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  return `${(value * 100).toFixed(fractionDigits)}%`;
+}
+
+export function formatDate(value) {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString(undefined, { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  } catch (err) {
+    return value;
+  }
+}
+
+export function debounce(fn, delay = 300) {
+  let timer = null;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}
+
+export function chunkArray(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+export function computeReturns(series) {
+  const closes = series.map((point) => Number(point?.close ?? point?.price ?? 0)).filter((v) => Number.isFinite(v));
+  const out = [];
+  for (let i = 1; i < closes.length; i += 1) {
+    const prev = closes[i - 1];
+    const current = closes[i];
+    if (prev > 0) out.push((current - prev) / prev);
+  }
+  return out;
+}
+
+export function computeVolatility(series, periodsPerYear = 252) {
+  const returns = computeReturns(series);
+  if (!returns.length) return 0;
+  const avg = returns.reduce((sum, v) => sum + v, 0) / returns.length;
+  const variance = returns.reduce((sum, v) => sum + (v - avg) ** 2, 0) / returns.length;
+  return Math.sqrt(variance * periodsPerYear);
+}
+
+export function computeMaxDrawdown(series) {
+  let peak = -Infinity;
+  let maxDrawdown = 0;
+  series.forEach((point) => {
+    const price = Number(point?.close ?? point?.price ?? 0);
+    if (!Number.isFinite(price)) return;
+    if (price > peak) peak = price;
+    if (peak > 0) {
+      const drawdown = (price - peak) / peak;
+      if (drawdown < maxDrawdown) maxDrawdown = drawdown;
+    }
+  });
+  return Math.abs(maxDrawdown);
+}
+
+export function movingAverage(series, window = 20) {
+  const closes = series.map((point) => Number(point?.close ?? point?.price ?? 0)).filter((v) => Number.isFinite(v));
+  if (closes.length < window) return [];
+  const out = [];
+  for (let i = window - 1; i < closes.length; i += 1) {
+    const slice = closes.slice(i - window + 1, i + 1);
+    const avg = slice.reduce((sum, v) => sum + v, 0) / slice.length;
+    out.push({ index: i, value: avg });
+  }
+  return out;
+}
+
+export function compoundGrowthRate(series) {
+  if (!series.length) return 0;
+  const first = Number(series[0]?.close ?? series[0]?.price);
+  const last = Number(series[series.length - 1]?.close ?? series[series.length - 1]?.price);
+  if (!Number.isFinite(first) || !Number.isFinite(last) || first <= 0) return 0;
+  const periods = series.length - 1;
+  if (periods <= 0) return 0;
+  return (last / first) ** (1 / periods) - 1;
+}
+
+export function formatMillions(value, currency = 'USD') {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  const millions = value / 1_000_000;
+  return `${formatCurrency(millions, currency)}`.replace('$', '$') + 'M';
+}
+

--- a/pro/js/charting.js
+++ b/pro/js/charting.js
@@ -1,0 +1,96 @@
+import { formatDate, formatNumber } from './apiClient.js';
+
+const DEFAULT_CHART_OPTIONS = {
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { intersect: false, mode: 'index' },
+  scales: {
+    x: {
+      ticks: {
+        color: 'rgba(255,255,255,0.6)',
+        maxRotation: 0,
+        autoSkip: true,
+        maxTicksLimit: 8,
+      },
+      grid: { color: 'rgba(255,255,255,0.08)' },
+    },
+    y: {
+      ticks: {
+        color: 'rgba(255,255,255,0.6)',
+        callback(value) {
+          return formatNumber(value, { maximumFractionDigits: 2 });
+        },
+      },
+      grid: { color: 'rgba(255,255,255,0.08)' },
+    },
+  },
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label(context) {
+          if (!context?.parsed?.y) return '';
+          return `Price: ${formatNumber(context.parsed.y, { maximumFractionDigits: 2 })}`;
+        },
+        title(points) {
+          if (!points?.length) return '';
+          const point = points[0];
+          return formatDate(point.raw?.date || point.label);
+        },
+      },
+    },
+  },
+};
+
+export function buildLineChart(canvas, series, options = {}) {
+  if (!canvas) return null;
+  const labels = series.map((point) => point?.date || '');
+  const prices = series.map((point) => Number(point?.close ?? point?.price ?? point?.last ?? 0));
+  const dataset = {
+    label: 'Price',
+    data: series.map((point, index) => ({ x: labels[index], y: prices[index], date: point?.date })),
+    borderColor: 'rgba(63, 140, 255, 1)',
+    borderWidth: 2,
+    tension: 0.25,
+    fill: {
+      target: 'origin',
+      above: 'rgba(63, 140, 255, 0.18)',
+    },
+    pointRadius: 0,
+  };
+  const config = {
+    type: 'line',
+    data: { labels, datasets: [dataset, ...(options.extraDatasets || [])] },
+    options: {
+      ...DEFAULT_CHART_OPTIONS,
+      ...options.chart,
+      scales: {
+        ...DEFAULT_CHART_OPTIONS.scales,
+        ...(options.chart?.scales || {}),
+      },
+    },
+  };
+
+  if (canvas.__chartist) {
+    canvas.__chartist.destroy();
+  }
+  const chart = new window.Chart(canvas, config);
+  canvas.__chartist = chart;
+  return chart;
+}
+
+export function overlaySeriesOnChart(chart, seriesList) {
+  if (!chart) return;
+  const baseDataset = chart.data.datasets[0];
+  const overlays = seriesList.map(({ label, series, color }) => ({
+    label,
+    data: series.map((point, index) => ({ x: point?.date || index, y: Number(point?.close ?? point?.price ?? 0) })),
+    borderColor: color || 'rgba(239, 83, 80, 0.8)',
+    borderWidth: 1.5,
+    tension: 0.2,
+    pointRadius: 0,
+  }));
+  chart.data.datasets = [baseDataset, ...overlays];
+  chart.update();
+}
+

--- a/pro/js/market-intel.js
+++ b/pro/js/market-intel.js
@@ -1,0 +1,235 @@
+import {
+  searchSymbols,
+  fetchCompanyIntel,
+  requestAiInsight,
+  formatCurrency,
+  formatPercent,
+  formatNumber,
+  formatDate,
+  debounce,
+} from './apiClient.js';
+
+const state = {
+  symbol: 'AAPL',
+  exchange: 'XNAS',
+  scopeDays: 120,
+  intel: null,
+  aiInFlight: false,
+};
+
+const dom = {};
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function setStatus(el, text, tone = '') {
+  if (!el) return;
+  el.textContent = text;
+  el.classList.remove('ok', 'warn', 'error');
+  if (tone) el.classList.add(tone);
+}
+
+function withinScope(dateStr) {
+  if (!dateStr) return true;
+  const eventDate = new Date(dateStr).getTime();
+  if (Number.isNaN(eventDate)) return true;
+  const cutoff = Date.now() - state.scopeDays * 24 * 60 * 60 * 1000;
+  return eventDate >= cutoff;
+}
+
+function buildEventTimeline(events = []) {
+  return events
+    .filter((event) => withinScope(event.publishedAt))
+    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))
+    .map((event) => `
+      <article class="pro-timeline-item">
+        <div class="pro-chip-row">
+          <span class="pro-chip ${event.severity || ''}">${event.type || 'Event'}</span>
+          ${event.tags?.map((tag) => `<span class="pro-chip">${tag}</span>`).join('') || ''}
+        </div>
+        <strong>${event.headline}</strong>
+        <p>${event.summary || ''}</p>
+        <p class="pro-status">${formatDate(event.publishedAt)} — <a href="${event.url}" target="_blank" rel="noopener">View source</a></p>
+      </article>
+    `)
+    .join('');
+}
+
+function buildDocumentList(documents = []) {
+  return documents
+    .filter((doc) => withinScope(doc.publishedAt))
+    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))
+    .map((doc) => `
+      <article class="pro-timeline-item">
+        <div class="pro-chip-row">
+          <span class="pro-chip">${doc.category || 'Document'}</span>
+          ${doc.tags?.map((tag) => `<span class="pro-chip">${tag}</span>`).join('') || ''}
+        </div>
+        <strong>${doc.title}</strong>
+        <p>${doc.summary || ''}</p>
+        <p class="pro-status">${formatDate(doc.publishedAt)} — <a href="${doc.url}" target="_blank" rel="noopener">Open</a></p>
+      </article>
+    `)
+    .join('');
+}
+
+function renderMetrics(container, metrics = []) {
+  if (!container) return;
+  if (!metrics.length) {
+    container.innerHTML = '<p class="pro-empty">No fundamentals available from Tiingo yet.</p>';
+    return;
+  }
+  container.innerHTML = metrics
+    .map((metric) => `
+      <div class="pro-metric">
+        <span class="label">${metric.label}</span>
+        <span class="value">${metric.value}</span>
+        ${metric.detail ? `<span class="pro-status">${metric.detail}</span>` : ''}
+      </div>
+    `)
+    .join('');
+}
+
+function buildFinancialMetrics(snapshot) {
+  if (!snapshot) return [];
+  return [
+    { label: 'Revenue Growth', value: formatPercent(snapshot.revenueGrowth ?? 0) },
+    { label: 'Gross Margin', value: formatPercent(snapshot.grossMargin ?? 0) },
+    { label: 'Operating Margin', value: formatPercent(snapshot.operatingMargin ?? 0) },
+    { label: 'Free Cash Flow', value: formatCurrency(snapshot.freeCashFlow ?? 0, snapshot.currency) },
+    { label: 'Net Debt', value: formatCurrency(snapshot.netDebt ?? 0, snapshot.currency) },
+    { label: 'Interest Coverage', value: formatNumber(snapshot.interestCoverage ?? 0, { maximumFractionDigits: 2 }) },
+  ];
+}
+
+function buildValuationMetrics(valuations = {}, snapshot = {}) {
+  return [
+    { label: 'Intrinsic Value', value: formatCurrency(valuations.intrinsicValue ?? 0, snapshot.currency) },
+    { label: 'Margin of Safety', value: formatPercent(valuations.marginOfSafety ?? 0) },
+    { label: 'Forward PE', value: formatNumber(valuations.forwardPe ?? valuations.trailingPe ?? 0, { maximumFractionDigits: 1 }) },
+    { label: 'Price to Sales', value: formatNumber(valuations.priceToSales ?? 0, { maximumFractionDigits: 2 }) },
+    { label: 'EV / EBITDA', value: formatNumber(valuations.evToEbitda ?? 0, { maximumFractionDigits: 1 }) },
+    { label: 'Risk Premium', value: formatPercent(valuations.riskPremium ?? 0) },
+  ];
+}
+
+async function runAiNarrative() {
+  if (state.aiInFlight) return;
+  if (!state.intel) return;
+  state.aiInFlight = true;
+  setStatus(dom.aiSummary, 'ChatGPT-5 is synthesising the last 120 days of public intelligence…');
+  dom.aiNarrative.classList.add('pro-empty');
+  dom.aiNarrative.textContent = 'Generating narrative…';
+
+  try {
+    const payload = await requestAiInsight({
+      symbol: state.symbol,
+      timeframe: `${state.scopeDays}d-intel`,
+      objectives: { focus: ['events', 'risk', 'sentiment'], directives: 'Deliver a concise intelligence brief with risk hierarchy.' },
+      intel: state.intel,
+      priceSummary: null,
+    });
+    dom.aiNarrative.classList.remove('pro-empty');
+    dom.aiNarrative.innerHTML = (payload?.analysis || '').replace(/\n/g, '<br>');
+    setStatus(dom.aiSummary, payload?.message || 'AI synthesis complete.', 'ok');
+  } catch (err) {
+    console.error(err);
+    dom.aiNarrative.classList.add('pro-empty');
+    dom.aiNarrative.textContent = err.message || 'Unable to synthesise intelligence.';
+    setStatus(dom.aiSummary, err.message || 'AI synthesis failed.', 'error');
+  } finally {
+    state.aiInFlight = false;
+  }
+}
+
+async function loadSymbol(symbol, opts = {}) {
+  state.symbol = symbol || state.symbol;
+  state.exchange = opts.exchange || state.exchange;
+  setStatus(dom.status, `Loading corporate intelligence for ${state.symbol}…`);
+  dom.search.value = state.symbol;
+  dom.searchResults.hidden = true;
+  try {
+    const intel = await fetchCompanyIntel(state.symbol, state.exchange);
+    state.intel = intel;
+    const events = intel?.events || [];
+    const documents = intel?.documents || [];
+    dom.timeline.innerHTML = buildEventTimeline(events) || '<div class="pro-empty">No notable events in scope.</div>';
+    dom.documents.innerHTML = buildDocumentList(documents) || '<div class="pro-empty">No high-priority filings.</div>';
+    renderMetrics(dom.financials, buildFinancialMetrics(intel?.snapshot));
+    renderMetrics(dom.valuation, buildValuationMetrics(intel?.valuations, intel?.snapshot));
+    setStatus(dom.status, `Loaded ${state.symbol} governance stack.`, 'ok');
+    runAiNarrative();
+  } catch (err) {
+    console.error(err);
+    setStatus(dom.status, err.message || 'Unable to load company intelligence.', 'error');
+  }
+}
+
+async function handleSearchInput(value) {
+  const query = value.trim();
+  if (!query) {
+    dom.searchResults.hidden = true;
+    dom.searchResults.innerHTML = '';
+    return;
+  }
+  setStatus(dom.status, 'Querying smart symbol universe…');
+  try {
+    const results = await searchSymbols(query, { limit: 15 });
+    if (!results.length) {
+      dom.searchResults.hidden = true;
+      setStatus(dom.status, 'No matches found.', 'warn');
+      return;
+    }
+    dom.searchResults.hidden = false;
+    dom.searchResults.innerHTML = results
+      .map((item) => `
+        <button type="button" data-symbol="${item.symbol}" data-exchange="${item.mic || item.exchange}">
+          <span style="flex:1 1 auto;"><strong>${item.symbol}</strong> — ${item.name || ''}</span>
+          <span>${item.exchange || item.mic || ''}</span>
+        </button>
+      `)
+      .join('');
+  } catch (err) {
+    dom.searchResults.hidden = true;
+    setStatus(dom.status, err.message || 'Search failed.', 'error');
+  }
+}
+
+function attachListeners() {
+  dom.search.addEventListener('input', debounce((event) => handleSearchInput(event.target.value), 250));
+  dom.searchResults.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-symbol]');
+    if (!button) return;
+    loadSymbol(button.dataset.symbol, { exchange: button.dataset.exchange });
+  });
+  dom.scope.addEventListener('change', (event) => {
+    state.scopeDays = Number(event.target.value) || 120;
+    if (state.intel) {
+      dom.timeline.innerHTML = buildEventTimeline(state.intel.events) || '<div class="pro-empty">No notable events in scope.</div>';
+      dom.documents.innerHTML = buildDocumentList(state.intel.documents) || '<div class="pro-empty">No high-priority filings.</div>';
+    }
+  });
+}
+
+function captureDom() {
+  dom.search = $('intelSearch');
+  dom.searchResults = $('intelSearchResults');
+  dom.status = $('intelStatus');
+  dom.timeline = $('intelTimeline');
+  dom.documents = $('intelDocuments');
+  dom.financials = $('intelFinancials');
+  dom.valuation = $('intelValuation');
+  dom.scope = $('intelScope');
+  dom.aiSummary = $('intelAiSummary');
+  dom.aiNarrative = $('intelAiNarrative');
+}
+
+async function bootstrap() {
+  captureDom();
+  attachListeners();
+  await loadSymbol(state.symbol, { exchange: state.exchange });
+}
+
+document.addEventListener('DOMContentLoaded', bootstrap);
+

--- a/pro/js/risk-lab.js
+++ b/pro/js/risk-lab.js
@@ -1,0 +1,305 @@
+import {
+  searchSymbols,
+  fetchPriceSeries,
+  formatCurrency,
+  formatPercent,
+  formatNumber,
+  debounce,
+  computeReturns,
+  computeVolatility,
+  computeMaxDrawdown,
+  movingAverage,
+} from './apiClient.js';
+import { buildLineChart } from './charting.js';
+
+const horizonConfig = {
+  '1M': { mode: 'eod', limit: 30 },
+  '3M': { mode: 'eod', limit: 90 },
+  '6M': { mode: 'eod', limit: 180 },
+  '1Y': { mode: 'eod', limit: 365 },
+  '3Y': { mode: 'eod', limit: 365 * 3 },
+};
+
+const state = {
+  symbol: 'AAPL',
+  exchange: 'XNAS',
+  horizon: '3M',
+  series: [],
+  chart: null,
+};
+
+const dom = {};
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function setStatus(el, text, tone = '') {
+  if (!el) return;
+  el.textContent = text;
+  el.classList.remove('ok', 'warn', 'error');
+  if (tone) el.classList.add(tone);
+}
+
+function renderMetrics(container, metrics = []) {
+  if (!container) return;
+  if (!metrics.length) {
+    container.innerHTML = '<p class="pro-empty">Not enough data to compute risk analytics.</p>';
+    return;
+  }
+  container.innerHTML = metrics
+    .map((metric) => `
+      <div class="pro-metric">
+        <span class="label">${metric.label}</span>
+        <span class="value">${metric.value}</span>
+        ${metric.detail ? `<span class="pro-status">${metric.detail}</span>` : ''}
+      </div>
+    `)
+    .join('');
+}
+
+function quantile(values, q) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+  return sorted[base];
+}
+
+function computeSkewness(returns) {
+  const n = returns.length;
+  if (n < 3) return 0;
+  const mean = returns.reduce((sum, v) => sum + v, 0) / n;
+  const std = Math.sqrt(returns.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (n - 1));
+  if (std === 0) return 0;
+  const skew = returns.reduce((sum, v) => sum + ((v - mean) / std) ** 3, 0);
+  return (n / ((n - 1) * (n - 2))) * skew;
+}
+
+function computeKurtosis(returns) {
+  const n = returns.length;
+  if (n < 4) return 0;
+  const mean = returns.reduce((sum, v) => sum + v, 0) / n;
+  const std = Math.sqrt(returns.reduce((sum, v) => sum + (v - mean) ** 2, 0) / n);
+  if (std === 0) return 0;
+  const kurt = returns.reduce((sum, v) => sum + ((v - mean) / std) ** 4, 0) / n;
+  return kurt - 3; // excess kurtosis
+}
+
+function computeHistoricalVar(returns, confidence = 0.95) {
+  if (!returns.length) return 0;
+  const losses = returns.filter((r) => r < 0);
+  if (!losses.length) return 0;
+  const percentile = quantile(losses, 1 - confidence);
+  return Math.abs(percentile);
+}
+
+function updateRiskMetrics() {
+  const returns = computeReturns(state.series);
+  const vol = computeVolatility(state.series);
+  const maxDD = computeMaxDrawdown(state.series);
+  const skew = computeSkewness(returns);
+  const kurt = computeKurtosis(returns);
+  const meanReturn = returns.length
+    ? returns.reduce((sum, v) => sum + v, 0) / returns.length
+    : 0;
+  const var95 = computeHistoricalVar(returns, 0.95);
+
+  const metrics = [
+    { label: 'Annualised Volatility', value: formatPercent(vol) },
+    { label: 'Average Daily Return', value: formatPercent(meanReturn) },
+    { label: 'Max Drawdown', value: formatPercent(maxDD) },
+    { label: 'Historical VaR (95%)', value: formatPercent(var95) },
+    { label: 'Skewness', value: formatNumber(skew, { maximumFractionDigits: 2 }) },
+    { label: 'Excess Kurtosis', value: formatNumber(kurt, { maximumFractionDigits: 2 }) },
+  ];
+  renderMetrics(dom.metrics, metrics);
+}
+
+function updateTrendDiagnostics() {
+  const ma20 = movingAverage(state.series, 20).at(-1)?.value;
+  const ma50 = movingAverage(state.series, 50).at(-1)?.value;
+  const ma200 = movingAverage(state.series, 200).at(-1)?.value;
+  const last = Number(state.series.at(-1)?.close ?? state.series.at(-1)?.price ?? 0);
+  const currency = 'USD';
+
+  const trendMetrics = [];
+  if (last && ma20) {
+    trendMetrics.push({
+      label: 'Price vs 20D',
+      value: formatPercent((last - ma20) / ma20),
+      detail: `Price ${last > ma20 ? 'above' : 'below'} short-term trend`,
+    });
+  }
+  if (ma50 && ma200) {
+    trendMetrics.push({
+      label: '50D vs 200D',
+      value: formatPercent((ma50 - ma200) / ma200),
+      detail: ma50 > ma200 ? 'Bullish structure' : 'Bearish structure',
+    });
+  }
+  if (ma200) {
+    trendMetrics.push({ label: '200D Level', value: formatCurrency(ma200, currency) });
+  }
+  renderMetrics(dom.trend, trendMetrics);
+}
+
+function updateDistributionDiagnostics() {
+  const returns = computeReturns(state.series);
+  if (!returns.length) {
+    renderMetrics(dom.distribution, []);
+    return;
+  }
+  const mean = returns.reduce((sum, v) => sum + v, 0) / returns.length;
+  const variance = returns.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (returns.length - 1 || 1);
+  const std = Math.sqrt(Math.max(variance, 0));
+  const downside = returns.filter((r) => r < 0).reduce((sum, v) => sum + v, 0) / (returns.filter((r) => r < 0).length || 1);
+  const upside = returns.filter((r) => r > 0).reduce((sum, v) => sum + v, 0) / (returns.filter((r) => r > 0).length || 1);
+
+  const metrics = [
+    { label: 'Mean Daily Return', value: formatPercent(mean) },
+    { label: 'Standard Deviation', value: formatPercent(std) },
+    { label: 'Downside Capture', value: formatPercent(Math.abs(downside)) },
+    { label: 'Upside Capture', value: formatPercent(upside) },
+  ];
+  renderMetrics(dom.distribution, metrics);
+}
+
+function updateScenario() {
+  const position = Number(dom.scenarioPosition.value) || 0;
+  const movePercent = Number(dom.scenarioMove.value) || 0;
+  const volMultiplier = Number(dom.scenarioVol.value) || 1;
+  const lastPrice = Number(state.series.at(-1)?.close ?? state.series.at(-1)?.price ?? 0);
+  const entryPrice = Number(dom.scenarioEntry.value) || lastPrice;
+
+  if (!position || !lastPrice) {
+    dom.scenarioPnL.textContent = '—';
+    dom.scenarioVar.textContent = '—';
+    setStatus(dom.scenarioStatus, 'Provide position inputs to simulate scenarios.');
+    return;
+  }
+
+  const scenarioPrice = lastPrice * (1 + movePercent / 100);
+  const pnl = (scenarioPrice - entryPrice) * position;
+  dom.scenarioPnL.textContent = formatCurrency(pnl, 'USD');
+  dom.scenarioPnLDetail.textContent = `Price moves to ${formatCurrency(scenarioPrice, 'USD')} (${formatPercent(movePercent / 100)}).`;
+
+  const returns = computeReturns(state.series);
+  const var95 = computeHistoricalVar(returns, 0.95) * volMultiplier;
+  const varValue = entryPrice * position * var95;
+  dom.scenarioVar.textContent = formatCurrency(varValue, 'USD');
+  dom.scenarioVarDetail.textContent = `Historical VaR scaled by ${volMultiplier.toFixed(2)}× volatility.`;
+  setStatus(dom.scenarioStatus, 'Scenario analytics refreshed.', 'ok');
+}
+
+async function updateChart() {
+  if (!dom.chart) return;
+  if (!state.series.length) {
+    dom.chartStatus.textContent = 'No data for chart.';
+    return;
+  }
+  state.chart = buildLineChart(dom.chart, state.series);
+  dom.chartStatus.textContent = '';
+}
+
+async function loadSymbol(symbol, opts = {}) {
+  state.symbol = symbol || state.symbol;
+  state.exchange = opts.exchange || state.exchange;
+  dom.search.value = state.symbol;
+  dom.searchResults.hidden = true;
+  setStatus(dom.status, `Loading price history for ${state.symbol}…`);
+  try {
+    const config = horizonConfig[state.horizon] || horizonConfig['3M'];
+    const { series, warning } = await fetchPriceSeries(state.symbol, { ...config, exchange: state.exchange });
+    state.series = series;
+    if (warning) setStatus(dom.chartStatus, warning, 'warn');
+    await updateChart();
+    updateRiskMetrics();
+    updateTrendDiagnostics();
+    updateDistributionDiagnostics();
+    updateScenario();
+    setStatus(dom.status, `Risk analytics refreshed for ${state.symbol}.`, 'ok');
+  } catch (err) {
+    console.error(err);
+    setStatus(dom.status, err.message || 'Failed to load risk analytics.', 'error');
+  }
+}
+
+async function handleSearchInput(value) {
+  const query = value.trim();
+  if (!query) {
+    dom.searchResults.hidden = true;
+    dom.searchResults.innerHTML = '';
+    return;
+  }
+  setStatus(dom.status, 'Searching tickers…');
+  try {
+    const results = await searchSymbols(query, { limit: 15 });
+    if (!results.length) {
+      dom.searchResults.hidden = true;
+      setStatus(dom.status, 'No matches found.', 'warn');
+      return;
+    }
+    dom.searchResults.hidden = false;
+    dom.searchResults.innerHTML = results
+      .map((item) => `
+        <button type="button" data-symbol="${item.symbol}" data-exchange="${item.mic || item.exchange}">
+          <span style="flex:1 1 auto;"><strong>${item.symbol}</strong> — ${item.name || ''}</span>
+          <span>${item.exchange || item.mic || ''}</span>
+        </button>
+      `)
+      .join('');
+  } catch (err) {
+    dom.searchResults.hidden = true;
+    setStatus(dom.status, err.message || 'Search failed.', 'error');
+  }
+}
+
+function attachListeners() {
+  dom.search.addEventListener('input', debounce((event) => handleSearchInput(event.target.value), 250));
+  dom.searchResults.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-symbol]');
+    if (!button) return;
+    loadSymbol(button.dataset.symbol, { exchange: button.dataset.exchange });
+  });
+  dom.horizon.addEventListener('change', (event) => {
+    state.horizon = event.target.value;
+    loadSymbol(state.symbol);
+  });
+  dom.scenarioForm.addEventListener('input', () => updateScenario());
+}
+
+function captureDom() {
+  dom.search = $('riskSearch');
+  dom.searchResults = $('riskSearchResults');
+  dom.status = $('riskStatus');
+  dom.chart = $('riskChart');
+  dom.chartStatus = $('riskChartStatus');
+  dom.metrics = $('riskMetrics');
+  dom.trend = $('riskTrend');
+  dom.distribution = $('riskDistribution');
+  dom.horizon = $('riskHorizon');
+  dom.scenarioForm = $('scenarioForm');
+  dom.scenarioPosition = $('scenarioPosition');
+  dom.scenarioEntry = $('scenarioEntry');
+  dom.scenarioMove = $('scenarioMove');
+  dom.scenarioVol = $('scenarioVol');
+  dom.scenarioPnL = $('scenarioPnL');
+  dom.scenarioPnLDetail = $('scenarioPnLDetail');
+  dom.scenarioVar = $('scenarioVar');
+  dom.scenarioVarDetail = $('scenarioVarDetail');
+  dom.scenarioStatus = $('scenarioStatus');
+}
+
+async function bootstrap() {
+  captureDom();
+  attachListeners();
+  await loadSymbol(state.symbol, { exchange: state.exchange });
+}
+
+document.addEventListener('DOMContentLoaded', bootstrap);
+

--- a/pro/market-intel.html
+++ b/pro/market-intel.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Market Intelligence War-Room</title>
+  <link rel="stylesheet" href="../app.css">
+  <link rel="stylesheet" href="pro.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="pro-shell">
+    <header class="pro-header">
+      <h1>Market Intelligence War-Room</h1>
+      <nav class="pro-nav">
+        <a href="ai-desk.html">AI Desk</a>
+        <a href="market-intel.html" class="active">Market Intel</a>
+        <a href="risk-lab.html">Risk Lab</a>
+        <a href="../index.html" target="_blank" rel="noopener">Legacy Terminal</a>
+      </nav>
+    </header>
+
+    <main class="pro-content">
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Corporate Event Radar</h2>
+            <p class="pro-status" id="intelStatus">Select a symbol to see real-time governance, filings, and catalysts.</p>
+          </div>
+          <div class="pro-inline-form">
+            <input type="search" id="intelSearch" class="pro-input" placeholder="Search ticker or company" autocomplete="off">
+            <select id="intelScope" class="pro-select">
+              <option value="60">Last 60 days</option>
+              <option value="120" selected>Last 120 days</option>
+              <option value="240">Last 240 days</option>
+              <option value="365">Last 365 days</option>
+            </select>
+          </div>
+        </div>
+        <div id="intelSearchResults" class="pro-search-results" hidden></div>
+        <div class="pro-divider"></div>
+        <div class="pro-grid-2">
+          <div>
+            <h3>Event Timeline</h3>
+            <div id="intelTimeline" class="pro-timeline pro-scroll" style="max-height:420px"></div>
+          </div>
+          <div>
+            <h3>Filings & Public Documents</h3>
+            <div id="intelDocuments" class="pro-timeline pro-scroll" style="max-height:420px"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Valuation Control Room</h2>
+            <p class="pro-status" id="valuationStatus">Review Tiingo fundamentals and AI-derived scoring.</p>
+          </div>
+        </div>
+        <div class="pro-grid-2">
+          <div>
+            <h3>Financial Healthboard</h3>
+            <div id="intelFinancials" class="pro-metric-grid"></div>
+          </div>
+          <div>
+            <h3>Valuation vs Market</h3>
+            <div id="intelValuation" class="pro-metric-grid"></div>
+          </div>
+        </div>
+        <div class="pro-divider"></div>
+        <div>
+          <h3>AI Synthesis</h3>
+          <p class="pro-status" id="intelAiSummary">AI commentary appears after a valuation refresh.</p>
+          <article id="intelAiNarrative" class="pro-status pro-empty">Awaiting selection…</article>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="./js/market-intel.js"></script>
+</body>
+</html>

--- a/pro/pro.css
+++ b/pro/pro.css
@@ -1,0 +1,467 @@
+:root {
+  --pro-accent: #3f8cff;
+  --pro-accent-dark: #1f5cd6;
+  --pro-bg: #0d1117;
+  --pro-surface: #161b22;
+  --pro-border: rgba(255, 255, 255, 0.08);
+  --pro-muted: rgba(255, 255, 255, 0.6);
+  --pro-success: #0fba81;
+  --pro-warning: #e9a23b;
+  --pro-danger: #ef5350;
+  --pro-font: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  font-family: var(--pro-font);
+  background: radial-gradient(circle at top, rgba(63, 140, 255, 0.12), rgba(13, 17, 23, 0.95)),
+    linear-gradient(180deg, rgba(13, 17, 23, 0.95) 0%, #05070a 80%);
+  color: #f5f8ff;
+  margin: 0;
+  min-height: 100vh;
+}
+
+.pro-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.pro-header {
+  padding: 24px 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--pro-border);
+  backdrop-filter: blur(16px);
+  background: rgba(13, 17, 23, 0.85);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.pro-header h1 {
+  font-size: 1.8rem;
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+.pro-nav {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+}
+
+.pro-nav a {
+  color: var(--pro-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
+  padding: 6px 0;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.pro-nav a.active,
+.pro-nav a:hover {
+  color: #f5f8ff;
+}
+
+.pro-nav a.active::after,
+.pro-nav a:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -10px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--pro-accent), var(--pro-success));
+  border-radius: 999px;
+}
+
+.pro-content {
+  flex: 1;
+  padding: 32px 36px 80px;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.pro-grid-2 {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.pro-card {
+  background: rgba(22, 27, 34, 0.82);
+  border: 1px solid var(--pro-border);
+  border-radius: 20px;
+  padding: 24px;
+  position: relative;
+  box-shadow: 0 30px 60px rgba(7, 9, 13, 0.45);
+  overflow: hidden;
+}
+
+.pro-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(63, 140, 255, 0.08), rgba(15, 186, 129, 0.06));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.pro-card:hover::after {
+  opacity: 1;
+}
+
+.pro-card h2 {
+  margin: 0 0 16px;
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.pro-card h3 {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.pro-card p {
+  margin: 0;
+  color: var(--pro-muted);
+  line-height: 1.55;
+}
+
+.pro-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 16px 0;
+}
+
+.pro-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.8rem;
+  background: rgba(63, 140, 255, 0.14);
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(63, 140, 255, 0.22);
+}
+
+.pro-chip.success {
+  background: rgba(15, 186, 129, 0.14);
+  border-color: rgba(15, 186, 129, 0.24);
+}
+
+.pro-chip.warning {
+  background: rgba(233, 162, 59, 0.14);
+  border-color: rgba(233, 162, 59, 0.24);
+}
+
+.pro-chip.danger {
+  background: rgba(239, 83, 80, 0.16);
+  border-color: rgba(239, 83, 80, 0.26);
+}
+
+.pro-highlight {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.pro-subtitle {
+  color: var(--pro-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pro-timeline {
+  display: grid;
+  gap: 12px;
+}
+
+.pro-timeline-item {
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(13, 17, 23, 0.74);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  position: relative;
+}
+
+.pro-timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -1px;
+  top: 16px;
+  bottom: 16px;
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--pro-accent), transparent);
+}
+
+.pro-timeline-item strong {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.pro-timeline-item a {
+  color: var(--pro-accent);
+  text-decoration: none;
+}
+
+.pro-metric-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.pro-metric {
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(9, 12, 17, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 8px;
+}
+
+.pro-metric .label {
+  color: var(--pro-muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+}
+
+.pro-metric .value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.pro-grid {
+  display: grid;
+  gap: 24px;
+}
+
+.pro-section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.pro-section-title h2 {
+  margin: 0;
+  letter-spacing: 0.08em;
+}
+
+.pro-section-title .actions {
+  display: flex;
+  gap: 10px;
+}
+
+.pro-btn {
+  background: linear-gradient(135deg, var(--pro-accent) 0%, var(--pro-success) 100%);
+  border: none;
+  color: white;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(63, 140, 255, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pro-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(63, 140, 255, 0.35);
+}
+
+.pro-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.pro-input,
+.pro-select,
+.pro-textarea {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(13, 17, 23, 0.6);
+  color: white;
+  font-size: 0.95rem;
+}
+
+.pro-textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.pro-input:focus,
+.pro-select:focus,
+.pro-textarea:focus {
+  outline: 2px solid rgba(63, 140, 255, 0.35);
+  border-color: rgba(63, 140, 255, 0.45);
+}
+
+.pro-search-results {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  background: rgba(5, 7, 10, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 10;
+  box-shadow: 0 16px 44px rgba(5, 7, 10, 0.6);
+}
+
+.pro-search-results button {
+  display: flex;
+  width: 100%;
+  padding: 12px 16px;
+  gap: 12px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.pro-search-results button:hover {
+  background: rgba(63, 140, 255, 0.18);
+}
+
+.pro-compact-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pro-compact-table th,
+.pro-compact-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.pro-compact-table tbody tr:hover {
+  background: rgba(63, 140, 255, 0.08);
+}
+
+.pro-stat-block {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(63, 140, 255, 0.16);
+  background: rgba(63, 140, 255, 0.08);
+}
+
+.pro-stat-block .label {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.pro-stat-block .value {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.pro-inline-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.pro-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(63, 140, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+}
+
+.pro-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pro-tag {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.78rem;
+}
+
+.pro-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: 24px 0;
+}
+
+.pro-status {
+  font-size: 0.85rem;
+  color: var(--pro-muted);
+}
+
+.pro-status.ok {
+  color: var(--pro-success);
+}
+
+.pro-status.warn {
+  color: var(--pro-warning);
+}
+
+.pro-status.error {
+  color: var(--pro-danger);
+}
+
+.pro-empty {
+  color: var(--pro-muted);
+  font-style: italic;
+}
+
+.pro-scroll {
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.pro-mini-chart {
+  height: 140px;
+}
+
+@media (max-width: 960px) {
+  .pro-header {
+    padding: 18px 20px;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .pro-content {
+    padding: 24px 20px 60px;
+  }
+}

--- a/pro/risk-lab.html
+++ b/pro/risk-lab.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Risk Lab — Scenario Studio</title>
+  <link rel="stylesheet" href="../app.css">
+  <link rel="stylesheet" href="pro.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+</head>
+<body>
+  <div class="pro-shell">
+    <header class="pro-header">
+      <h1>Risk Analytics Laboratory</h1>
+      <nav class="pro-nav">
+        <a href="ai-desk.html">AI Desk</a>
+        <a href="market-intel.html">Market Intel</a>
+        <a href="risk-lab.html" class="active">Risk Lab</a>
+        <a href="../index.html" target="_blank" rel="noopener">Legacy Terminal</a>
+      </nav>
+    </header>
+
+    <main class="pro-content">
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Volatility Surface</h2>
+            <p class="pro-status" id="riskStatus">Select a symbol and compare horizon-specific risk.</p>
+          </div>
+          <div class="pro-inline-form">
+            <input type="search" id="riskSearch" class="pro-input" placeholder="Search ticker" autocomplete="off">
+            <select id="riskHorizon" class="pro-select">
+              <option value="1M">1 Month</option>
+              <option value="3M" selected>3 Months</option>
+              <option value="6M">6 Months</option>
+              <option value="1Y">1 Year</option>
+              <option value="3Y">3 Years</option>
+            </select>
+          </div>
+        </div>
+        <div id="riskSearchResults" class="pro-search-results" hidden></div>
+        <div class="pro-grid-2" style="align-items:stretch;">
+          <div>
+            <canvas id="riskChart" style="height:320px"></canvas>
+            <p class="pro-status" id="riskChartStatus"></p>
+          </div>
+          <div id="riskMetrics" class="pro-metric-grid"></div>
+        </div>
+      </section>
+
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Scenario Studio</h2>
+            <p class="pro-status" id="scenarioStatus">Simulate drawdowns, rallies, and custom stress events.</p>
+          </div>
+        </div>
+        <form id="scenarioForm" class="pro-grid-2">
+          <label>
+            <span class="pro-subtitle">Position Size (shares)</span>
+            <input type="number" id="scenarioPosition" class="pro-input" min="1" step="1" value="100">
+          </label>
+          <label>
+            <span class="pro-subtitle">Entry Price</span>
+            <input type="number" id="scenarioEntry" class="pro-input" step="0.01" placeholder="Auto from last price">
+          </label>
+          <label>
+            <span class="pro-subtitle">Scenario Move (%)</span>
+            <input type="number" id="scenarioMove" class="pro-input" step="0.5" value="-15">
+          </label>
+          <label>
+            <span class="pro-subtitle">Volatility Multiplier</span>
+            <input type="number" id="scenarioVol" class="pro-input" step="0.25" value="1.0">
+          </label>
+        </form>
+        <div class="pro-divider"></div>
+        <div class="pro-grid-2">
+          <div class="pro-stat-block">
+            <span class="label">Projected P&L</span>
+            <span id="scenarioPnL" class="value">—</span>
+            <span class="pro-status" id="scenarioPnLDetail"></span>
+          </div>
+          <div class="pro-stat-block">
+            <span class="label">Stress VaR (95%)</span>
+            <span id="scenarioVar" class="value">—</span>
+            <span class="pro-status" id="scenarioVarDetail"></span>
+          </div>
+        </div>
+      </section>
+
+      <section class="pro-card">
+        <div class="pro-section-title">
+          <div>
+            <h2>Cross-Timeframe Diagnostics</h2>
+            <p class="pro-status">Review moving averages, skew, and kurtosis for risk governance.</p>
+          </div>
+        </div>
+        <div class="pro-grid-2">
+          <div>
+            <h3>Trend Signatures</h3>
+            <div id="riskTrend" class="pro-metric-grid"></div>
+          </div>
+          <div>
+            <h3>Distribution Analytics</h3>
+            <div id="riskDistribution" class="pro-metric-grid"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="./js/risk-lab.js"></script>
+</body>
+</html>

--- a/tests/aiAnalyst.test.js
+++ b/tests/aiAnalyst.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const MODULE_PATH = '../netlify/functions/aiAnalyst.js';
+const originalFetch = global.fetch;
+
+const buildRequest = (body) => new Request('https://example.org/.netlify/functions/aiAnalyst', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+describe('aiAnalyst Netlify function', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_KEY;
+    delete process.env.GPT5_API_KEY;
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns informative fallback when API key is missing', async () => {
+    const { default: aiAnalyst } = await import(`${MODULE_PATH}?case=fallback`);
+    const response = await aiAnalyst(buildRequest({ symbol: 'AAPL' }));
+    const payload = await response.json();
+    expect(payload.mock).toBe(true);
+    expect(payload.analysis).toMatch(/chatgpt-5 staging mode/i);
+  });
+
+  it('passes payload to OpenAI and returns structured analysis', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+
+    const aiResponse = {
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              narrative: 'Fair value supported by durable FCF.',
+              valuation: { fairValue: 320, confidence: 0.72, bias: 'Bullish', marginOfSafety: 0.18 },
+              checklist: [
+                { item: 'Revenue momentum', signal: 'Positive' },
+                { item: 'Balance sheet', signal: 'Positive' },
+              ],
+              meta: { message: 'Valuation rendered successfully.' },
+            }),
+          },
+        },
+      ],
+    };
+
+    global.fetch = vi.fn(async (input, init) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      expect(url.pathname).toBe('/v1/chat/completions');
+      const parsed = JSON.parse(init.body);
+      expect(parsed.model).toBeDefined();
+      return new Response(JSON.stringify(aiResponse), { status: 200 });
+    });
+
+    const { default: aiAnalyst } = await import(`${MODULE_PATH}?case=live`);
+    const response = await aiAnalyst(buildRequest({ symbol: 'MSFT', timeframe: '1Y' }));
+    const payload = await response.json();
+
+    expect(payload.valuation.fairValue).toBe(320);
+    expect(payload.checklist).toHaveLength(2);
+    expect(payload.message).toMatch(/valuation rendered successfully/i);
+  });
+});
+

--- a/tests/companyIntel.test.js
+++ b/tests/companyIntel.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const MODULE_PATH = '../netlify/functions/companyIntel.js';
+const originalFetch = global.fetch;
+
+const buildRequest = (queryString) => new Request(`https://example.org/.netlify/functions/companyIntel${queryString ? `?${queryString}` : ''}`);
+
+describe('companyIntel Netlify function', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.TIINGO_KEY;
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns curated fallback intelligence when Tiingo key is missing', async () => {
+    delete process.env.TIINGO_KEY;
+    const { default: companyIntel } = await import(`${MODULE_PATH}?case=fallback`);
+    const response = await companyIntel(buildRequest('symbol=AAPL'));
+    const payload = await response.json();
+    expect(payload.source).toBe('fallback');
+    expect(payload.symbol).toBe('AAPL');
+    expect(payload.warning).toMatch(/tiingo api key missing/i);
+    expect(payload.events.length).toBeGreaterThan(0);
+  });
+
+  it('normalises Tiingo fundamentals and news into analytics', async () => {
+    process.env.TIINGO_KEY = 'test-key';
+
+    const fundamentals = [
+      {
+        date: '2024-05-01',
+        currency: 'USD',
+        sector: 'Technology',
+        industry: 'Software',
+        marketCap: 150000000000,
+        revenueGrowth: 0.12,
+        ebitdaMargin: 0.34,
+        freeCashFlow: 12000000000,
+        returnOnEquity: 0.45,
+        netDebt: 5000000000,
+        currentRatio: 1.9,
+        interestCoverage: 8,
+        eps: 6.5,
+        closePrice: 140,
+        peRatio: 21,
+        forwardPe: 18,
+        priceToSales: 6,
+        evToEbitda: 12,
+        riskPremium: 0.05,
+      },
+    ];
+
+    const news = [
+      {
+        title: 'Company beats earnings expectations',
+        description: 'Strong cloud momentum and margin expansion.',
+        url: 'https://example.org/news',
+        publishedDate: '2024-05-15T12:00:00Z',
+        tags: ['Earnings', 'Filing'],
+        sentimentScore: 0.45,
+      },
+      {
+        title: 'Regulator opens inquiry into data practices',
+        description: 'Preliminary review launched by European Commission.',
+        url: 'https://example.org/regulation',
+        publishedDate: '2024-05-28T08:00:00Z',
+        tags: ['Regulation'],
+        sentimentScore: -0.35,
+      },
+    ];
+
+    global.fetch = vi.fn(async (input) => {
+      const rawUrl = typeof input === 'string' ? input : input?.href || input?.url;
+      if (!rawUrl) throw new Error('Missing request URL');
+      const url = new URL(rawUrl);
+      if (url.pathname.includes('/tiingo/fundamentals')) {
+        expect(url.searchParams.get('token')).toBe('test-key');
+        return new Response(JSON.stringify(fundamentals), { status: 200 });
+      }
+      if (url.pathname.includes('/tiingo/news')) {
+        return new Response(JSON.stringify(news), { status: 200 });
+      }
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    const { default: companyIntel } = await import(`${MODULE_PATH}?case=live`);
+    const response = await companyIntel(buildRequest('symbol=MSFT'));
+    const payload = await response.json();
+
+    expect(payload.source).toBe('tiingo');
+    expect(payload.snapshot.marketCap).toBeCloseTo(150000000000);
+    expect(payload.valuations.intrinsicValue).toBeGreaterThan(0);
+    expect(payload.valuations.marginOfSafety).toBeTypeOf('number');
+    expect(payload.events).toHaveLength(2);
+    expect(payload.documents.length).toBeGreaterThanOrEqual(1);
+  });
+});
+

--- a/tests/tiingo.test.js
+++ b/tests/tiingo.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const MODULE_PATH = '../netlify/functions/tiingo.js';
+
+const originalFetch = global.fetch;
+
+const buildRequest = (queryString) => new Request(`https://example.org/.netlify/functions/tiingo${queryString ? `?${queryString}` : ''}`);
+
+function mockFetch(handler) {
+  global.fetch = vi.fn(async (input, init) => {
+    const url = typeof input === 'string' || input instanceof URL
+      ? new URL(input, 'https://api.tiingo.com')
+      : new URL(input?.url || 'https://api.tiingo.com', 'https://api.tiingo.com');
+    return handler(url, init);
+  });
+  return global.fetch;
+}
+
+describe('tiingo Netlify function', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.TIINGO_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    delete process.env.TIINGO_KEY;
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns chronologically sorted intraday data', async () => {
+    const mockSeries = [
+      { date: '2024-06-10T14:35:00Z', open: 100, high: 102, low: 99, close: 101, volume: 1000 },
+      { date: '2024-06-10T14:40:00Z', open: 101, high: 103, low: 100, close: 102, volume: 1100 },
+      { date: '2024-06-10T14:45:00Z', open: 102, high: 104, low: 101, close: 103, volume: 900 },
+    ];
+
+    mockFetch((url) => {
+      expect(url.pathname).toContain('/iex/AAPL/prices');
+      return Promise.resolve(new Response(JSON.stringify(mockSeries), { status: 200 }));
+    });
+
+    const { default: tiingo } = await import(`${MODULE_PATH}?case=intraday`);
+    const response = await tiingo(buildRequest('symbol=AAPL&kind=intraday&interval=5min&limit=3'));
+    const payload = await response.json();
+
+    expect(Array.isArray(payload.data)).toBe(true);
+    expect(payload.data).toHaveLength(3);
+    const dates = payload.data.map((row) => new Date(row.date).getTime());
+    expect(dates).toEqual([...dates].sort((a, b) => a - b));
+    expect(payload.data[0]).toMatchObject({ symbol: 'AAPL' });
+    expect(payload.data[0].open).toBeTypeOf('number');
+    expect(payload.data[0].close).toBeTypeOf('number');
+  });
+
+  it('falls back to end-of-day data when intraday fails', async () => {
+    const mockEod = [
+      { date: '2024-05-01', open: 98, high: 100, low: 95, close: 99, volume: 1500000 },
+      { date: '2024-05-02', open: 99, high: 103, low: 98, close: 102, volume: 1200000 },
+    ];
+
+    mockFetch((url) => {
+      if (url.pathname.includes('/iex/')) {
+        return Promise.resolve(new Response('error', { status: 500 }));
+      }
+      if (url.pathname.includes('/tiingo/daily')) {
+        return Promise.resolve(new Response(JSON.stringify(mockEod), { status: 200 }));
+      }
+      return Promise.reject(new Error(`Unexpected URL ${url}`));
+    });
+
+    const { default: tiingo } = await import(`${MODULE_PATH}?case=fallback`);
+    const response = await tiingo(buildRequest('symbol=MSFT&kind=intraday&interval=5min&limit=2'));
+    const payload = await response.json();
+
+    expect(payload.data).toHaveLength(2);
+    expect(payload.warning).toMatch(/end-of-day/i);
+    expect(payload.data[0]).toMatchObject({ symbol: 'MSFT' });
+  });
+
+  it('returns real-time intraday_latest quotes for eligible tickers', async () => {
+    const realtimeQuote = [{ ticker: 'AAPL', last: 175.5, prevClose: 173.2, volume: 1200000 }];
+
+    const fetchMock = mockFetch((url) => {
+      if (url.pathname === '/iex') {
+        return new Response(JSON.stringify(realtimeQuote), { status: 200 });
+      }
+      if (url.pathname.includes('/tiingo/daily/')) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return Promise.reject(new Error(`Unexpected URL ${url}`));
+    });
+
+    const { default: tiingo } = await import(`${MODULE_PATH}?case=latest-us`);
+    const response = await tiingo(buildRequest('symbol=AAPL&kind=intraday_latest'));
+    const payload = await response.json();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(payload.data).toHaveLength(1);
+    expect(payload.data[0].symbol).toBe('AAPL');
+    expect(payload.data[0].price).toBeCloseTo(175.5, 5);
+    expect(payload.warning || '').not.toMatch(/sample data/i);
+  });
+
+  it('falls back to end-of-day quotes for international intraday_latest requests', async () => {
+    const fallbackDaily = [
+      { date: '2024-06-07', close: 150, adjClose: 150, volume: 900000 },
+      { date: '2024-06-10', close: 152, adjClose: 152, volume: 950000 },
+    ];
+
+    mockFetch((url) => {
+      if (url.pathname === '/iex') {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (url.pathname.includes('/tiingo/daily/')) {
+        return new Response(JSON.stringify(fallbackDaily), { status: 200 });
+      }
+      return Promise.reject(new Error(`Unexpected URL ${url}`));
+    });
+
+    const { default: tiingo } = await import(`${MODULE_PATH}?case=latest-intl`);
+    const response = await tiingo(buildRequest('symbol=SONY&kind=intraday_latest&exchange=XTKS'));
+    const payload = await response.json();
+
+    expect(payload.data).toHaveLength(1);
+    expect(payload.data[0].symbol).toBe('SONY');
+    expect(payload.data[0].price).toBeCloseTo(152, 5);
+    expect(payload.warning).toMatch(/end-of-day/i);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add dedicated AI Desk, Market Intel, and Risk Lab pages with professional trading workflows
- implement aiAnalyst and companyIntel Netlify functions for ChatGPT-5 valuations and Tiingo corporate intelligence
- share reusable client modules and comprehensive Vitest coverage validating Tiingo data normalization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d383ed9ba88329830ee12ed9633f71