### PR TITLE
Add Tiingo-powered instrument search and watchlist

### DIFF
--- a/app.css
+++ b/app.css
@@ -26,13 +26,30 @@ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-se
 .search-container input,.profile-form input{width:100%;padding:10px;background-color:var(--background-tertiary);border:1px solid var(--border-color);color:var(--text-primary);border-radius:6px}
 #profileForm button{width:100%;margin-top:10px}
 #profileForm button:first-of-type{margin-top:0}
-#searchResults{margin-top:10px}
-.search-result-item{display:flex;justify-content:space-between;align-items:center;padding:8px;border-radius:6px;background:rgba(255,255,255,.03);margin-bottom:6px}
-.search-result-item button{background-color:var(--accent-blue);color:#fff;border:none;padding:6px 10px;border-radius:6px;cursor:pointer}
-.watchlist-item{display:flex;justify-content:space-between;align-items:center;padding:10px 6px;border-bottom:1px solid var(--border-color);cursor:pointer}
-.watchlist-item:hover{background:rgba(255,255,255,.03)}
-.watchlist-symbol{font-weight:700}
-.watchlist-remove{color:var(--accent-red);font-weight:700;cursor:pointer;padding:6px}
+#searchResults{margin-top:10px;display:flex;flex-direction:column;gap:6px}
+.search-result-item{display:flex;justify-content:space-between;align-items:center;padding:10px;border-radius:8px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);gap:10px}
+.search-result-item:hover{background:rgba(255,255,255,.08)}
+.search-result-main{display:flex;align-items:center;gap:10px;min-width:0}
+.search-result-icon{width:32px;height:32px;border-radius:8px;background:rgba(52,152,219,.25);display:flex;align-items:center;justify-content:center;font-weight:700;color:#fff}
+.search-result-text{display:flex;flex-direction:column;gap:2px;min-width:0}
+.search-result-symbol{font-weight:700;font-size:1em;color:#fff}
+.search-result-name{font-size:.85em;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:220px}
+.search-result-meta{font-size:.75em;color:var(--text-secondary);opacity:.85}
+.search-result-actions{display:flex;gap:6px}
+.search-result-btn{border:none;border-radius:6px;padding:6px 12px;font-size:.85em;cursor:pointer;transition:background-color .2s ease,color .2s ease}
+.search-result-btn.watch{background:transparent;border:1px solid rgba(255,255,255,.18);color:var(--text-primary)}
+.search-result-btn.watch:hover{background:rgba(255,255,255,.12)}
+.search-result-btn.load{background:var(--accent-green);color:#fff}
+.search-result-btn.load:hover{background:#29b765}
+.search-empty,.search-loading{padding:14px;border-radius:8px;background:rgba(255,255,255,.03);text-align:center;font-size:.9em}
+.watchlist-item{display:flex;justify-content:space-between;align-items:center;padding:10px 8px;border-bottom:1px solid var(--border-color);gap:10px;cursor:pointer;transition:background-color .2s ease}
+.watchlist-item:hover,.watchlist-item.active{background:rgba(255,255,255,.05)}
+.watchlist-info{display:flex;flex-direction:column;gap:2px;min-width:0}
+.watchlist-symbol{font-weight:700;color:#fff}
+.watchlist-name{font-size:.85em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px}
+.watchlist-meta{display:flex;align-items:center;gap:8px}
+.watchlist-remove{background:transparent;border:none;color:var(--accent-red);font-weight:700;cursor:pointer;padding:4px 6px;border-radius:4px}
+.watchlist-remove:hover{background:rgba(231,76,60,.18)}
 .news-sources{display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap}
 .news-sources button{background-color:var(--background-tertiary);color:var(--text-secondary);border:1px solid var(--border-color);padding:8px 12px;border-radius:999px;cursor:pointer}
 .news-sources button.active,.news-sources button:hover{background-color:var(--accent-blue);color:#fff;border-color:var(--accent-blue)}

--- a/app.js
+++ b/app.js
@@ -17,17 +17,19 @@ function showError(msg) {
 }
 
 /* Formatting */
-const fmt = (n) => (Number.isFinite(Number(n)) ? Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 }) : '�');
-const fmtVol = (n) => (Number.isFinite(Number(n)) ? Number(n).toLocaleString() : '�');
+const fmt = (n) => (Number.isFinite(Number(n)) ? Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 }) : '—');
+const fmtVol = (n) => (Number.isFinite(Number(n)) ? Number(n).toLocaleString() : '—');
 
 /* API wrapper */
 const API = '/api';
 async function callTiingo(params) {
   const url = new URL(`${API}/tiingo`, window.location.origin);
-  Object.entries(params || {}).forEach(([k, v]) => { if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v); });
+  Object.entries(params || {}).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v);
+  });
   showLoading(true);
   try {
-    const resp = await fetch(url, { headers: { 'accept': 'application/json' } });
+    const resp = await fetch(url, { headers: { accept: 'application/json' } });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) throw new Error(data?.warning || data?.error || resp.statusText);
     if (data?.warning) console.warn('tiingo warning:', data.warning);
