### PR TITLE
Add professional desk and valuation lab shells with core components

### DIFF
--- a/professional-desk.html
+++ b/professional-desk.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Professional Desk</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="./professional/pro-shared.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js" defer></script>
+    <script type="module" src="./professional/professional-desk.js" defer></script>
+  </head>
+  <body>
+    <div class="pro-app-shell">
+      <aside class="pro-sidebar">
+        <section class="pro-card pro-brand fade-in">
+          <h1>Professional Desk</h1>
+          <p>High-performance workspace for live market intelligence and execution planning.</p>
+        </section>
+        <section class="pro-card pro-watchlist fade-in" style="animation-delay: 0.05s">
+          <div class="watchlist-title">Pinned Symbols</div>
+          <ul id="watchlist-items">
+            <li data-symbol="AAPL" class="active">
+              <div class="symbol">AAPL</div>
+              <div class="price muted" id="quote-price">—</div>
+            </li>
+            <li data-symbol="MSFT">
+              <div class="symbol">MSFT</div>
+              <div class="price muted">—</div>
+            </li>
+            <li data-symbol="NVDA">
+              <div class="symbol">NVDA</div>
+              <div class="price muted">—</div>
+            </li>
+            <li data-symbol="GOOGL">
+              <div class="symbol">GOOGL</div>
+              <div class="price muted">—</div>
+            </li>
+          </ul>
+        </section>
+        <section class="pro-card pro-mini-card fade-in" style="animation-delay: 0.12s">
+          <h3>Execution Notes</h3>
+          <p>
+            Track catalysts, liquidity windows, and risk parameters for <span data-active-symbol>AAPL</span>.
+            Sync with OMS once ready for live routing.
+          </p>
+        </section>
+        <section class="pro-card pro-mini-card fade-in" style="animation-delay: 0.16s">
+          <h3>Market Pulse</h3>
+          <p>Overlay macro signals and cross-asset flows to contextualize price action.</p>
+        </section>
+      </aside>
+      <main class="pro-main">
+        <header class="pro-card pro-toolbar fade-in" id="top-toolbar">
+          <div class="pro-symbol-controls" id="symbol-controls"></div>
+          <div class="pro-chart-meta">
+            <div class="symbol" data-active-symbol>AAPL</div>
+            <div id="status-host" class="pro-status-region"></div>
+          </div>
+        </header>
+        <section class="pro-card pro-chart-card fade-in" style="animation-delay: 0.08s">
+          <div class="pro-chart-meta">
+            <div>
+              <div class="symbol" data-active-symbol>AAPL</div>
+              <div id="quote-change" class="muted" data-direction="">—</div>
+            </div>
+          </div>
+          <div class="pro-chart-wrapper">
+            <canvas id="price-history" aria-label="Price history chart" role="img"></canvas>
+          </div>
+          <footer class="pro-footer-note muted">Data via Tiingo · Zoom with scroll or pinch · Reset via range toggle</footer>
+        </section>
+        <section class="pro-grid fade-in" style="animation-delay: 0.12s">
+          <article class="pro-mini-card">
+            <h3>Order Staging</h3>
+            <p>Configure entry slices, urgency, and ATS routing rules in alignment with <span data-active-symbol>AAPL</span> strategy.</p>
+          </article>
+          <article class="pro-mini-card">
+            <h3>Scenario Planning</h3>
+            <p>Run rapid sensitivity analyses across vol regimes and liquidity tiers before committing capital.</p>
+          </article>
+          <article class="pro-mini-card">
+            <h3>Research Feed</h3>
+            <p>Stream proprietary desk notes, sell-side models, and machine summaries alongside price structure.</p>
+          </article>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/professional/api-client.js
+++ b/professional/api-client.js
@@ -1,0 +1,95 @@
+const API_ROOT = '/api/tiingo';
+
+function buildUrl(params = {}) {
+  const url = new URL(API_ROOT, window.location.origin);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    url.searchParams.set(key, value);
+  });
+  return url.toString();
+}
+
+async function requestTiingo(params) {
+  const url = buildUrl(params);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message = data?.warning || data?.error || response.statusText;
+    const error = new Error(message || 'Request failed');
+    error.response = data;
+    throw error;
+  }
+
+  return data;
+}
+
+const RANGE_LIMITS = {
+  '1D': { kind: 'intraday', interval: '1Min', limit: 390 },
+  '5D': { kind: 'intraday', interval: '5Min', limit: 400 },
+  '1M': { kind: 'eod', limit: 30 },
+  '3M': { kind: 'eod', limit: 90 },
+  '6M': { kind: 'eod', limit: 180 },
+  '1Y': { kind: 'eod', limit: 365 },
+  '2Y': { kind: 'eod', limit: 365 * 2 },
+  '5Y': { kind: 'eod', limit: 365 * 5 },
+  MAX: { kind: 'eod', limit: 400 },
+};
+
+export async function fetchPriceHistory(symbol, rangeKey = '6M') {
+  const upper = (symbol || '').trim().toUpperCase() || 'AAPL';
+  const range = RANGE_LIMITS[rangeKey] || RANGE_LIMITS['6M'];
+  const params = { symbol: upper, kind: range.kind, limit: range.limit };
+  if (range.interval) params.interval = range.interval;
+
+  const payload = await requestTiingo(params);
+  const rows = Array.isArray(payload?.data) ? payload.data : [];
+  const meta = payload?.meta || {};
+  const warning = payload?.warning || '';
+
+  return { symbol: payload?.symbol || upper, rows, meta, warning };
+}
+
+export async function fetchLatestQuote(symbol) {
+  const upper = (symbol || '').trim().toUpperCase() || 'AAPL';
+  const payload = await requestTiingo({ symbol: upper, kind: 'intraday_latest' });
+  const rows = Array.isArray(payload?.data) ? payload.data : [];
+  return { symbol: payload?.symbol || upper, row: rows[0] || null, meta: payload?.meta || {}, warning: payload?.warning || '' };
+}
+
+export function describeRange(rangeKey) {
+  switch (rangeKey) {
+    case '1D':
+      return '1 Day';
+    case '5D':
+      return '5 Days';
+    case '1M':
+      return '1 Month';
+    case '3M':
+      return '3 Months';
+    case '6M':
+      return '6 Months';
+    case '1Y':
+      return '1 Year';
+    case '2Y':
+      return '2 Years';
+    case '5Y':
+      return '5 Years';
+    case 'MAX':
+      return 'Max Available';
+    default:
+      return rangeKey;
+  }
+}
+
+export const AVAILABLE_RANGES = Object.keys(RANGE_LIMITS);
+
+export async function fetchValuationSnapshot(symbol) {
+  const upper = (symbol || '').trim().toUpperCase() || 'AAPL';
+  const payload = await requestTiingo({ symbol: upper, kind: 'valuation' });
+  const data = payload?.data || null;
+  return { symbol: payload?.symbol || upper, snapshot: data, meta: payload?.meta || {}, warning: payload?.warning || '' };
+}

