### PR TITLE
Enhance AI analyst orchestration with multi-LLM support

### DIFF
--- a/netlify/functions/lib/codex.js
+++ b/netlify/functions/lib/codex.js
@@ -1,0 +1,82 @@
+const CODEX_ENV_KEYS = [
+  'CHATGPT_CODEX_API_KEY',
+  'CHATGPT_API_KEY',
+  'OPENAI_API_KEY',
+  'REACT_APP_OPENAI_API_KEY',
+];
+
+const readEnvValue = (key) => {
+  const raw = process.env?.[key];
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  return trimmed || '';
+};
+
+export const getCodexKeyDetail = () => {
+  for (const key of CODEX_ENV_KEYS) {
+    const value = readEnvValue(key);
+    if (value) return { key, token: value };
+  }
+  for (const key of CODEX_ENV_KEYS) {
+    const value = readEnvValue(key.toLowerCase());
+    if (value) return { key: key.toLowerCase(), token: value };
+  }
+  return { key: '', token: '' };
+};
+
+export const getCodexModel = () => {
+  const value = readEnvValue('CHATGPT_CODEX_MODEL');
+  return value || 'gpt-4.1-mini';
+};
+
+export async function generateCodexContent({ apiKey, model, systemPrompt, userPrompt }) {
+  if (!apiKey) {
+    throw new Error('ChatGPT Codex API key missing.');
+  }
+  const chosenModel = model || getCodexModel();
+  const url = 'https://api.openai.com/v1/chat/completions';
+  const body = {
+    model: chosenModel,
+    temperature: 0.2,
+    messages: [
+      systemPrompt ? { role: 'system', content: systemPrompt } : null,
+      { role: 'user', content: userPrompt },
+    ].filter(Boolean),
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const message = errorText.slice(0, 500) || response.statusText || 'Unknown ChatGPT Codex error';
+    const err = new Error(`ChatGPT Codex error ${response.status}: ${message}`);
+    err.status = response.status;
+    throw err;
+  }
+
+  const payload = await response.json();
+  const text = payload?.choices?.map((choice) => choice?.message?.content || '')
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+
+  return {
+    model: chosenModel,
+    text: text || '',
+    payload,
+  };
+}
+
+export default {
+  CODEX_ENV_KEYS,
+  getCodexKeyDetail,
+  getCodexModel,
+  generateCodexContent,
+};

--- a/netlify/functions/lib/grok.js
+++ b/netlify/functions/lib/grok.js
@@ -1,0 +1,92 @@
+const GROK_ENV_KEYS = [
+  'GROK_API_KEY',
+  'XAI_API_KEY',
+  'XAI_GROK_API_KEY',
+  'REACT_APP_GROK_API_KEY',
+];
+
+const readEnvValue = (key) => {
+  const raw = process.env?.[key];
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  return trimmed || '';
+};
+
+export const getGrokKeyDetail = () => {
+  for (const key of GROK_ENV_KEYS) {
+    const value = readEnvValue(key);
+    if (value) return { key, token: value };
+  }
+  for (const key of GROK_ENV_KEYS) {
+    const value = readEnvValue(key.toLowerCase());
+    if (value) return { key: key.toLowerCase(), token: value };
+  }
+  return { key: '', token: '' };
+};
+
+export const getGrokModel = () => {
+  const value = readEnvValue('GROK_MODEL');
+  return value || 'grok-beta';
+};
+
+export async function generateGrokContent({ apiKey, model, systemPrompt, userPrompt }) {
+  if (!apiKey) {
+    throw new Error('Grok API key missing.');
+  }
+  const chosenModel = model || getGrokModel();
+  const url = `https://api.x.ai/v1/${encodeURIComponent(chosenModel)}:generateContent`;
+  const body = {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          { text: userPrompt },
+        ],
+      },
+    ],
+  };
+  if (systemPrompt) {
+    body.systemInstruction = {
+      role: 'system',
+      parts: [
+        { text: systemPrompt },
+      ],
+    };
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const message = errorText.slice(0, 500) || response.statusText || 'Unknown Grok API error';
+    const err = new Error(`Grok API error ${response.status}: ${message}`);
+    err.status = response.status;
+    throw err;
+  }
+
+  const payload = await response.json();
+  const text = payload?.candidates?.flatMap((candidate) => candidate?.content?.parts || [])
+    .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n');
+
+  return {
+    model: chosenModel,
+    text: (text || '').trim(),
+    payload,
+  };
+}
+
+export default {
+  GROK_ENV_KEYS,
+  getGrokKeyDetail,
+  getGrokModel,
+  generateGrokContent,
+};