@@ -40,9 +42,27 @@ async function callTiingo(params) {
   }
 }
 
-/* Chart state */
+/* App state */
 let priceChart = null;
 let currentSymbol = 'AAPL';
+let currentSymbolName = 'Apple Inc.';
+let currentExchange = 'XNAS';
+let currentTimeframe = '1D';
+let watchlist = [];
+let selectedExchange = '';
+let searchAbortController = null;
+let searchDebounceTimer = null;
+let searchInputEl = null;
+let searchResultsEl = null;
+let exchangeFilterEl = null;
+
+const WATCHLIST_STORAGE_KEY = 'tiingo.watchlist';
+const DEFAULT_WATCHLIST = [
+  { symbol: 'AAPL', name: 'Apple Inc.', mic: 'XNAS', exchange: 'NASDAQ' },
+  { symbol: 'MSFT', name: 'Microsoft Corporation', mic: 'XNAS', exchange: 'NASDAQ' },
+  { symbol: 'TSLA', name: 'Tesla, Inc.', mic: 'XNAS', exchange: 'NASDAQ' },
+];
+const SEARCH_PLACEHOLDER = 'Start typing to search…';
 
 function sma(values, windowSize) {
   const w = Math.max(1, Math.min(windowSize || 1, values.length));
@@ -57,8 +77,293 @@ function sma(values, windowSize) {
   return out;
 }
 
+const getWatchlistKey = (item) => {
+  if (!item || !item.symbol) return '';
+  const symbol = String(item.symbol).toUpperCase();
+  const mic = String(item.mic || item.exchange || '').toUpperCase();
+  return `${symbol}::${mic}`;
+};
+
+function loadStoredWatchlist() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(WATCHLIST_STORAGE_KEY) || '[]');
+    if (Array.isArray(raw) && raw.length) {
+      watchlist = raw
+        .map((item) => ({
+          symbol: String(item.symbol || '').toUpperCase(),
+          name: item.name || '',
+          mic: item.mic || item.exchange || '',
+          exchange: item.exchange || '',
+        }))
+        .filter((item) => item.symbol);
+      if (watchlist.length) return;
+    }
+  } catch (err) {
+    console.warn('Failed to parse stored watchlist', err);
+  }
+  watchlist = DEFAULT_WATCHLIST.map((item) => ({ ...item }));
+}
+
+function persistWatchlist() {
+  const serialisable = watchlist.map((item) => ({
+    symbol: item.symbol,
+    name: item.name,
+    mic: item.mic || '',
+    exchange: item.exchange || '',
+  }));
+  localStorage.setItem(WATCHLIST_STORAGE_KEY, JSON.stringify(serialisable));
+}
+
+function renderWatchlist() {
+  const container = $('watchlist');
+  if (!container) return;
+  container.innerHTML = '';
+  if (!watchlist.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted watchlist-empty';
+    empty.textContent = 'No symbols yet. Search above to add.';
+    container.appendChild(empty);
+    return;
+  }
+
+  watchlist.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'watchlist-item';
+    if (item.symbol === currentSymbol) {
+      row.classList.add('active');
+    }
+    const key = getWatchlistKey(item);
+    row.dataset.key = key;
+    row.innerHTML = `
+      <div class="watchlist-info">
+        <div class="watchlist-symbol">${item.symbol}</div>
+        <div class="watchlist-name muted">${item.name || ''}</div>
+      </div>
+      <div class="watchlist-meta">
+        <span class="watchlist-exchange mono">${(item.mic || item.exchange || '').toUpperCase()}</span>
+        <button type="button" class="watchlist-remove" data-action="remove" data-key="${key}" aria-label="Remove ${item.symbol}">&times;</button>
+      </div>
+    `;
+    container.appendChild(row);
+  });
+}
+
+function addToWatchlist(item) {
+  if (!item || !item.symbol) return;
+  const normalised = {
+    symbol: String(item.symbol).toUpperCase(),
+    name: item.name || '',
+    mic: item.mic || item.exchange || '',
+    exchange: item.exchange || '',
+  };
+  const key = getWatchlistKey(normalised);
+  if (!key) return;
+  if (watchlist.some((existing) => getWatchlistKey(existing) === key)) return;
+  watchlist.push(normalised);
+  persistWatchlist();
+  renderWatchlist();
+}
+
+function removeFromWatchlist(key) {
+  if (!key) return;
+  watchlist = watchlist.filter((item) => getWatchlistKey(item) !== key);
+  persistWatchlist();
+  renderWatchlist();
+}
+
+function handleWatchlistClick(event) {
+  const removeBtn = event.target.closest('button[data-action="remove"]');
+  if (removeBtn) {
+    removeFromWatchlist(removeBtn.dataset.key || '');
+    event.stopPropagation();
+    return;
+  }
+
+  const itemEl = event.target.closest('.watchlist-item');
+  if (!itemEl) return;
+  const key = itemEl.dataset.key || '';
+  const match = watchlist.find((entry) => getWatchlistKey(entry) === key);
+  if (!match) return;
+  loadSymbol(match.symbol, match.name, match.mic || match.exchange || '');
+}
+
+function clearSearchResults(message = SEARCH_PLACEHOLDER) {
+  if (!searchResultsEl) return;
+  searchResultsEl.innerHTML = '';
+  if (message) {
+    const note = document.createElement('div');
+    note.className = 'search-empty muted';
+    note.textContent = message;
+    searchResultsEl.appendChild(note);
+  }
+}
+
+function setSearchLoading() {
+  if (!searchResultsEl) return;
+  searchResultsEl.innerHTML = '<div class="search-loading">Searching…</div>';
+}
+
+function renderSearchResults(items) {
+  if (!searchResultsEl) return;
+  searchResultsEl.innerHTML = '';
+  if (!items.length) {
+    clearSearchResults('No matching instruments.');
+    return;
+  }
+
+  items.forEach((item) => {
+    const symbol = (item.symbol || '').toUpperCase();
+    if (!symbol) return;
+    const name = item.name || '';
+    const mic = (item.mic || item.exchange || '').toUpperCase();
+    const type = item.type || '';
+    const country = item.country || '';
+    const meta = [mic, type, country].filter(Boolean).join(' • ');
+
+    const row = document.createElement('div');
+    row.className = 'search-result-item';
+    row.innerHTML = `
+      <div class="search-result-main">
+        <div class="search-result-icon">${symbol.charAt(0)}</div>
+        <div class="search-result-text">
+          <div class="search-result-symbol">${symbol}</div>
+          <div class="search-result-name">${name}</div>
+          <div class="search-result-meta">${meta}</div>
+        </div>
+      </div>
+      <div class="search-result-actions">
+        <button type="button" class="search-result-btn watch" data-action="watch" data-symbol="${symbol}" data-name="${name}" data-mic="${mic}" data-exchange="${item.exchange || ''}">Add</button>
+        <button type="button" class="search-result-btn load" data-action="load" data-symbol="${symbol}" data-name="${name}" data-mic="${mic}" data-exchange="${item.exchange || ''}">Load</button>
+      </div>
+    `;
+    searchResultsEl.appendChild(row);
+  });
+}
+
+async function performSearch(query) {
+  const q = query.trim();
+  if (q.length < 2) {
+    clearSearchResults('Keep typing to search…');
+    return;
+  }
+
+  if (searchAbortController) {
+    searchAbortController.abort();
+  }
+  const controller = new AbortController();
+  searchAbortController = controller;
+  setSearchLoading();
+
+  try {
+    const endpoint = new URL(`${API}/search`, window.location.origin);
+    endpoint.searchParams.set('q', q);
+    endpoint.searchParams.set('limit', '12');
+    if (selectedExchange) {
+      endpoint.searchParams.set('exchange', selectedExchange);
+    }
+    const response = await fetch(endpoint, { signal: controller.signal, headers: { accept: 'application/json' } });
+    if (!response.ok) {
+      throw new Error(`Search failed with status ${response.status}`);
+    }
+    const payload = await response.json().catch(() => ({}));
+    const items = Array.isArray(payload?.data) ? payload.data : [];
+    renderSearchResults(items.slice(0, 12));
+  } catch (err) {
+    if (controller.signal.aborted) return;
+    console.error('Search request failed', err);
+    clearSearchResults('Search unavailable. Try again later.');
+  }
+}
+
+function setupSearch() {
+  searchInputEl = $('stockSearchInput');
+  searchResultsEl = $('searchResults');
+  exchangeFilterEl = $('exchangeFilters');
+
+  if (exchangeFilterEl) {
+    selectedExchange = exchangeFilterEl.value || '';
+    exchangeFilterEl.addEventListener('change', () => {
+      selectedExchange = exchangeFilterEl.value || '';
+      if (searchInputEl && searchInputEl.value.trim().length >= 2) {
+        performSearch(searchInputEl.value);
+      }
+    });
+  }
+
+  if (searchInputEl) {
+    searchInputEl.addEventListener('input', () => {
+      if (searchDebounceTimer) {
+        clearTimeout(searchDebounceTimer);
+      }
+      const value = searchInputEl.value;
+      if (!value.trim()) {
+        clearSearchResults();
+        return;
+      }
+      searchDebounceTimer = setTimeout(() => {
+        performSearch(value);
+      }, 200);
+    });
+  }
+
+  if (searchResultsEl) {
+    searchResultsEl.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action]');
+      if (!button) return;
+      const symbol = button.dataset.symbol || '';
+      const name = button.dataset.name || '';
+      const mic = button.dataset.mic || '';
+      const exchange = button.dataset.exchange || '';
+      if (button.dataset.action === 'load') {
+        loadSymbol(symbol, name, mic || exchange);
+        if (searchInputEl) {
+          searchInputEl.value = '';
+        }
+        clearSearchResults('Select another symbol to view quotes.');
+      } else if (button.dataset.action === 'watch') {
+        addToWatchlist({ symbol, name, mic, exchange });
+      }
+    });
+  }
+
+  clearSearchResults();
+}
+
+function setupWatchlist() {
+  const container = $('watchlist');
+  if (!container) return;
+  container.addEventListener('click', handleWatchlistClick);
+}
+
+function updateRangeStats(rows) {
+  const highs = [];
+  const lows = [];
+  rows.forEach((row) => {
+    const h = Number(row.high ?? row.close);
+    const l = Number(row.low ?? row.close);
+    if (Number.isFinite(h)) highs.push(h);
+    if (Number.isFinite(l)) lows.push(l);
+  });
+  if (!highs.length || !lows.length) {
+    $('stat52wHigh').textContent = '—';
+    $('stat52wLow').textContent = '—';
+    return;
+  }
+  $('stat52wHigh').textContent = fmt(Math.max(...highs));
+  $('stat52wLow').textContent = fmt(Math.min(...lows));
+}
+
 function renderQuote(q) {
-  if (!q) return;
+  if (!q) {
+    $('stockPrice').textContent = '—';
+    $('stockChange').textContent = '—';
+    $('stockChange').className = 'stock-change';
+    $('statOpen').textContent = '—';
+    $('statHigh').textContent = '—';
+    $('statLow').textContent = '—';
+    $('statVolume').textContent = '—';
+    return;
+  }
   const price = q.close ?? q.last ?? q.price;
   const open = q.open ?? price;
   const deltaAbs = Number(price) - Number(open || 0);
@@ -72,35 +377,45 @@ function renderQuote(q) {
   $('statHigh').textContent = fmt(q.high);
   $('statLow').textContent = fmt(q.low);
   $('statVolume').textContent = fmtVol(q.volume);
-  $('exchangeAcronym').textContent = q.exchange ? `� ${q.exchange}` : '';
+  const exchange = (q.exchange || q.exchangeCode || currentExchange || '').toUpperCase();
+  currentExchange = exchange || currentExchange;
+  $('exchangeAcronym').textContent = exchange ? ` ${exchange}` : '';
 }
 
 function renderChart(rows, intraday) {
   const ctx = $('stockChart');
   if (!ctx || !Array.isArray(rows)) return;
-  const labels = rows.map(r => new Date(r.date)[intraday ? 'toLocaleTimeString' : 'toLocaleDateString']());
-  const values = rows.map(r => Number(r.close));
+  const labels = rows.map((r) => new Date(r.date)[intraday ? 'toLocaleTimeString' : 'toLocaleDateString']());
+  const values = rows.map((r) => Number(r.close));
   const ma = sma(values, Math.min(20, values.length));
-  if (priceChart) { priceChart.destroy(); priceChart = null; }
+  if (priceChart) {
+    priceChart.destroy();
+    priceChart = null;
+  }
   priceChart = new Chart(ctx, {
     type: 'line',
     data: {
       labels,
       datasets: [
-        { label: 'Price', data: values, borderColor: '#2ecc71', backgroundColor: 'rgba(46,204,113,.14)', fill: values.length > 1, tension: .12, spanGaps: false, clip: 5 },
+        { label: 'Price', data: values, borderColor: '#2ecc71', backgroundColor: 'rgba(46,204,113,.14)', fill: values.length > 1, tension: 0.12, spanGaps: false, clip: 5 },
         { label: 'SMA 20', data: ma, borderColor: '#f1c40f', borderDash: [6, 4], fill: false, tension: 0, spanGaps: false, clip: 5 },
-      ]
+      ],
     },
     options: {
-      responsive: true, maintainAspectRatio: false,
+      responsive: true,
+      maintainAspectRatio: false,
       scales: {
         y: { grid: { color: 'rgba(255,255,255,.08)' }, ticks: { color: '#cfd3da' } },
         x: { grid: { color: 'rgba(255,255,255,.06)' }, ticks: { color: '#cfd3da', maxTicksLimit: 10 } },
       },
       plugins: { legend: { labels: { color: '#cfd3da' } }, tooltip: { mode: 'index', intersect: false } },
-      animation: { duration: 400 }
-    }
+      animation: { duration: 400 },
+    },
   });