--- a/professional/pro-shared.css
+++ b/professional/pro-shared.css
@@ -1,0 +1,483 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  background-color: #0c1017;
+  --surface-0: #0f141d;
+  --surface-1: #151b27;
+  --surface-2: #1f2634;
+  --surface-3: #283143;
+  --accent: #4c8dff;
+  --accent-soft: rgba(76, 141, 255, 0.12);
+  --accent-strong: rgba(76, 141, 255, 0.32);
+  --text-primary: #f4f6fb;
+  --text-secondary: #9aa4bf;
+  --border-color: rgba(255, 255, 255, 0.08);
+  --positive: #3dd68c;
+  --negative: #ff6b6b;
+  --shadow-soft: 0 14px 42px rgba(0, 0, 0, 0.28);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 0% 0%, rgba(76, 141, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(61, 214, 140, 0.1), transparent 45%),
+    var(--surface-0);
+  color: var(--text-primary);
+  font-size: 16px;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.pro-app-shell {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 1.75rem;
+  padding: 1.75rem 2rem;
+}
+
+@media (max-width: 1100px) {
+  .pro-app-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .pro-sidebar {
+    order: 2;
+  }
+
+  .pro-main {
+    order: 1;
+  }
+}
+
+.pro-card {
+  background: linear-gradient(160deg, rgba(24, 32, 46, 0.92), rgba(13, 17, 24, 0.88));
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  padding: 1.25rem;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
+}
+
+.pro-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.pro-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.pro-brand h1 {
+  font-size: 1.45rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  margin: 0;
+}
+
+.pro-brand p {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
+.pro-watchlist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pro-watchlist .watchlist-title {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-secondary);
+}
+
+.pro-watchlist ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.pro-watchlist li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.75rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  border: 1px solid transparent;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.pro-watchlist li.active,
+.pro-watchlist li:hover {
+  border-color: var(--accent-strong);
+  background: rgba(76, 141, 255, 0.1);
+}
+
+.pro-watchlist .symbol {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.pro-watchlist .price {
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.pro-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.pro-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pro-symbol-controls {
+  display: flex;
+  flex: 1 1 320px;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.pro-symbol-input {
+  position: relative;
+  flex: 1 1 auto;
+}
+
+.pro-symbol-input input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: rgba(10, 14, 22, 0.72);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pro-symbol-input input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(76, 141, 255, 0.15);
+}
+
+.pro-symbol-input button {
+  position: absolute;
+  inset: 0;
+  right: 0;
+  width: 3rem;
+  border: none;
+  background: linear-gradient(140deg, var(--accent), #3c6eff);
+  color: white;
+  border-radius: 0 12px 12px 0;
+  cursor: pointer;
+  font-size: 1.05rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pro-range-selector {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 999px;
+  padding: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.pro-range-selector button {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 0.4rem 0.85rem;
+  font-size: 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.pro-range-selector button.active {
+  background: var(--accent);
+  color: white;
+}
+
+.pro-range-selector button:hover,
+.pro-range-selector button:focus {
+  color: var(--text-primary);
+}
+
+.pro-chart-card {
+  position: relative;
+  padding: 1rem;
+}
+
+.pro-chart-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.pro-chart-meta .symbol {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.pro-chart-meta .status {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.pro-chart-wrapper {
+  position: relative;
+  min-height: 340px;
+}
+
+.pro-chart-wrapper canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.pro-status-banner {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.pro-status-banner[data-variant='error'] {
+  color: var(--negative);
+}
+
+.pro-status-banner .dot {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.pro-status-banner[data-variant='warning'] .dot {
+  background: #e3b341;
+}
+
+.pro-status-banner[data-variant='error'] .dot {
+  background: var(--negative);
+}
+
+.pro-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.pro-mini-card {
+  padding: 1rem 1.2rem;
+  background: rgba(15, 21, 31, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pro-mini-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.pro-mini-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.pro-sparkline {
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(76, 141, 255, 0.08);
+}
+
+.pro-footer-note {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-align: right;
+}
+
+.loading-spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: var(--accent);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.45s ease both;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(10, 14, 22, 0.65);
+  border-radius: 16px;
+  backdrop-filter: blur(6px);
+  z-index: 2;
+}
+
+#quote-change[data-direction='up'] {
+  color: var(--positive);
+}
+
+#quote-change[data-direction='down'] {
+  color: var(--negative);
+}
+
+#quote-change[data-direction='flat'] {
+  color: var(--text-secondary);
+}
+
+.muted {
+  color: var(--text-secondary);
+}
+
+.valuation-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.valuation-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.2rem;
+  background: rgba(15, 21, 31, 0.82);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.valuation-metric strong {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.valuation-metric span {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.valuation-narrative {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+.valuation-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.valuation-table th,
+.valuation-table td {
+  text-align: left;
+  padding: 0.6rem 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.valuation-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.valuation-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(76, 141, 255, 0.12);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+}
+
+.valuation-tag[data-variant='bearish'] {
+  background: rgba(255, 107, 107, 0.18);
+  color: #ffb5b5;
+}
+
+.valuation-tag[data-variant='bullish'] {
+  background: rgba(61, 214, 140, 0.18);
+  color: #b7f8d8;
+}
+
+.pro-mini-card ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+}
+
+.pro-mini-card li + li {
+  margin-top: 0.35rem;
+}

--- a/professional/professional-desk.js
+++ b/professional/professional-desk.js
@@ -1,0 +1,285 @@
+import { createSymbolInput, createRangeSelector, createStatusBanner, createLoadingOverlay } from './ui-components.js';
+import { fetchPriceHistory, fetchLatestQuote, AVAILABLE_RANGES, describeRange } from './api-client.js';
+
+const state = {
+  symbol: 'AAPL',
+  range: '6M',
+  chart: null,
+  chartCtx: null,
+  loading: false,
+  lastQuote: null,
+};
+
+const statusBanner = createStatusBanner();
+let symbolControl;
+let rangeSelector;
+let loadingOverlay;
+
+function registerZoomPlugin() {
+  const zoomPlugin = window?.ChartZoom || window?.chartjs_plugin_zoom;
+  if (zoomPlugin && window.Chart && typeof window.Chart.register === 'function') {
+    window.Chart.register(zoomPlugin);
+  }
+}
+
+function ensureChart(ctx) {
+  if (!window.Chart) {
+    throw new Error('Chart.js not loaded');
+  }
+
+  if (state.chart) {
+    return state.chart;
+  }
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, ctx.canvas.height);
+  gradient.addColorStop(0, 'rgba(76, 141, 255, 0.45)');
+  gradient.addColorStop(1, 'rgba(76, 141, 255, 0.02)');
+
+  state.chart = new window.Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label: 'Close',
+          data: [],
+          tension: 0.35,
+          borderColor: 'rgba(76, 141, 255, 0.9)',
+          borderWidth: 2.4,
+          fill: true,
+          backgroundColor: gradient,
+          pointRadius: 0,
+          pointHoverRadius: 4,
+          pointHoverBackgroundColor: '#fff',
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { intersect: false, mode: 'index' },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(15, 21, 31, 0.92)',
+          borderColor: 'rgba(76, 141, 255, 0.45)',
+          borderWidth: 1,
+          padding: 12,
+          displayColors: false,
+          callbacks: {
+            title: (items) => (items[0]?.label ?? ''),
+            label: (item) => `Close: $${Number(item.parsed.y || 0).toFixed(2)}`,
+          },
+        },
+        zoom: {
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            drag: { enabled: false },
+            mode: 'x',
+          },
+          pan: { enabled: true, mode: 'x' },
+          limits: { x: { min: 'original', max: 'original' } },
+        },
+      },
+      scales: {
+        x: {
+          grid: { color: 'rgba(255, 255, 255, 0.05)' },
+          ticks: {
+            color: 'rgba(255, 255, 255, 0.5)',
+            maxRotation: 0,
+            autoSkipPadding: 24,
+          },
+        },
+        y: {
+          grid: { color: 'rgba(255, 255, 255, 0.06)' },
+          ticks: {
+            color: 'rgba(255, 255, 255, 0.55)',
+            callback: (value) => `$${Number(value).toFixed(2)}`,
+          },
+        },
+      },
+    },
+  });
+
+  return state.chart;
+}
+
+function resetZoom() {
+  if (state.chart?.resetZoom) {
+    state.chart.resetZoom();
+  }
+}
+
+function formatLabel(row, rangeKey) {
+  const raw = row?.date || row?.timestamp || row?.datetime;
+  if (!raw) return '';
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw;
+  if (rangeKey === '1D' || rangeKey === '5D') {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function updateChart(rows, rangeKey) {
+  if (!state.chartCtx) return;
+  const chart = ensureChart(state.chartCtx);
+  const labels = rows.map((row) => formatLabel(row, rangeKey));
+  const values = rows.map((row) => Number(row?.close ?? row?.price ?? row?.last ?? 0));
+
+  chart.data.labels = labels;
+  chart.data.datasets[0].data = values;
+  chart.update('none');
+}
+
+function setLoading(isLoading) {
+  state.loading = isLoading;
+  if (isLoading) {
+    loadingOverlay?.show();
+    statusBanner.setMessage('Loading market data…', 'default');
+  } else {
+    loadingOverlay?.hide();
+  }
+}
+
+function updateStatus({ warning, meta }) {
+  if (warning) {
+    statusBanner.setMessage(warning, 'warning');
+    return;
+  }
+  const source = meta?.source === 'live' ? 'Live feed' : meta?.source === 'eod-fallback' ? 'EOD fallback' : 'Sample data';
+  const label = `${state.symbol} · ${describeRange(state.range)} · ${source}`;
+  statusBanner.setMessage(label);
+}
+
+function updateQuoteDisplay(quote) {
+  const priceEl = document.getElementById('quote-price');
+  const changeEl = document.getElementById('quote-change');
+  if (!priceEl || !changeEl) return;
+  if (!quote) {
+    priceEl.textContent = '—';
+    changeEl.textContent = '';
+    changeEl.dataset.direction = '';
+    return;
+  }
+  const price = Number(quote?.last ?? quote?.close ?? quote?.price ?? 0);
+  const previous = Number(quote?.previousClose ?? quote?.close ?? 0);
+  const change = price - previous;
+  const pct = previous ? (change / previous) * 100 : 0;
+  priceEl.textContent = price ? `$${price.toFixed(2)}` : '—';
+  if (Number.isFinite(change)) {
+    const sign = change > 0 ? '+' : change < 0 ? '−' : '';
+    const pctSign = pct > 0 ? '+' : pct < 0 ? '−' : '';
+    changeEl.textContent = `${sign}${Math.abs(change).toFixed(2)} (${pctSign}${Math.abs(pct).toFixed(2)}%)`;
+    changeEl.dataset.direction = change > 0 ? 'up' : change < 0 ? 'down' : 'flat';
+  } else {
+    changeEl.textContent = '';
+    changeEl.dataset.direction = '';
+  }
+}
+
+async function refreshData() {
+  if (!state.symbol) return;
+  setLoading(true);
+  try {
+    const [{ rows, warning, meta }, latest] = await Promise.all([
+      fetchPriceHistory(state.symbol, state.range),
+      fetchLatestQuote(state.symbol).catch(() => ({ row: null })),
+    ]);
+    updateChart(rows, state.range);
+    updateStatus({ warning, meta });
+    state.lastQuote = latest?.row || rows?.[rows.length - 1] || null;
+    updateQuoteDisplay(state.lastQuote);
+    resetZoom();
+  } catch (error) {
+    console.error(error);
+    statusBanner.setMessage(error?.message || 'Unable to load data', 'error');
+  } finally {
+    setLoading(false);
+  }
+}
+
+function handleSymbolChange(symbol) {
+  state.symbol = symbol;
+  document.querySelectorAll('[data-active-symbol]').forEach((el) => {
+    el.textContent = symbol;
+  });
+  const watchlist = document.getElementById('watchlist-items');
+  if (watchlist) {
+    watchlist.querySelectorAll('li').forEach((item) => {
+      if (item.dataset.symbol === symbol) {
+        item.classList.add('active');
+      } else {
+        item.classList.remove('active');
+      }
+    });
+  }
+  refreshData();
+}
+
+function handleRangeChange(range) {
+  state.range = range;
+  refreshData();
+}
+
+function hydrateWatchlist() {
+  const list = document.getElementById('watchlist-items');
+  if (!list) return;
+  list.querySelectorAll('li[data-symbol]').forEach((item) => {
+    item.addEventListener('click', () => {
+      const symbol = item.dataset.symbol;
+      if (!symbol) return;
+      symbolControl?.setValue(symbol);
+      handleSymbolChange(symbol);
+      list.querySelectorAll('li').forEach((li) => li.classList.remove('active'));
+      item.classList.add('active');
+    });
+  });
+}
+
+function init() {
+  registerZoomPlugin();
+
+  const controls = document.getElementById('symbol-controls');
+  const statusHost = document.getElementById('status-host');
+  const chartCard = document.querySelector('.pro-chart-card');
+  const canvas = document.getElementById('price-history');
+
+  if (!controls || !canvas || !chartCard) {
+    console.warn('Professional desk shell missing required elements');
+    return;
+  }
+
+  symbolControl = createSymbolInput({
+    initial: state.symbol,
+    onSubmit: handleSymbolChange,
+  });
+  controls.appendChild(symbolControl.element);
+
+  rangeSelector = createRangeSelector(AVAILABLE_RANGES, {
+    onChange: handleRangeChange,
+    active: state.range,
+  });
+  controls.appendChild(rangeSelector.element);
+
+  statusHost?.appendChild(statusBanner.element);
+
+  loadingOverlay = createLoadingOverlay();
+  chartCard.appendChild(loadingOverlay.element);
+
+  state.chartCtx = canvas.getContext('2d');
+
+  hydrateWatchlist();
+  document.querySelectorAll('[data-active-symbol]').forEach((el) => {
+    el.textContent = state.symbol;
+  });
+
+  refreshData();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/professional/ui-components.js
+++ b/professional/ui-components.js
@@ -1,0 +1,112 @@
+export function createSymbolInput({ onSubmit, placeholder = 'Search symbol…', initial = 'AAPL' } = {}) {
+  const wrapper = document.createElement('form');
+  wrapper.className = 'pro-symbol-input';
+  wrapper.setAttribute('autocomplete', 'off');
+
+  const input = document.createElement('input');
+  input.type = 'search';
+  input.name = 'symbol';
+  input.autocomplete = 'off';
+  input.spellcheck = false;
+  input.placeholder = placeholder;
+  input.value = initial;
+  input.setAttribute('aria-label', 'Symbol search');
+
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.title = 'Load symbol';
+  submit.innerHTML = '↵';
+
+  wrapper.append(input, submit);
+
+  wrapper.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const value = input.value.trim().toUpperCase();
+    if (!value) return;
+    if (typeof onSubmit === 'function') {
+      onSubmit(value);
+    }
+  });
+
+  return {
+    element: wrapper,
+    input,
+    focus: () => input.focus(),
+    setValue: (value) => {
+      input.value = value || '';
+    },
+  };
+}
+
+export function createRangeSelector(ranges, { onChange, active } = {}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'pro-range-selector';
+
+  const buttons = ranges.map((key) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = key;
+    if (key === active) button.classList.add('active');
+    button.addEventListener('click', () => {
+      if (button.classList.contains('active')) return;
+      buttons.forEach((btn) => btn.classList.remove('active'));
+      button.classList.add('active');
+      if (typeof onChange === 'function') {
+        onChange(key);
+      }
+    });
+    wrapper.appendChild(button);
+    return button;
+  });
+
+  return { element: wrapper, setActive: (key) => {
+    buttons.forEach((btn) => {
+      if (btn.textContent === key) {
+        btn.classList.add('active');
+      } else {
+        btn.classList.remove('active');
+      }
+    });
+  } };
+}
+
+export function createStatusBanner() {
+  const el = document.createElement('div');
+  el.className = 'pro-status-banner';
+  const dot = document.createElement('span');
+  dot.className = 'dot';
+  const label = document.createElement('span');
+  label.textContent = 'Ready';
+  el.append(dot, label);
+
+  const setVariant = (variant = 'default') => {
+    el.dataset.variant = variant === 'default' ? '' : variant;
+  };
+
+  return {
+    element: el,
+    setMessage: (message, variant = 'default') => {
+      label.textContent = message;
+      setVariant(variant);
+    },
+  };
+}
+
+export function createLoadingOverlay() {
+  const el = document.createElement('div');
+  el.className = 'loading-overlay';
+  const spinner = document.createElement('div');
+  spinner.className = 'loading-spinner';
+  el.appendChild(spinner);
+  el.style.display = 'none';
+
+  return {
+    element: el,
+    show: () => {
+      el.style.display = 'flex';
+    },
+    hide: () => {
+      el.style.display = 'none';
+    },
+  };
+}

--- a/professional/valuation-lab.js
+++ b/professional/valuation-lab.js
@@ -1,0 +1,143 @@
+import { createSymbolInput, createStatusBanner } from './ui-components.js';
+import { fetchValuationSnapshot } from './api-client.js';
+
+const state = {
+  symbol: 'AAPL',
+  loading: false,
+};
+
+const statusBanner = createStatusBanner();
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+  return `$${Number(value).toFixed(2)}`;
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+  const pct = Number(value) * 100;
+  const sign = pct > 0 ? '+' : pct < 0 ? '−' : '';
+  return `${sign}${Math.abs(pct).toFixed(1)}%`;
+}
+
+function updateBiasTag(upside) {
+  const tag = document.getElementById('valuation-bias');
+  if (!tag) return;
+  if (upside === null || upside === undefined || Number.isNaN(Number(upside))) {
+    tag.textContent = 'Neutral';
+    tag.dataset.variant = '';
+    return;
+  }
+  const pct = Number(upside);
+  if (pct > 0.1) {
+    tag.textContent = 'Bullish Bias';
+    tag.dataset.variant = 'bullish';
+  } else if (pct < -0.1) {
+    tag.textContent = 'Bearish Bias';
+    tag.dataset.variant = 'bearish';
+  } else {
+    tag.textContent = 'Neutral';
+    tag.dataset.variant = '';
+  }
+}
+
+function renderScenarios(snapshot) {
+  const table = document.querySelector('#valuation-scenarios tbody');
+  if (!table) return;
+  table.innerHTML = '';
+  const price = Number(snapshot?.price ?? snapshot?.valuation?.price ?? 0) || 0;
+  const scenarios = snapshot?.valuation?.scenarios || {};
+  const entries = [
+    ['Bull', scenarios.bull],
+    ['Base', scenarios.base],
+    ['Bear', scenarios.bear],
+  ];
+  entries.forEach(([label, value]) => {
+    if (value === null || value === undefined) return;
+    const row = document.createElement('tr');
+    const delta = price ? ((Number(value) - price) / price) : null;
+    row.innerHTML = `
+      <td>${label}</td>
+      <td>${formatCurrency(value)}</td>
+      <td>${delta === null ? '—' : `${delta > 0 ? '+' : delta < 0 ? '−' : ''}${Math.abs(delta * 100).toFixed(1)}%`}</td>
+    `;
+    table.appendChild(row);
+  });
+}
+
+function renderSnapshot(snapshot) {
+  const valuation = snapshot?.valuation || {};
+  const priceEl = document.getElementById('valuation-last-price');
+  const fairEl = document.getElementById('valuation-fair-value');
+  const entryEl = document.getElementById('valuation-entry');
+  const upsideEl = document.getElementById('valuation-upside');
+  const narrativeEl = document.getElementById('valuation-narrative');
+
+  if (priceEl) priceEl.textContent = formatCurrency(snapshot?.price ?? valuation.price);
+  if (fairEl) fairEl.textContent = formatCurrency(valuation.fairValue);
+  if (entryEl) entryEl.textContent = formatCurrency(valuation.suggestedEntry);
+  if (upsideEl) upsideEl.textContent = formatPercent(valuation.upside);
+  updateBiasTag(valuation.upside);
+  if (narrativeEl) {
+    narrativeEl.textContent = snapshot?.narrative || 'No valuation narrative available yet.';
+  }
+  renderScenarios(snapshot);
+}
+
+async function refreshSnapshot() {
+  if (!state.symbol) return;
+  state.loading = true;
+  statusBanner.setMessage('Loading valuation snapshot…');
+  try {
+    const { snapshot, warning, meta } = await fetchValuationSnapshot(state.symbol);
+    renderSnapshot(snapshot);
+    if (warning) {
+      statusBanner.setMessage(warning, 'warning');
+    } else {
+      const source = meta?.source === 'live' ? 'Live feed' : meta?.source === 'eod-fallback' ? 'EOD fallback' : 'Sample data';
+      statusBanner.setMessage(`${state.symbol} · ${source}`);
+    }
+  } catch (error) {
+    console.error(error);
+    statusBanner.setMessage(error?.message || 'Unable to load valuation', 'error');
+  } finally {
+    state.loading = false;
+  }
+}
+
+function handleSymbolChange(symbol) {
+  state.symbol = symbol;
+  document.querySelectorAll('[data-active-symbol]').forEach((el) => {
+    el.textContent = symbol;
+  });
+  refreshSnapshot();
+}
+
+function init() {
+  const controlsHost = document.getElementById('valuation-symbol-controls');
+  const statusHost = document.getElementById('valuation-status');
+  if (!controlsHost || !statusHost) {
+    console.warn('Valuation lab shell missing required mounts');
+    return;
+  }
+
+  const symbolInput = createSymbolInput({
+    initial: state.symbol,
+    onSubmit: handleSymbolChange,
+    placeholder: 'Enter symbol for valuation…',
+  });
+  controlsHost.appendChild(symbolInput.element);
+  statusHost.appendChild(statusBanner.element);
+
+  document.querySelectorAll('[data-active-symbol]').forEach((el) => {
+    el.textContent = state.symbol;
+  });
+
+  refreshSnapshot();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/valuation-lab.html
+++ b/valuation-lab.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Valuation Lab</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="./professional/pro-shared.css" />
+    <script type="module" src="./professional/valuation-lab.js" defer></script>
+  </head>
+  <body>
+    <div class="pro-app-shell">
+      <aside class="pro-sidebar">
+        <section class="pro-card pro-brand fade-in">
+          <h1>Valuation Lab</h1>
+          <p>Scenario-driven valuation canvas for analysts calibrating intrinsic value frameworks.</p>
+        </section>
+        <section class="pro-card pro-mini-card fade-in" style="animation-delay: 0.05s">
+          <h3>Methodology</h3>
+          <p>Blend DCF, earnings power, revenue multiples, and book value benchmarks with configurable growth paths.</p>
+        </section>
+        <section class="pro-card pro-mini-card fade-in" style="animation-delay: 0.1s">
+          <h3>Team Notes</h3>
+          <p>Align research assumptions across teams and surface the consensus entry ranges for <span data-active-symbol>AAPL</span>.</p>
+        </section>
+        <section class="pro-card pro-mini-card fade-in" style="animation-delay: 0.15s">
+          <h3>Pending Tasks</h3>
+          <ul>
+            <li>Upload refreshed factor model</li>
+            <li>Review macro overlay</li>
+            <li>Sync alternative data feed</li>
+          </ul>
+        </section>
+      </aside>
+      <main class="pro-main">
+        <header class="pro-card pro-toolbar fade-in">
+          <div class="pro-symbol-controls" id="valuation-symbol-controls"></div>
+          <div class="pro-chart-meta">
+            <div class="symbol" data-active-symbol>AAPL</div>
+            <div id="valuation-status"></div>
+          </div>
+        </header>
+        <section class="pro-card fade-in" style="animation-delay: 0.08s">
+          <header class="pro-chart-meta">
+            <div>
+              <div class="symbol" data-active-symbol>AAPL</div>
+              <div class="muted">Intrinsic Value Dashboard</div>
+            </div>
+            <div class="valuation-tag" id="valuation-bias">Neutral</div>
+          </header>
+          <div class="valuation-metrics" id="valuation-metrics">
+            <div class="valuation-metric">
+              <span>Last Price</span>
+              <strong id="valuation-last-price">—</strong>
+            </div>
+            <div class="valuation-metric">
+              <span>Fair Value</span>
+              <strong id="valuation-fair-value">—</strong>
+            </div>
+            <div class="valuation-metric">
+              <span>Suggested Entry</span>
+              <strong id="valuation-entry">—</strong>
+            </div>
+            <div class="valuation-metric">
+              <span>Upside</span>
+              <strong id="valuation-upside">—</strong>
+            </div>
+          </div>
+        </section>
+        <section class="pro-card fade-in" style="animation-delay: 0.12s">
+          <h3>Scenario Map</h3>
+          <table class="valuation-table" id="valuation-scenarios">
+            <thead>
+              <tr>
+                <th>Scenario</th>
+                <th>Value</th>
+                <th>Delta vs Price</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </section>
+        <section class="pro-card fade-in" style="animation-delay: 0.16s">
+          <h3>Narrative</h3>
+          <p class="valuation-narrative" id="valuation-narrative">
+            Loading valuation narrative for <span data-active-symbol>AAPL</span>…
+          </p>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared pro-level dark theme stylesheet that drives the new professional desk and valuation lab shells
- create the professional desk layout with symbol controls, Chart.js price history, range selector, and watchlist wiring through reusable UI/API modules
- build the valuation lab workspace that reuses the shared modules to surface valuation snapshots, scenarios, and narrative updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e2342c208329bd8f34e620a97504