--- a/tests/aiAnalystFunction.spec.js
+++ b/tests/aiAnalystFunction.spec.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockTiingoHandler = vi.fn();
+const mockGenerateCodexContent = vi.fn();
+const mockGenerateGrokContent = vi.fn();
+const mockGenerateGeminiContent = vi.fn();
+
+vi.mock('../netlify/functions/tiingo.js', () => ({
+  __esModule: true,
+  default: mockTiingoHandler,
+}));
+
+vi.mock('../netlify/functions/lib/codex.js', () => ({
+  __esModule: true,
+  getCodexKeyDetail: vi.fn(() => ({ key: 'CHATGPT_CODEX_API_KEY', token: 'codex-token' })),
+  getCodexModel: vi.fn(() => 'gpt-codex'),
+  generateCodexContent: mockGenerateCodexContent,
+}));
+
+vi.mock('../netlify/functions/lib/grok.js', () => ({
+  __esModule: true,
+  getGrokKeyDetail: vi.fn(() => ({ key: 'GROK_API_KEY', token: 'grok-token' })),
+  getGrokModel: vi.fn(() => 'grok-beta'),
+  generateGrokContent: mockGenerateGrokContent,
+}));
+
+vi.mock('../netlify/functions/lib/gemini.js', () => ({
+  __esModule: true,
+  getGeminiKeyDetail: vi.fn(() => ({ key: 'GEMINI_API_KEY', token: 'gemini-token' })),
+  getGeminiModel: vi.fn(() => 'gemini-1.5'),
+  generateGeminiContent: mockGenerateGeminiContent,
+}));
+
+const valuationDataset = {
+  valuation: {
+    price: 120,
+    fairValue: 140,
+    suggestedEntry: 110,
+    marginOfSafety: 0.15,
+    growth: { base: 0.08, bull: 0.12, bear: 0.04 },
+    scenarios: { bull: 160, bear: 90 },
+  },
+  price: 120,
+  fundamentals: {
+    metrics: {
+      earningsPerShare: 6,
+      revenuePerShare: 45,
+      freeCashFlowPerShare: 5,
+      bookValuePerShare: 25,
+      revenueGrowth: 0.07,
+      epsGrowth: 0.08,
+      fcfGrowth: 0.06,
+    },
+    latest: {
+      totalDebt: 2000,
+      shareholderEquity: 1500,
+      netDebt: 1800,
+      ebitda: 600,
+      netIncome: 320,
+    },
+  },
+};
+
+const buildTiingoResponse = (kind) => {
+  switch (kind) {
+    case 'valuation':
+      return { data: valuationDataset };
+    case 'news':
+      return { data: [
+        { publishedAt: '2024-01-10T00:00:00Z', headline: 'Earnings beat', summary: 'Beating expectations', source: 'Wire', sentiment: 0.5 },
+      ] };
+    case 'documents':
+      return { data: [
+        { publishedAt: '2024-01-05T00:00:00Z', headline: '10-Q filing', source: 'SEC', documentType: '10-Q' },
+      ] };
+    case 'actions':
+      return { data: {
+        dividends: [{ exDate: '2023-12-15', amount: 0.24, currency: 'USD' }],
+        splits: [],
+      } };
+    case 'eod':
+      return { data: [
+        { date: '2023-12-01', close: 110 },
+        { date: '2023-12-29', close: 120 },
+      ] };
+    default:
+      return { data: null };
+  }
+};
+
+const mockTiingoRequest = async (request) => {
+  const url = new URL(request.url);
+  const kind = url.searchParams.get('kind');
+  const payload = buildTiingoResponse(kind);
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      'x-tiingo-source': `mock-${kind}`,
+    },
+  });
+};
+
+const importHandler = async () => {
+  const module = await import('../netlify/functions/ai-analyst.js');
+  return module.handleRequest;
+};
+
+describe('ai-analyst orchestrator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTiingoHandler.mockImplementation(mockTiingoRequest);
+    mockGenerateCodexContent.mockReset();
+    mockGenerateGrokContent.mockReset();
+    mockGenerateGeminiContent.mockReset();
+  });
+
+  it('prefers ChatGPT Codex response when available and enriches prompt with quant metrics', async () => {
+    mockGenerateCodexContent.mockResolvedValue({ text: 'Codex narrative', model: 'gpt-codex' });
+
+    const handleRequest = await importHandler();
+    const response = await handleRequest(new Request('https://example.com/.netlify/functions/ai-analyst', {
+      method: 'POST',
+      body: JSON.stringify({ symbol: 'TEST' }),
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const body = await response.json();
+    expect(body.narrative.source).toBe('chatgpt-codex');
+    expect(body.narrative.text).toBe('Codex narrative');
+    expect(body.prompt.user).toMatch(/Quantitative Ratios/);
+    expect(body.quant.priceToEarnings).toBeGreaterThan(0);
+    expect(mockGenerateGrokContent).not.toHaveBeenCalled();
+    expect(mockGenerateGeminiContent).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Grok then Gemini when prior services fail', async () => {
+    mockGenerateCodexContent.mockRejectedValue(new Error('codex down'));
+    mockGenerateGrokContent.mockResolvedValue({ text: 'Grok verdict', model: 'grok-beta' });
+
+    const handleRequest = await importHandler();
+    const response = await handleRequest(new Request('https://example.com/.netlify/functions/ai-analyst?symbol=demo'));
+    const body = await response.json();
+
+    expect(mockGenerateCodexContent).toHaveBeenCalled();
+    expect(mockGenerateGrokContent).toHaveBeenCalled();
+    expect(body.narrative.source).toBe('grok');
+    expect(body.narrative.text).toBe('Grok verdict');
+    expect(Array.isArray(body.warnings)).toBe(true);
+    expect(body.warnings.join(' ')).toMatch(/codex down/);
+  });
+
+  it('uses Gemini then valuation fallback when all LLM calls fail', async () => {
+    mockGenerateCodexContent.mockRejectedValue(new Error('codex down'));
+    mockGenerateGrokContent.mockRejectedValue(new Error('grok down'));
+    mockGenerateGeminiContent.mockRejectedValue(new Error('gemini down'));
+
+    const handleRequest = await importHandler();
+    const response = await handleRequest(new Request('https://example.com/.netlify/functions/ai-analyst?symbol=demo'));
+    const body = await response.json();
+
+    expect(body.narrative.source).toBe('fallback');
+    expect(body.narrative.text).toContain('DEMO');
+    expect(Array.isArray(body.warnings)).toBe(true);
+    expect(body.warnings.join(' ')).toMatch(/gemini down/);
+  });
+});

--- a/tests/quantMath.spec.js
+++ b/tests/quantMath.spec.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  priceToEarnings,
+  priceToSales,
+  debtToEquity,
+  freeCashFlowYield,
+  netDebtToEBITDA,
+  returnOnEquity,
+  toQuantNumber,
+} from '../utils/quant-math.js';
+
+describe('quantitative math utilities', () => {
+  it('computes valuation multiples', () => {
+    expect(priceToEarnings(100, 5)).toBeCloseTo(20);
+    expect(priceToSales(120, 40)).toBeCloseTo(3);
+  });
+
+  it('computes leverage and profitability ratios', () => {
+    expect(debtToEquity(200, 100)).toBeCloseTo(2);
+    expect(netDebtToEBITDA(150, 50)).toBeCloseTo(3);
+    expect(returnOnEquity(25, 125)).toBeCloseTo(0.2);
+  });
+
+  it('computes yield metrics', () => {
+    expect(freeCashFlowYield(80, 4)).toBeCloseTo(0.05);
+  });
+
+  it('returns null when inputs invalid', () => {
+    expect(priceToEarnings(100, 0)).toBeNull();
+    expect(priceToSales('bad', 20)).toBeNull();
+    expect(debtToEquity(50, null)).toBeNull();
+    expect(netDebtToEBITDA(40, 0)).toBeNull();
+    expect(returnOnEquity(undefined, 10)).toBeNull();
+    expect(freeCashFlowYield(0, 4)).toBeNull();
+    expect(toQuantNumber('not-a-number')).toBeNull();
+  });
+});

