### PR TITLE
Enhance trading desk UI with live data integration

### DIFF
--- a/app.css
+++ b/app.css
@@ -4,21 +4,32 @@
   --accent-red:#e74c3c; --border-color:#3b4355;
 }
 *{box-sizing:border-box}
-body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:linear-gradient(135deg,#0f2027,#203a43,#2c5364);color:var(--text-primary);display:flex;height:100vh;overflow:hidden}
-.main-container{display:flex;flex-grow:1}
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:linear-gradient(135deg,#0f2027,#203a43,#2c5364);color:var(--text-primary);display:flex;flex-direction:column;height:100vh;overflow:hidden}
+.main-container{display:flex;flex-direction:row;flex-grow:1;min-height:0}
+.top-nav{display:flex;align-items:center;justify-content:space-between;padding:14px 20px;background-color:rgba(18,23,33,.95);border-bottom:1px solid var(--border-color);gap:16px}
+.nav-brand{font-weight:700;font-size:1.05em;letter-spacing:.5px;color:#fff}
+.nav-links{display:flex;gap:10px;flex-wrap:wrap}
+.nav-links a{color:var(--text-secondary);text-decoration:none;padding:8px 12px;border-radius:8px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.03);transition:all .2s ease}
+.nav-links a:hover{color:#fff;border-color:rgba(255,255,255,.18)}
+.nav-links a.active{background:var(--accent-blue);color:#fff;border-color:rgba(255,255,255,.25)}
 .main-content{flex:3;padding:20px;display:flex;flex-direction:column;gap:20px;overflow-y:auto}
 .sidebar{flex:1;background-color:rgba(31,37,51,.95);padding:20px;display:flex;flex-direction:column;gap:20px;overflow-y:auto;border-left:1px solid var(--border-color);backdrop-filter:blur(4px)}
 .card{background-color:rgba(31,37,51,.92);border-radius:10px;padding:16px;border:1px solid var(--border-color)}
 .card-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;padding-bottom:8px;border-bottom:1px solid var(--border-color)}
 .card-header h3{margin:0;font-size:1.05em;color:var(--text-primary)}
-.chip{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.15);color:var(--text-secondary);padding:6px 10px;border-radius:999px;font-size:12px}
+.chip{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.15);color:var(--text-secondary);padding:6px 10px;border-radius:999px;font-size:12px;transition:background-color .2s ease,color .2s ease,border-color .2s ease}
+.chip.chip-warning{background:rgba(231,76,60,.12);border-color:rgba(231,76,60,.35);color:#ffb3a8}
+.chip.chip-live{background:rgba(46,204,113,.18);border-color:rgba(46,204,113,.4);color:#d4ffe4}
 .stock-header h1{margin:0;font-size:2.2em;display:flex;align-items:center;gap:8px}
 .stock-header h1 small{font-size:.5em;color:var(--text-secondary)}
 .stock-price{font-size:2.2em;font-weight:800}
 .stock-change{font-size:1.05em;margin-left:12px}
 .positive-change{color:var(--accent-green)} .negative-change{color:var(--accent-red)}
 #stockChart{max-height:420px;height:320px;min-height:260px;width:100%;display:block}
-.chart-status{margin-top:8px;font-size:.9em;min-height:1.2em}
+.chart-status{margin-top:8px;font-size:.9em;min-height:1.2em;transition:color .2s ease}
+.chart-status.positive{color:var(--accent-green)}
+.chart-status.warning{color:#f1c40f}
+.chart-status.error{color:var(--accent-red)}
 .stock-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px}
 .stat-item{background-color:var(--background-tertiary);padding:12px;border-radius:8px}
 .stat-item-label{font-size:.8em;color:var(--text-secondary);margin-bottom:4px}
@@ -44,9 +55,12 @@ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-se
 .search-empty,.search-loading{padding:14px;border-radius:8px;background:rgba(255,255,255,.03);text-align:center;font-size:.9em}
 .watchlist-item{display:flex;justify-content:space-between;align-items:center;padding:10px 8px;border-bottom:1px solid var(--border-color);gap:10px;cursor:pointer;transition:background-color .2s ease}
 .watchlist-item:hover,.watchlist-item.active{background:rgba(255,255,255,.05)}
-.watchlist-info{display:flex;flex-direction:column;gap:2px;min-width:0}
+.watchlist-info{display:flex;flex-direction:column;gap:4px;min-width:0}
 .watchlist-symbol{font-weight:700;color:#fff}
 .watchlist-name{font-size:.85em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px}
+.watchlist-quote{display:flex;align-items:center;gap:8px;font-size:.85em;color:var(--text-secondary)}
+.watchlist-price{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace;color:#fff}
+.watchlist-change{font-weight:600}
 .watchlist-meta{display:flex;align-items:center;gap:8px}
 .watchlist-remove{background:transparent;border:none;color:var(--accent-red);font-weight:700;cursor:pointer;padding:4px 6px;border-radius:4px}
 .watchlist-remove:hover{background:rgba(231,76,60,.18)}

--- a/app.js
+++ b/app.js
@@ -4,10 +4,12 @@
 
 /* DOM helpers */
 const $ = (id) => document.getElementById(id);
+let loadingCounter = 0;
 function showLoading(on) {
   const el = $('loading');
   if (!el) return;
-  el.style.display = on ? 'block' : 'none';
+  loadingCounter = Math.max(0, loadingCounter + (on ? 1 : -1));
+  el.style.display = loadingCounter > 0 ? 'flex' : 'none';
 }
 function showError(msg) {
   const el = $('error');
@@ -19,26 +21,50 @@ function showError(msg) {
 /* Formatting */
 const fmt = (n) => (Number.isFinite(Number(n)) ? Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 }) : '—');
 const fmtVol = (n) => (Number.isFinite(Number(n)) ? Number(n).toLocaleString() : '—');
+const fmtPct = (n) => {
+  const num = Number(n);
+  if (!Number.isFinite(num)) return '—';
+  const sign = num >= 0 ? '+' : '';
+  return `${sign}${Math.abs(num).toFixed(2)}%`;
+};
 
 /* API wrapper */
 const API = '/api';
-async function callTiingo(params) {
+async function callTiingo(params, options = {}) {
+  const { silent = false } = options || {};
   const url = new URL(`${API}/tiingo`, window.location.origin);
   Object.entries(params || {}).forEach(([k, v]) => {
     if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v);
   });
-  showLoading(true);
+  if (!silent) showLoading(true);
   try {
     const resp = await fetch(url, { headers: { accept: 'application/json' } });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) throw new Error(data?.warning || data?.error || resp.statusText);
     if (data?.warning) console.warn('tiingo warning:', data.warning);
-    return data;
+    const meta = {
+      source: resp.headers.get('x-tiingo-source') || data?.meta?.source || '',
+      fallback: resp.headers.get('x-tiingo-fallback') || data?.meta?.fallback || '',
+      tokenPreview: resp.headers.get('x-tiingo-token-preview') || '',
+      chosenKey: resp.headers.get('x-tiingo-chosen-key') || '',
+      kind: data?.meta?.kind || params?.kind || '',
+    };
+    return {
+      body: data,
+      data: data?.data,
+      symbol: data?.symbol || params?.symbol || '',
+      warning: data?.warning || '',
+      meta,
+    };
   } catch (err) {
-    showError(`Request failed: ${String(err.message || err)}`);
+    if (!silent) {
+      showError(`Request failed: ${String(err.message || err)}`);
+    } else {
+      console.warn('Tiingo request failed', err);
+    }
     throw err;
   } finally {
-    showLoading(false);
+    if (!silent) showLoading(false);
   }
 }
 
@@ -55,6 +81,17 @@ let searchDebounceTimer = null;
 let searchInputEl = null;
 let searchResultsEl = null;
 let exchangeFilterEl = null;
+const watchlistQuotes = new Map();
+let watchlistRefreshTimer = null;
+
+const WATCHLIST_REFRESH_INTERVAL = 60 * 1000;
+const WATCHLIST_FETCH_LIMIT = 12;
+const CLOCK_ZONES = [
+  { label: 'New York (ET)', tz: 'America/New_York' },
+  { label: 'London (UK)', tz: 'Europe/London' },
+  { label: 'Tokyo (JST)', tz: 'Asia/Tokyo' },
+  { label: 'Sydney (AEST)', tz: 'Australia/Sydney' },
+];
 
 const WATCHLIST_STORAGE_KEY = 'tiingo.watchlist';
 const DEFAULT_WATCHLIST = [
@@ -134,13 +171,26 @@ function renderWatchlist() {
     }
     const key = getWatchlistKey(item);
     row.dataset.key = key;
+    const stats = watchlistQuotes.get(key);
+    const exchange = (stats?.exchange || item.mic || item.exchange || '').toUpperCase();
+    const price = stats ? fmt(stats.price) : '—';
+    const pct = stats ? fmtPct(stats.changePct) : '—';
+    const changeClass = stats ? (stats.changeAbs >= 0 ? 'positive-change' : 'negative-change') : 'muted';
+    const asOf = stats?.asOf ? new Date(stats.asOf).toLocaleString() : '';
+    if (asOf) {
+      row.title = `Last update: ${asOf}`;
+    }
     row.innerHTML = `
       <div class="watchlist-info">
         <div class="watchlist-symbol">${item.symbol}</div>
         <div class="watchlist-name muted">${item.name || ''}</div>
+        <div class="watchlist-quote">
+          <span class="watchlist-price">${price}</span>
+          <span class="watchlist-change ${changeClass}">${pct}</span>
+        </div>
       </div>
       <div class="watchlist-meta">
-        <span class="watchlist-exchange mono">${(item.mic || item.exchange || '').toUpperCase()}</span>
+        <span class="watchlist-exchange mono">${exchange}</span>
         <button type="button" class="watchlist-remove" data-action="remove" data-key="${key}" aria-label="Remove ${item.symbol}">&times;</button>
       </div>
     `;
@@ -162,13 +212,16 @@ function addToWatchlist(item) {
   watchlist.push(normalised);
   persistWatchlist();
   renderWatchlist();
+  refreshWatchlistQuotes();
 }
 
 function removeFromWatchlist(key) {
   if (!key) return;
   watchlist = watchlist.filter((item) => getWatchlistKey(item) !== key);
+  watchlistQuotes.delete(key);
   persistWatchlist();
   renderWatchlist();
+  renderMarketMovers();
 }
 
 function handleWatchlistClick(event) {
@@ -195,6 +248,381 @@ function clearSearchResults(message = SEARCH_PLACEHOLDER) {
     note.className = 'search-empty muted';
     note.textContent = message;
     searchResultsEl.appendChild(note);
+  }
+}
+
+function updateApiBadge(meta = {}) {
+  const badge = $('apiKeyEcho');
+  if (!badge) return;
+  const preview = meta.tokenPreview || '';
+  badge.textContent = preview ? `API: ${preview}` : 'API: demo/mock';
+  badge.title = meta.chosenKey
+    ? `Using ${meta.chosenKey}`
+    : preview
+      ? 'Tiingo token detected'
+      : 'Tiingo token not configured — using fallback data';
+  badge.classList.remove('chip-warning', 'chip-live');
+  if ((meta.source || '').toLowerCase() === 'live') {
+    badge.classList.add('chip-live');
+  } else {
+    badge.classList.add('chip-warning');
+  }
+}
+
+function updateChartStatus(meta = {}, warning = '', count = 0) {
+  const el = $('chartStatus');
+  if (!el) return;
+  const source = (meta.source || '').toLowerCase();
+  const parts = [];
+  let css = 'chart-status';
+  if (source === 'live') {
+    parts.push('Live Tiingo data');
+    css += ' positive';
+  } else if (source === 'eod-fallback') {
+    parts.push('Tiingo EOD fallback');
+    css += ' warning';
+  } else if (source === 'mock') {
+    parts.push('Sample data (offline)');
+    css += ' warning';
+  } else if (source) {
+    parts.push(source.replace(/-/g, ' '));
+  } else {
+    parts.push('Awaiting market data…');
+    css += ' warning';
+  }
+  if (count) {
+    parts.push(`${count} pts`);
+  }
+  if (meta.fallback && meta.fallback !== 'mock') {
+    parts.push(`fallback: ${meta.fallback}`);
+  }
+  if (warning) {
+    parts.push(warning);
+  }
+  el.textContent = parts.join(' · ') || 'Awaiting market data…';
+  el.className = css;
+  el.title = meta.chosenKey ? `Source key: ${meta.chosenKey}` : '';
+}
+
+function computeQuoteStats(row) {
+  if (!row || typeof row !== 'object') return null;
+  const price = Number(row.last ?? row.close ?? row.price);
+  if (!Number.isFinite(price)) return null;
+  const base = Number(
+    Number.isFinite(Number(row.previousClose)) ? row.previousClose
+      : Number.isFinite(Number(row.prevClose)) ? row.prevClose
+        : Number.isFinite(Number(row.open)) ? row.open
+          : price,
+  );
+  const changeAbs = Number.isFinite(base) ? price - Number(base) : 0;
+  const changePct = Number.isFinite(base) && Math.abs(base) > 1e-8 ? (changeAbs / Number(base)) * 100 : 0;
+  return {
+    price,
+    changeAbs,
+    changePct,
+    exchange: (row.exchange || row.exchangeCode || row.mic || '').toUpperCase(),
+    currency: row.currency || 'USD',
+    asOf: row.date || row.timestamp || row.datetime || new Date().toISOString(),
+  };
+}
+
+function setWatchlistQuote(item, row, meta = {}) {
+  if (!item) return;
+  const key = getWatchlistKey(item);
+  if (!key) return;
+  const stats = computeQuoteStats(row);
+  if (!stats) return;
+  watchlistQuotes.set(key, { ...stats, symbol: item.symbol, name: item.name || '', source: meta.source || '' });
+}
+
+function renderMarketMovers() {
+  const table = $('marketMoversTable');
+  if (!table) return;
+  const body = table.querySelector('tbody');
+  if (!body) return;
+  body.innerHTML = '';
+  const entries = (watchlist.length ? watchlist : DEFAULT_WATCHLIST)
+    .map((item) => {
+      const key = getWatchlistKey(item);
+      const stats = watchlistQuotes.get(key);
+      if (!stats) return null;
+      return { ...stats, symbol: item.symbol };
+    })
+    .filter(Boolean);
+
+  if (!entries.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 3;
+    cell.className = 'muted';
+    cell.textContent = 'Price data unavailable. Add symbols or wait for refresh.';
+    row.appendChild(cell);
+    body.appendChild(row);
+    return;
+  }
+
+  entries.sort((a, b) => b.changePct - a.changePct);
+  entries.slice(0, 10).forEach((entry) => {
+    const tr = document.createElement('tr');
+    const changeClass = entry.changeAbs >= 0 ? 'positive-change' : 'negative-change';
+    tr.innerHTML = `
+      <td class="mono">${entry.symbol}</td>
+      <td>${fmt(entry.price)}</td>
+      <td class="${changeClass}">${fmtPct(entry.changePct)}</td>
+    `;
+    body.appendChild(tr);
+  });
+}
+
+async function refreshWatchlistQuotes() {
+  const entries = (watchlist.length ? watchlist : DEFAULT_WATCHLIST).slice(0, WATCHLIST_FETCH_LIMIT);
+  if (!entries.length) {
+    watchlistQuotes.clear();
+    renderMarketMovers();
+    return;
+  }
+  const results = await Promise.all(entries.map((item) =>
+    callTiingo({ symbol: item.symbol, kind: 'intraday_latest' }, { silent: true })
+      .then((res) => ({ item, res }))
+      .catch((err) => {
+        console.warn('Quote refresh failed', item.symbol, err);
+        return null;
+      })
+  ));
+  let updated = false;
+  results.forEach((result) => {
+    if (!result) return;
+    const { item, res } = result;
+    const rows = Array.isArray(res?.data) ? res.data : [];
+    const row = rows[0] || null;
+    if (row) {
+      setWatchlistQuote(item, row, res.meta || {});
+      updated = true;
+      if (res.meta) updateApiBadge(res.meta);
+    }
+  });
+  if (updated) {
+    renderWatchlist();
+  }
+  renderMarketMovers();
+}
+
+function startWatchlistAutoRefresh() {
+  if (watchlistRefreshTimer) {
+    clearInterval(watchlistRefreshTimer);
+  }
+  watchlistRefreshTimer = setInterval(() => {
+    refreshWatchlistQuotes();
+    if (currentSymbol) {
+      loadLatestQuote(currentSymbol, { silent: true }).catch(() => {});
+    }
+  }, WATCHLIST_REFRESH_INTERVAL);
+}
+
+function startClock() {
+  const container = $('digitalClockContainer');
+  if (!container) return;
+  const grid = document.createElement('div');
+  grid.className = 'digital-clock-grid';
+  container.innerHTML = '';
+  container.appendChild(grid);
+
+  const render = () => {
+    grid.innerHTML = '';
+    const now = Date.now();
+    CLOCK_ZONES.forEach(({ label, tz }) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'clock-item';
+      const date = new Date(now);
+      const timeText = date.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+        timeZone: tz,
+      });
+      const dateText = date.toLocaleDateString([], {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: tz,
+      });
+      wrapper.innerHTML = `
+        <div class="clock-zone-name">${label}</div>
+        <div class="clock-time">${timeText}</div>
+        <div class="clock-date">${dateText}</div>
+      `;
+      grid.appendChild(wrapper);
+    });
+  };
+
+  render();
+  setInterval(render, 1000);
+}
+
+function formatRelativeTime(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.round(diffMs / 60000);
+  if (diffMinutes <= 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes} min ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours} hr${diffHours === 1 ? '' : 's'} ago`;
+  const diffDays = Math.round(diffHours / 24);
+  return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+}
+
+async function loadNews(source = 'All') {
+  const feed = $('news-feed');
+  if (!feed) return;
+  feed.innerHTML = '<div class="muted">Loading news…</div>';
+  try {
+    const resp = await fetch(`${API}/news?source=${encodeURIComponent(source)}`, {
+      headers: { accept: 'application/json' },
+    });
+    const payload = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(payload?.error || resp.statusText);
+    }
+    const articles = Array.isArray(payload?.articles) ? payload.articles : [];
+    if (!articles.length) {
+      feed.innerHTML = '<div class="muted">No articles available right now.</div>';
+      return;
+    }
+    feed.innerHTML = '';
+    articles.forEach((article) => {
+      const item = document.createElement('div');
+      item.className = 'news-item';
+      const relative = formatRelativeTime(article.publishedAt);
+      const metaParts = [article.source || source];
+      if (relative) metaParts.push(relative);
+      item.innerHTML = `
+        <a href="${article.url}" target="_blank" rel="noopener">${article.title}</a>
+        <small>${metaParts.join(' · ')}</small>
+      `;
+      feed.appendChild(item);
+    });
+  } catch (err) {
+    feed.innerHTML = `<div class="muted">News unavailable. ${err.message || err}</div>`;
+  }
+}
+
+function setupNews() {
+  const container = $('newsApiButtons');
+  if (!container) return;
+  container.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-source]');
+    if (!button) return;
+    container.querySelectorAll('button').forEach((btn) => {
+      btn.classList.toggle('active', btn === button);
+    });
+    loadNews(button.dataset.source || 'All');
+  });
+  loadNews('All');
+}
+
+function getStoredProfile() {
+  try {
+    const raw = JSON.parse(localStorage.getItem('userProfile') || 'null');
+    if (raw && typeof raw === 'object') {
+      return { name: raw.name || '', email: raw.email || '' };
+    }
+  } catch (err) {
+    console.warn('Failed to parse stored profile', err);
+  }
+  return { name: '', email: '' };
+}
+
+function saveProfile(profile) {
+  localStorage.setItem('userProfile', JSON.stringify({
+    name: profile.name || '',
+    email: profile.email || '',
+  }));
+}
+
+async function sendWatchlistSummary() {
+  const statusEl = $('sendSummaryStatus');
+  const btn = $('sendSummaryBtn');
+  const nameEl = $('userName');
+  const emailEl = $('userEmail');
+  if (!statusEl || !btn || !nameEl || !emailEl) return;
+  const profile = { name: nameEl.value.trim(), email: emailEl.value.trim() };
+  if (!profile.email) {
+    statusEl.textContent = 'Add your email address before sending a summary.';
+    statusEl.className = 'status-msg error';
+    return;
+  }
+  saveProfile(profile);
+  const universe = watchlist.length ? watchlist : DEFAULT_WATCHLIST;
+  const lines = universe.map((item) => {
+    const stats = watchlistQuotes.get(getWatchlistKey(item));
+    const price = stats ? fmt(stats.price) : '—';
+    const pct = stats ? fmtPct(stats.changePct) : '—';
+    return `${item.symbol} ${price} (${pct})`;
+  });
+  statusEl.textContent = 'Sending summary…';
+  statusEl.className = 'status-msg';
+  btn.disabled = true;
+  try {
+    const res = await fetch(`${API}/sendEmail`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        template_params: {
+          user_name: profile.name || 'Trader',
+          user_email: profile.email,
+          watchlist_lines: lines.join('\n'),
+          generated_at: new Date().toISOString(),
+        },
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok || body?.error) {
+      throw new Error(body?.error || res.statusText || 'Unable to send summary');
+    }
+    statusEl.textContent = 'Summary sent successfully!';
+    statusEl.className = 'status-msg success';
+  } catch (err) {
+    statusEl.textContent = err.message || 'Unable to send summary.';
+    statusEl.className = 'status-msg error';
+  } finally {
+    btn.disabled = false;
+    setTimeout(() => {
+      statusEl.textContent = '';
+      statusEl.className = 'status-msg';
+    }, 4000);
+  }
+}
+
+function setupProfile() {
+  const form = $('profileForm');
+  if (!form) return;
+  const nameEl = $('userName');
+  const emailEl = $('userEmail');
+  const confirmationEl = $('saveConfirmation');
+  const stored = getStoredProfile();
+  if (nameEl) nameEl.value = stored.name || '';
+  if (emailEl) emailEl.value = stored.email || '';
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const profile = {
+      name: nameEl?.value.trim() || '',
+      email: emailEl?.value.trim() || '',
+    };
+    saveProfile(profile);
+    if (confirmationEl) {
+      confirmationEl.textContent = 'Details saved successfully!';
+      setTimeout(() => {
+        confirmationEl.textContent = '';
+      }, 3000);
+    }
+  });
+  const sendBtn = $('sendSummaryBtn');
+  if (sendBtn) {
+    sendBtn.addEventListener('click', () => {
+      sendWatchlistSummary();
+    });
   }
 }
 
@@ -418,10 +846,18 @@ function renderChart(rows, intraday) {
   }
 }
 
-async function loadLatestQuote(symbol) {
-  const res = await callTiingo({ symbol, kind: 'intraday_latest' });
+async function loadLatestQuote(symbol, options = {}) {
+  const res = await callTiingo({ symbol, kind: 'intraday_latest' }, options);
   const q = Array.isArray(res?.data) ? res.data[0] : null;
+  if (res?.meta) updateApiBadge(res.meta);
   renderQuote(q);
+  const match = watchlist.find((item) => item.symbol === String(symbol).toUpperCase());
+  if (match && q) {
+    setWatchlistQuote(match, q, res.meta || {});
+    renderWatchlist();
+    renderMarketMovers();
+  }
+  return { quote: q, meta: res?.meta, warning: res?.warning };
 }
 
 function tfParams(tf) {
@@ -451,9 +887,12 @@ async function loadTimeframe(tf) {
     : [];
   if (!rows.length) {
     showError('No data returned.');
+    updateChartStatus(res?.meta || {}, res?.warning || 'No data returned', 0);
     return;
   }
   renderChart(rows, intraday);
+  updateChartStatus(res?.meta || {}, res?.warning || '', rows.length);
+  if (res?.meta) updateApiBadge(res.meta);
   if (intraday) {
     updateRangeStats([]);
   }
@@ -488,7 +927,12 @@ async function init() {
   loadStoredWatchlist();
   setupWatchlist();
   setupSearch();
+  setupNews();
+  setupProfile();
+  startClock();
   renderWatchlist();
+  renderMarketMovers();
+  updateApiBadge({});
   $('stockSymbol').textContent = currentSymbol;
   $('stockName').textContent = currentSymbolName;
   $('exchangeAcronym').textContent = currentExchange ? ` ${currentExchange}` : '';
@@ -502,6 +946,12 @@ async function init() {
   } catch (err) {
     console.warn('Initial timeframe load failed', err);
   }
+  try {
+    await refreshWatchlistQuotes();
+  } catch (err) {
+    console.warn('Initial watchlist refresh failed', err);
+  }
+  startWatchlistAutoRefresh();
 
   document.querySelectorAll('#tfControls button').forEach((btn) => {
     btn.addEventListener('click', async () => {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,17 @@
 <body>
   <div id="loading"><i class="fa-solid fa-spinner"></i>&nbsp;Loading…</div>
 
+  <nav class="top-nav" aria-label="Primary">
+    <div class="nav-brand">Good Hope Desk</div>
+    <div class="nav-links">
+      <a href="index.html" class="active">Trading Desk</a>
+      <a href="professional-desk.html">Professional Desk</a>
+      <a href="quant-screener.html">Quant Screener</a>
+      <a href="valuation-lab.html">Valuation Lab</a>
+      <a href="ai-analyst.html">AI Analyst</a>
+    </div>
+  </nav>
+
   <div class="main-container">
     <main class="main-content">
       <div id="error"></div>


### PR DESCRIPTION
## Summary
- add a primary navigation bar so the trading desk can jump between existing workspace pages
- surface Tiingo meta information while refreshing watchlist quotes, market movers, and chart status from live data
- wire the sidebar news feed and profile/email actions to their Netlify API counterparts and add utility widgets like the world clock

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e76751148329aa8d94970526e23f