### PR TITLE
Add AI analyst orchestrator function with Gemini integration

### DIFF
--- a/netlify/functions/ai-analyst.js
+++ b/netlify/functions/ai-analyst.js
@@ -1,0 +1,385 @@
+import handleTiingoRequest from './tiingo.js';
+import { summarizeValuationNarrative } from './lib/valuation.js';
+import { getGeminiKeyDetail, getGeminiModel, generateGeminiContent } from './lib/gemini.js';
+
+const SYSTEM_PROMPT = "You are a senior equity research analyst. Based on the following financial data, news, and filings, provide a concise, single-paragraph investment thesis. Include key valuation metrics, potential risks, and a concluding sentence on the equity's outlook.";
+
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '*';
+const corsHeaders = {
+  'access-control-allow-origin': ALLOWED_ORIGIN,
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': 'content-type',
+};
+
+const DEFAULT_NEWS_LIMIT = 6;
+const DEFAULT_DOCUMENT_LIMIT = 4;
+const DEFAULT_PRICE_POINTS = 120;
+
+const toNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const fmtCurrency = (value) => {
+  const num = toNumber(value);
+  if (num === null) return 'n/a';
+  return `$${num.toFixed(2)}`;
+};
+
+const fmtPercent = (value, fraction = false) => {
+  const num = toNumber(value);
+  if (num === null) return 'n/a';
+  const pct = fraction ? num * 100 : num;
+  return `${pct.toFixed(1)}%`;
+};
+
+const buildTiingoRequest = (symbol, { kind = 'eod', limit, interval } = {}) => {
+  const params = new URLSearchParams({ symbol: symbol.toUpperCase() });
+  if (kind) params.set('kind', kind);
+  if (limit) params.set('limit', String(limit));
+  if (interval) params.set('interval', String(interval));
+  const url = `http://localhost/.netlify/functions/tiingo?${params.toString()}`;
+  return new Request(url, { method: 'GET' });
+};
+
+const callTiingo = async (symbol, options) => {
+  const request = buildTiingoRequest(symbol, options);
+  const response = await handleTiingoRequest(request);
+  const headers = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  let body = null;
+  try {
+    body = await response.json();
+  } catch (error) {
+    const fallback = await response.text();
+    body = { error: 'Non-JSON Tiingo response', raw: fallback.slice(0, 200) };
+  }
+  return {
+    status: response.status,
+    headers,
+    body,
+    warning: body?.warning || headers['x-tiingo-warning'] || '',
+    meta: body?.meta || {},
+  };
+};
+
+const summarizePriceHistory = (symbol, rows = []) => {
+  if (!Array.isArray(rows) || !rows.length) {
+    return `${symbol} price history unavailable.`;
+  }
+  const sorted = rows
+    .slice()
+    .filter((row) => row?.date)
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+  if (!sorted.length) {
+    return `${symbol} price history unavailable.`;
+  }
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const start = toNumber(first.close ?? first.price ?? first.last);
+  const end = toNumber(last.close ?? last.price ?? last.last);
+  if (start === null || end === null || !first.date || !last.date) {
+    return `${symbol} price history insufficient for analysis.`;
+  }
+  const change = ((end - start) / start) * 100;
+  const direction = change > 0 ? 'advanced' : change < 0 ? 'declined' : 'was flat';
+  return `${symbol} ${direction} ${change.toFixed(1)}% from ${new Date(first.date).toISOString().slice(0, 10)} (${fmtCurrency(start)}) to ${new Date(last.date).toISOString().slice(0, 10)} (${fmtCurrency(end)}).`;
+};
+
+const formatValuationSection = (symbol, valuationData) => {
+  const valuation = valuationData?.valuation;
+  if (!valuation) {
+    return `Valuation snapshot unavailable for ${symbol}.`;
+  }
+  const growth = valuation?.growth || {};
+  const scenarios = valuation?.scenarios || {};
+  return [
+    'Valuation Snapshot:',
+    `- Last price: ${fmtCurrency(valuation?.price ?? valuationData?.price)}`,
+    `- Fair value estimate: ${fmtCurrency(valuation?.fairValue)} (upside ${fmtPercent((valuation?.fairValue && valuation?.price) ? ((valuation.fairValue - valuation.price) / valuation.price) * 100 : null)})`,
+    `- Suggested entry (margin of safety ${fmtPercent((valuation?.marginOfSafety || 0) * 100)}): ${fmtCurrency(valuation?.suggestedEntry)}`,
+    `- Growth outlook: base ${fmtPercent(growth.base, true)} · bull ${fmtPercent(growth.bull, true)} · bear ${fmtPercent(growth.bear, true)}`,
+    scenarios?.bull && scenarios?.bear
+      ? `- Scenario targets: bull ${fmtCurrency(scenarios.bull)} · bear ${fmtCurrency(scenarios.bear)}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+const formatFundamentalSection = (fundamentals = {}) => {
+  const metrics = fundamentals?.metrics || {};
+  const latest = fundamentals?.latest || {};
+  const lines = [
+    'Key Fundamental Metrics:',
+    `- Revenue per share: ${fmtCurrency(metrics.revenuePerShare)}`,
+    `- EPS: ${fmtCurrency(metrics.earningsPerShare)}`,
+    `- Free cash flow per share: ${fmtCurrency(metrics.freeCashFlowPerShare)}`,
+    `- Book value per share: ${fmtCurrency(metrics.bookValuePerShare)}`,
+    `- Revenue growth: ${fmtPercent(metrics.revenueGrowth, true)}`,
+    `- EPS growth: ${fmtPercent(metrics.epsGrowth, true)}`,
+    `- FCF growth: ${fmtPercent(metrics.fcfGrowth, true)}`,
+  ];
+  if (latest?.reportDate) {
+    lines.push(`- Latest report date: ${latest.reportDate}`);
+  }
+  return lines.join('\n');
+};
+
+const formatNewsSection = (news = []) => {
+  if (!Array.isArray(news) || news.length === 0) {
+    return 'Recent News: No notable coverage in the lookback window.';
+  }
+  const lines = news.slice(0, DEFAULT_NEWS_LIMIT).map((item) => {
+    const date = item?.publishedAt ? new Date(item.publishedAt).toISOString().slice(0, 10) : 'Unknown date';
+    const sentiment = typeof item?.sentiment === 'number' ? `${(item.sentiment * 100).toFixed(0)}%` : 'n/a';
+    return `- ${date} | ${item?.source || 'Unknown source'} | ${item?.headline || 'Headline unavailable'} (Sentiment ${sentiment}). ${item?.summary || ''}`.trim();
+  });
+  return ['Recent News Highlights:', ...lines].join('\n');
+};
+
+const formatDocumentSection = (documents = []) => {
+  if (!Array.isArray(documents) || documents.length === 0) {
+    return 'Recent Filings: None reported over the sampling period.';
+  }
+  const lines = documents.slice(0, DEFAULT_DOCUMENT_LIMIT).map((doc) => {
+    const date = doc?.publishedAt ? new Date(doc.publishedAt).toISOString().slice(0, 10) : 'Unknown date';
+    return `- ${date} | ${doc?.documentType || 'Filing'} | ${doc?.headline || 'Untitled document'} (${doc?.source || 'Unknown source'}).`;
+  });
+  return ['Recent Filings & Documents:', ...lines].join('\n');
+};
+
+const formatActionsSection = (actions = {}) => {
+  const lines = [];
+  if (Array.isArray(actions?.dividends) && actions.dividends.length) {
+    const recent = actions.dividends.slice(0, 3).map((div) => {
+      const date = div?.exDate || div?.payDate || 'Unknown date';
+      return `${date}: ${fmtCurrency(div?.amount)} dividend (${div?.currency || 'USD'}).`;
+    });
+    lines.push('Dividend Activity:', ...recent.map((line) => `- ${line}`));
+  }
+  if (Array.isArray(actions?.splits) && actions.splits.length) {
+    const recentSplits = actions.splits.slice(0, 2).map((split) => {
+      const date = split?.exDate || 'Unknown date';
+      return `${date}: ${split?.numerator || 1}:${split?.denominator || 1} split.`;
+    });
+    lines.push('Share Split Activity:', ...recentSplits.map((line) => `- ${line}`));
+  }
+  if (!lines.length) {
+    return 'Corporate Actions: No recent dividends or splits disclosed.';
+  }
+  return lines.join('\n');
+};
+
+const buildUserPrompt = (symbol, datasets) => {
+  const sections = [
+    `Ticker: ${symbol}`,
+    datasets.valuation ? formatValuationSection(symbol, datasets.valuation) : `Valuation snapshot unavailable for ${symbol}.`,
+    datasets.fundamentals ? formatFundamentalSection(datasets.fundamentals) : 'Key Fundamental Metrics: unavailable.',
+    `Price Performance: ${summarizePriceHistory(symbol, datasets.priceHistory)}`,
+    formatNewsSection(datasets.news),
+    formatDocumentSection(datasets.documents),
+    formatActionsSection(datasets.actions),
+  ];
+  if (datasets.warnings?.length) {
+    sections.push(`Data Quality Flags: ${datasets.warnings.join(' | ')}`);
+  }
+  return sections.filter(Boolean).join('\n\n');
+};
+
+const mergeWarnings = (...messages) => messages.filter((msg) => typeof msg === 'string' && msg.trim()).map((msg) => msg.trim());
+
+const gatherTiingoIntel = async (symbol, { newsLimit = DEFAULT_NEWS_LIMIT, documentLimit = DEFAULT_DOCUMENT_LIMIT, priceLimit = DEFAULT_PRICE_POINTS } = {}) => {
+  const [valuationRes, newsRes, documentsRes, actionsRes, priceRes] = await Promise.all([
+    callTiingo(symbol, { kind: 'valuation' }),
+    callTiingo(symbol, { kind: 'news', limit: newsLimit }),
+    callTiingo(symbol, { kind: 'documents', limit: documentLimit }),
+    callTiingo(symbol, { kind: 'actions' }),
+    callTiingo(symbol, { kind: 'eod', limit: priceLimit }),
+  ]);
+
+  const datasets = {
+    valuation: valuationRes?.body?.data || null,
+    fundamentals: valuationRes?.body?.data?.fundamentals || null,
+    news: Array.isArray(newsRes?.body?.data) ? newsRes.body.data : [],
+    documents: Array.isArray(documentsRes?.body?.data) ? documentsRes.body.data : [],
+    actions: actionsRes?.body?.data || {},
+    priceHistory: Array.isArray(priceRes?.body?.data) ? priceRes.body.data : [],
+  };
+
+  const warnings = mergeWarnings(
+    valuationRes?.warning,
+    newsRes?.warning,
+    documentsRes?.warning,
+    actionsRes?.warning,
+    priceRes?.warning,
+  );
+
+  const responses = {
+    valuation: valuationRes,
+    news: newsRes,
+    documents: documentsRes,
+    actions: actionsRes,
+    priceHistory: priceRes,
+  };
+
+  return { datasets, warnings, responses };
+};
+
+const ok = (body, warning) => {
+  const headers = { ...corsHeaders };
+  if (warning) {
+    headers['x-ai-analyst-warning'] = warning;
+  }
+  return Response.json(body, { headers });
+};
+
+const handleOptions = () => new Response(null, { status: 204, headers: corsHeaders });
+
+export async function handleRequest(request) {
+  if (request.method === 'OPTIONS') return handleOptions();
+
+  let symbol = 'AAPL';
+  let newsLimit = DEFAULT_NEWS_LIMIT;
+  let documentLimit = DEFAULT_DOCUMENT_LIMIT;
+  let priceLimit = DEFAULT_PRICE_POINTS;
+
+  if (request.method === 'GET') {
+    const url = new URL(request.url);
+    symbol = (url.searchParams.get('symbol') || symbol).toUpperCase();
+    newsLimit = Number(url.searchParams.get('newsLimit')) || newsLimit;
+    documentLimit = Number(url.searchParams.get('documentLimit')) || documentLimit;
+    priceLimit = Number(url.searchParams.get('priceLimit')) || priceLimit;
+  } else if (request.method === 'POST') {
+    try {
+      const payload = await request.json();
+      if (payload?.symbol) symbol = String(payload.symbol).toUpperCase();
+      if (payload?.newsLimit) newsLimit = Number(payload.newsLimit) || newsLimit;
+      if (payload?.documentLimit) documentLimit = Number(payload.documentLimit) || documentLimit;
+      if (payload?.priceLimit) priceLimit = Number(payload.priceLimit) || priceLimit;
+    } catch (error) {
+      return Response.json({ error: 'Invalid JSON payload.' }, { status: 400, headers: corsHeaders });
+    }
+  }
+
+  try {
+    const { datasets, warnings: tiingoWarnings, responses } = await gatherTiingoIntel(symbol, {
+      newsLimit,
+      documentLimit,
+      priceLimit,
+    });
+
+    const userPrompt = buildUserPrompt(symbol, { ...datasets, warnings: tiingoWarnings });
+
+    const geminiKeyDetail = getGeminiKeyDetail();
+    const geminiKey = geminiKeyDetail.token;
+    const geminiModel = getGeminiModel();
+
+    let narrativeSource = 'gemini';
+    let narrativeText = '';
+    let geminiPayload = null;
+    let geminiError = '';
+
+    if (geminiKey) {
+      try {
+        const result = await generateGeminiContent({
+          apiKey: geminiKey,
+          model: geminiModel,
+          systemPrompt: SYSTEM_PROMPT,
+          userPrompt,
+        });
+        narrativeText = result.text?.trim() || '';
+        geminiPayload = {
+          model: result.model,
+          hasText: Boolean(result.text),
+        };
+      } catch (error) {
+        narrativeSource = 'fallback';
+        geminiError = error?.message || 'Gemini request failed.';
+      }
+    } else {
+      narrativeSource = 'fallback';
+      geminiError = 'Gemini API key missing.';
+    }
+
+    if (narrativeSource === 'fallback') {
+      const fallbackNarrative = datasets?.valuation?.narrative
+        || summarizeValuationNarrative(symbol, datasets?.valuation?.valuation)
+        || `${symbol} valuation narrative unavailable.`;
+      narrativeText = fallbackNarrative;
+    }
+
+    const combinedWarnings = mergeWarnings(
+      ...tiingoWarnings,
+      geminiError,
+    );
+
+    const responseBody = {
+      symbol,
+      generatedAt: new Date().toISOString(),
+      tiingo: {
+        data: datasets,
+        warnings: tiingoWarnings,
+        responses: Object.fromEntries(
+          Object.entries(responses).map(([key, value]) => [key, {
+            status: value?.status,
+            warning: value?.warning || '',
+            meta: value?.meta || {},
+            source: value?.headers?.['x-tiingo-source'] || value?.headers?.['x-intel-source'] || '',
+          }]),
+        ),
+      },
+      prompt: {
+        system: SYSTEM_PROMPT,
+        user: userPrompt,
+      },
+      narrative: {
+        text: narrativeText,
+        source: narrativeSource,
+        gemini: geminiPayload,
+        error: geminiError || undefined,
+      },
+      warnings: combinedWarnings,
+      gemini: {
+        model: geminiModel,
+        keyHint: geminiKeyDetail.key || '',
+      },
+    };
+
+    return ok(responseBody, combinedWarnings.join(' | '));
+  } catch (error) {
+    console.error('AI analyst orchestrator failed:', error);
+    return Response.json({ error: 'AI analyst orchestrator failed.' }, { status: 500, headers: corsHeaders });
+  }
+}
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? '';
+  const path = event?.path || '/';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'GET';
+  const body = method === 'GET' || method === 'HEAD' ? undefined : event?.body;
+
+  const request = new Request(url, {
+    method,
+    headers: event?.headers || {},
+    body,
+  });
+
+  const response = await handleRequest(request);
+  const headers = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return {
+    statusCode: response.status,
+    headers,
+    body: await response.text(),
+  };
+};
+
+export default handleRequest;

--- a/netlify/functions/lib/gemini.js
+++ b/netlify/functions/lib/gemini.js
@@ -1,0 +1,94 @@
+const GEMINI_ENV_KEYS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_GENAI_API_KEY',
+  'GOOGLE_AI_API_KEY',
+  'AI_STUDIO_API_KEY',
+  'REACT_APP_GEMINI_API_KEY',
+];
+
+const readEnvValue = (key) => {
+  const raw = process.env?.[key];
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  return trimmed || '';
+};
+
+export const getGeminiKeyDetail = () => {
+  for (const key of GEMINI_ENV_KEYS) {
+    const value = readEnvValue(key);
+    if (value) return { key, token: value };
+  }
+  for (const key of GEMINI_ENV_KEYS) {
+    const value = readEnvValue(key.toLowerCase());
+    if (value) return { key: key.toLowerCase(), token: value };
+  }
+  return { key: '', token: '' };
+};
+
+export const getGeminiApiKey = () => getGeminiKeyDetail().token;
+
+export const getGeminiModel = () => {
+  const model = readEnvValue('GEMINI_MODEL');
+  return model || 'gemini-1.5-flash';
+};
+
+export async function generateGeminiContent({ apiKey, model, systemPrompt, userPrompt }) {
+  if (!apiKey) {
+    throw new Error('Gemini API key missing.');
+  }
+  const chosenModel = model || getGeminiModel();
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(chosenModel)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const body = {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          { text: userPrompt },
+        ],
+      },
+    ],
+  };
+  if (systemPrompt) {
+    body.systemInstruction = {
+      role: 'system',
+      parts: [
+        { text: systemPrompt },
+      ],
+    };
+  }
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const message = errorText.slice(0, 500) || response.statusText || 'Unknown Gemini API error';
+    const err = new Error(`Gemini API error ${response.status}: ${message}`);
+    err.status = response.status;
+    throw err;
+  }
+
+  const payload = await response.json();
+  const text = payload?.candidates?.flatMap((candidate) => candidate?.content?.parts || [])
+    .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n') || '';
+
+  return {
+    model: chosenModel,
+    text,
+    payload,
+  };
+}
+
+export default {
+  GEMINI_ENV_KEYS,
+  getGeminiApiKey,
+  getGeminiKeyDetail,
+  getGeminiModel,
+  generateGeminiContent,
+};


### PR DESCRIPTION
## Summary
- add new `/ai-analyst` Netlify function that orchestrates Tiingo data aggregation and Gemini narrative generation
- create Gemini helper to resolve API credentials, configure defaults, and invoke the generateContent endpoint
- format Tiingo valuation, fundamentals, price action, news, filings, and corporate actions into a prompt with Gemini fallback narratives

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54ea6d9388329b70eebd696f61f33