--- a/utils/quant-math.js
+++ b/utils/quant-math.js
@@ -1,0 +1,39 @@
+const toNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const safeDivide = (numerator, denominator) => {
+  const n = toNumber(numerator);
+  const d = toNumber(denominator);
+  if (n === null || d === null || d === 0) return null;
+  return n / d;
+};
+
+export const priceToEarnings = (price, earningsPerShare) => safeDivide(price, earningsPerShare);
+
+export const priceToSales = (price, revenuePerShare) => safeDivide(price, revenuePerShare);
+
+export const debtToEquity = (totalDebt, shareholdersEquity) => safeDivide(totalDebt, shareholdersEquity);
+
+export const freeCashFlowYield = (price, freeCashFlowPerShare) => {
+  const ratio = safeDivide(freeCashFlowPerShare, price);
+  return ratio === null ? null : ratio;
+};
+
+export const netDebtToEBITDA = (netDebt, ebitda) => safeDivide(netDebt, ebitda);
+
+export const returnOnEquity = (netIncome, shareholdersEquity) => safeDivide(netIncome, shareholdersEquity);
+
+export const toQuantNumber = toNumber;
+
+export default {
+  priceToEarnings,
+  priceToSales,
+  debtToEquity,
+  freeCashFlowYield,
+  netDebtToEBITDA,
+  returnOnEquity,
+  toQuantNumber,
+};


### PR DESCRIPTION
## Summary
- add reusable quantitative ratio utilities and cover them with unit tests
- expand the ai-analyst orchestrator to compute valuation ratios, build enriched prompts, and call ChatGPT Codex, Grok, and Gemini services with structured fallbacks
- introduce dedicated tests for the ai-analyst serverless function, mocking Tiingo and LLM APIs to verify narrative sourcing and warning handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5df3fb59083298dd745721b6dcc2f