+
+  if (!intraday) {
+    updateRangeStats(rows);
+  }
 }
 
 async function loadLatestQuote(symbol) {
@@ -122,31 +437,76 @@ function tfParams(tf) {
 }
 
 async function loadTimeframe(tf) {
-  document.querySelectorAll('#tfControls button').forEach(b => b.classList.remove('active'));
-  const btn = document.querySelector(`#tfControls button[data-tf="${tf}"]`);
-  if (btn) btn.classList.add('active');
+  currentTimeframe = tf;
+  document.querySelectorAll('#tfControls button').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.tf === tf);
+  });
   const { intraday, interval, limit } = tfParams(tf);
-  const params = intraday ? { symbol: currentSymbol, kind: 'intraday', interval, limit } : { symbol: currentSymbol, kind: 'eod', limit };
+  const params = intraday
+    ? { symbol: currentSymbol, kind: 'intraday', interval, limit }
+    : { symbol: currentSymbol, kind: 'eod', limit };
   const res = await callTiingo(params);
-  const rows = Array.isArray(res?.data) ? res.data.slice().sort((a, b) => new Date(a.date) - new Date(b.date)) : [];
-  if (!rows.length) { showError('No data returned.'); return; }
+  const rows = Array.isArray(res?.data)
+    ? res.data.slice().sort((a, b) => new Date(a.date) - new Date(b.date))
+    : [];
+  if (!rows.length) {
+    showError('No data returned.');
+    return;
+  }
   renderChart(rows, intraday);
+  if (intraday) {
+    updateRangeStats([]);
+  }
+}
+
+async function loadSymbol(symbol, name, exchange) {
+  if (!symbol) return;
+  currentSymbol = String(symbol).toUpperCase();
+  currentSymbolName = name || currentSymbol;
+  if (exchange) {
+    currentExchange = String(exchange).toUpperCase();
+  }
+  $('stockSymbol').textContent = currentSymbol;
+  $('stockName').textContent = currentSymbolName;
+  $('exchangeAcronym').textContent = currentExchange ? ` ${currentExchange}` : '';
+  renderWatchlist();
+  showError('');
+  try {
+    await loadLatestQuote(currentSymbol);
+  } catch (err) {
+    console.warn('Failed to load latest quote', err);
+  }
+  try {
+    await loadTimeframe(currentTimeframe);
+  } catch (err) {
+    console.warn('Failed to load timeframe data', err);
+  }
 }
 
 async function init() {
   showError('');
+  loadStoredWatchlist();
+  setupWatchlist();
+  setupSearch();
+  renderWatchlist();
   $('stockSymbol').textContent = currentSymbol;
+  $('stockName').textContent = currentSymbolName;
+  $('exchangeAcronym').textContent = currentExchange ? ` ${currentExchange}` : '';
   try {
     await loadLatestQuote(currentSymbol);
-  } catch (_) {}
+  } catch (err) {
+    console.warn('Initial quote load failed', err);
+  }
   try {
-    await loadTimeframe('1D');
-  } catch (_) {}
+    await loadTimeframe(currentTimeframe);
+  } catch (err) {
+    console.warn('Initial timeframe load failed', err);
+  }
 
-  // Wire up timeframe buttons
   document.querySelectorAll('#tfControls button').forEach((btn) => {
     btn.addEventListener('click', async () => {
       const tf = btn.getAttribute('data-tf');
+      if (!tf) return;
       await loadTimeframe(tf);
     });
   });


### PR DESCRIPTION
## Summary
- add Tiingo-backed symbol search with exchange filter, watchlist integration, and debounced fetching
- persist and render a richer watchlist with local storage support and active-symbol highlighting
- refresh UI styling for search results and watchlist rows to match the richer data presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5307f456c832995117dd5ccfc6208