### PR TITLE
Add market intelligence feeds and document review shell

### DIFF
--- a/professional-desk.html
+++ b/professional-desk.html
@@ -86,6 +86,31 @@
             <p>Stream proprietary desk notes, sell-side models, and machine summaries alongside price structure.</p>
           </article>
         </section>
+        <section class="pro-intel-grid fade-in" style="animation-delay: 0.2s">
+          <div class="pro-intel-column" id="intel-streams">
+            <article class="pro-card pro-feed-card placeholder-card">
+              <header class="pro-feed-header">
+                <div class="pro-feed-heading">
+                  <h3>Market Intelligence</h3>
+                  <p class="muted">Loading latest headlines and filings…</p>
+                </div>
+              </header>
+              <div class="pro-feed-body">
+                <div class="pro-feed-loader">Connecting to Tiingo…</div>
+              </div>
+            </article>
+          </div>
+          <div class="pro-intel-column" id="intel-tools">
+            <article class="pro-card pro-shell-card placeholder-card">
+              <header class="pro-shell-header">
+                <h3>Workspace Extensions</h3>
+              </header>
+              <div class="pro-shell-body">
+                <p class="muted">Preparing Market Radar and document review modules…</p>
+              </div>
+            </article>
+          </div>
+        </section>
       </main>
     </div>
   </body>

--- a/professional/api-client.js
+++ b/professional/api-client.js
@@ -60,6 +60,20 @@ export async function fetchLatestQuote(symbol) {
   return { symbol: payload?.symbol || upper, row: rows[0] || null, meta: payload?.meta || {}, warning: payload?.warning || '' };
 }
 
+export async function fetchCompanyNews(symbol, { limit = 20 } = {}) {
+  const upper = (symbol || '').trim().toUpperCase() || 'AAPL';
+  const payload = await requestTiingo({ symbol: upper, kind: 'news', limit });
+  const rows = Array.isArray(payload?.data) ? payload.data : [];
+  return { symbol: payload?.symbol || upper, rows, meta: payload?.meta || {}, warning: payload?.warning || '' };
+}
+
+export async function fetchSecFilings(symbol, { limit = 20 } = {}) {
+  const upper = (symbol || '').trim().toUpperCase() || 'AAPL';
+  const payload = await requestTiingo({ symbol: upper, kind: 'filings', limit });
+  const rows = Array.isArray(payload?.data) ? payload.data : [];
+  return { symbol: payload?.symbol || upper, rows, meta: payload?.meta || {}, warning: payload?.warning || '' };
+}
+
 export function describeRange(rangeKey) {
   switch (rangeKey) {
     case '1D':

--- a/professional/feeds.js
+++ b/professional/feeds.js
@@ -1,0 +1,428 @@
+const SOURCE_VARIANTS = {
+  live: { label: 'Live Feed', variant: 'live' },
+  'eod-fallback': { label: 'Fallback Feed', variant: 'fallback' },
+  mock: { label: 'Sample Data', variant: 'mock' },
+};
+
+function describeSource(meta = {}) {
+  const key = meta.source && SOURCE_VARIANTS[meta.source] ? meta.source : 'live';
+  const { label, variant } = SOURCE_VARIANTS[key] || SOURCE_VARIANTS.live;
+  const extras = [];
+  if (meta.mockSource) {
+    extras.push(`origin: ${meta.mockSource}`);
+  }
+  if (meta.reason) {
+    extras.push(`reason: ${meta.reason}`);
+  }
+  if (meta.kind) {
+    extras.push(`kind: ${meta.kind}`);
+  }
+  return {
+    label,
+    variant,
+    title: [`Source: ${label}`, ...extras].join('\n'),
+  };
+}
+
+function formatRelativeTime(input) {
+  if (!input) return '';
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.max(0, Math.round(diffMs / 60000));
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.round(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined });
+}
+
+function createElement(tag, className, textContent) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  if (textContent !== undefined) el.textContent = textContent;
+  return el;
+}
+
+function createFeedCard({ title, subtitle, emptyMessage }) {
+  const card = createElement('section', 'pro-card pro-feed-card');
+  const header = createElement('header', 'pro-feed-header');
+  const headingWrap = createElement('div', 'pro-feed-heading');
+  const heading = createElement('h3');
+  heading.textContent = title;
+  headingWrap.appendChild(heading);
+
+  if (subtitle) {
+    if (typeof subtitle === 'string') {
+      const sub = createElement('p', 'muted', subtitle);
+      headingWrap.appendChild(sub);
+    } else {
+      subtitle.classList.add('muted');
+      headingWrap.appendChild(subtitle);
+    }
+  }
+
+  const badge = createElement('span', 'pro-badge');
+  const sourceInfo = describeSource();
+  badge.dataset.variant = sourceInfo.variant;
+  badge.textContent = sourceInfo.label;
+  badge.title = sourceInfo.title;
+
+  const headerMeta = createElement('div', 'pro-feed-header-meta');
+  headerMeta.appendChild(badge);
+
+  header.append(headingWrap, headerMeta);
+  card.appendChild(header);
+
+  const notice = createElement('div', 'pro-feed-notice muted');
+  notice.hidden = true;
+  card.appendChild(notice);
+
+  const body = createElement('div', 'pro-feed-body');
+  const loader = createElement('div', 'pro-feed-loader', 'Fetching latest…');
+  const empty = createElement('div', 'pro-feed-empty', emptyMessage || 'No records available.');
+  empty.hidden = true;
+  const list = createElement('div', 'pro-feed-scroll');
+  list.setAttribute('role', 'list');
+
+  body.append(loader, empty, list);
+  card.appendChild(body);
+
+  const setNotice = (message, variant = 'muted') => {
+    if (!message) {
+      notice.hidden = true;
+      notice.textContent = '';
+      notice.dataset.variant = '';
+      return;
+    }
+    notice.hidden = false;
+    notice.textContent = message;
+    notice.dataset.variant = variant === 'muted' ? '' : variant;
+  };
+
+  const setSource = (meta = {}) => {
+    const info = describeSource(meta);
+    badge.dataset.variant = info.variant;
+    badge.textContent = info.label;
+    badge.title = info.title;
+  };
+
+  const setLoading = (flag) => {
+    if (flag) {
+      loader.hidden = false;
+      card.classList.add('is-loading');
+    } else {
+      loader.hidden = true;
+      card.classList.remove('is-loading');
+    }
+  };
+
+  const setItems = (nodes) => {
+    list.innerHTML = '';
+    if (Array.isArray(nodes) && nodes.length) {
+      nodes.forEach((node) => {
+        if (node) {
+          node.setAttribute('role', 'listitem');
+          list.appendChild(node);
+        }
+      });
+      empty.hidden = true;
+    } else {
+      empty.hidden = false;
+    }
+    loader.hidden = true;
+  };
+
+  return {
+    element: card,
+    setItems,
+    setNotice,
+    setSource,
+    setLoading,
+  };
+}
+
+function buildNewsItem(item, { onOpen } = {}) {
+  const entry = createElement('article', 'pro-feed-item');
+
+  const link = createElement('a', 'pro-feed-headline');
+  link.textContent = item.headline || 'Untitled headline';
+  if (item.url) {
+    link.href = item.url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    if (typeof onOpen === 'function') {
+      link.addEventListener('click', () => onOpen(item));
+    }
+  } else {
+    link.href = '#';
+    link.classList.add('is-disabled');
+    link.addEventListener('click', (event) => event.preventDefault());
+  }
+  entry.appendChild(link);
+
+  const meta = createElement('div', 'pro-feed-meta');
+  const source = createElement('span');
+  source.textContent = item.source || 'Tiingo';
+  const time = createElement('time');
+  time.textContent = formatRelativeTime(item.publishedAt);
+  if (item.publishedAt) {
+    time.dateTime = item.publishedAt;
+  }
+  meta.append(source, createElement('span', null, '•'), time);
+  entry.appendChild(meta);
+
+  if (item.summary) {
+    const summary = createElement('p', 'pro-feed-summary');
+    summary.textContent = item.summary;
+    entry.appendChild(summary);
+  }
+
+  return entry;
+}
+
+function buildFilingItem(item, { onOpen, onPreview } = {}) {
+  const entry = createElement('article', 'pro-feed-item');
+
+  const header = createElement('div', 'pro-feed-filing-header');
+  const type = createElement('span', 'pro-pill');
+  type.textContent = item.documentType || 'Filing';
+  header.appendChild(type);
+
+  const link = createElement('a', 'pro-feed-headline');
+  link.textContent = item.headline || item.documentType || 'Regulatory filing';
+  if (item.url) {
+    link.href = item.url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    if (typeof onOpen === 'function') {
+      link.addEventListener('click', () => onOpen(item));
+    }
+  } else {
+    link.href = '#';
+    link.classList.add('is-disabled');
+    link.addEventListener('click', (event) => event.preventDefault());
+  }
+  header.appendChild(link);
+  entry.appendChild(header);
+
+  const meta = createElement('div', 'pro-feed-meta');
+  const source = createElement('span');
+  source.textContent = item.source || 'SEC';
+  const time = createElement('time');
+  time.textContent = formatRelativeTime(item.publishedAt);
+  if (item.publishedAt) {
+    time.dateTime = item.publishedAt;
+  }
+  meta.append(source, createElement('span', null, '•'), time);
+  entry.appendChild(meta);
+
+  if (item.summary) {
+    const summary = createElement('p', 'pro-feed-summary');
+    summary.textContent = item.summary;
+    entry.appendChild(summary);
+  }
+
+  if (item.url && typeof onPreview === 'function') {
+    const actionRow = createElement('div', 'pro-feed-actions');
+    const previewButton = createElement('button', 'pro-button tertiary', 'Preview filing');
+    previewButton.type = 'button';
+    previewButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      onPreview(item);
+    });
+    actionRow.appendChild(previewButton);
+    entry.appendChild(actionRow);
+  }
+
+  if (typeof onPreview === 'function') {
+    entry.addEventListener('dblclick', () => onPreview(item));
+  }
+
+  return entry;
+}
+
+export function createNewsFeed(options = {}) {
+  const subtitle = createElement('p');
+  subtitle.innerHTML = 'Latest headlines for <span data-active-symbol></span>.';
+  const feed = createFeedCard({ title: 'News Feed', subtitle, emptyMessage: 'No headlines published yet.' });
+
+  return {
+    element: feed.element,
+    setLoading: feed.setLoading,
+    update(data = {}) {
+      const items = Array.isArray(data.rows) ? data.rows : [];
+      const nodes = items.map((item) => buildNewsItem(item, options));
+      feed.setItems(nodes);
+      feed.setSource(data.meta || {});
+      feed.setNotice(data.warning || '', data.warning ? 'warning' : 'muted');
+    },
+  };
+}
+
+export function createFilingsFeed(options = {}) {
+  const subtitle = createElement('p');
+  subtitle.innerHTML = 'Recent SEC activity for <span data-active-symbol></span>.';
+  const feed = createFeedCard({ title: 'SEC Filings', subtitle, emptyMessage: 'No filings available.' });
+  const nodeMap = new Map();
+
+  return {
+    element: feed.element,
+    setLoading: feed.setLoading,
+    update(data = {}) {
+      const items = Array.isArray(data.rows) ? data.rows : [];
+      nodeMap.clear();
+      const nodes = items.map((item) => {
+        const node = buildFilingItem(item, options);
+        const id = item?.id || item?.url || (item?.documentType ? `${item.documentType}-${item?.publishedAt || ''}` : item?.publishedAt || '');
+        if (id) {
+          node.dataset.filingId = id;
+          nodeMap.set(id, node);
+        }
+        return node;
+      });
+      feed.setItems(nodes);
+      feed.setSource(data.meta || {});
+      feed.setNotice(data.warning || '', data.warning ? 'warning' : 'muted');
+    },
+    setActive(id) {
+      const activeId = id || '';
+      nodeMap.forEach((node, key) => {
+        if (!node) return;
+        if (key === activeId) {
+          node.classList.add('is-active');
+        } else {
+          node.classList.remove('is-active');
+        }
+      });
+    },
+  };
+}
+
+export function createMarketRadarShell(options = {}) {
+  const card = createElement('section', 'pro-card pro-shell-card');
+  const header = createElement('header', 'pro-shell-header');
+  const title = createElement('h3', null, 'Market Radar');
+  const badge = createElement('span', 'pro-badge subtle', 'Quant Screener');
+  header.append(title, badge);
+  card.appendChild(header);
+
+  const body = createElement('div', 'pro-shell-body');
+  const paragraph = createElement(
+    'p',
+    'muted',
+    'Monitor breadth, liquidity pockets, and volatility regimes. The Market Radar will host the forthcoming quant screener heatmap.',
+  );
+  body.appendChild(paragraph);
+
+  const actions = createElement('div', 'pro-shell-actions');
+  const screenerButton = createElement('a', 'pro-button primary', 'Launch Screener');
+  screenerButton.href = options.screenerUrl || 'quant-screener.html';
+  screenerButton.target = options.openInNewTab ? '_blank' : '_self';
+  screenerButton.rel = 'noopener';
+  actions.appendChild(screenerButton);
+
+  if (options.additionalLinks?.length) {
+    options.additionalLinks.forEach((link) => {
+      const btn = createElement('a', 'pro-button secondary', link.label || 'Open');
+      btn.href = link.href || '#';
+      btn.target = link.target || (options.openInNewTab ? '_blank' : '_self');
+      if (btn.target === '_blank') {
+        btn.rel = 'noopener';
+      }
+      actions.appendChild(btn);
+    });
+  } else {
+    const analystLink = createElement('a', 'pro-button secondary', 'AI Analyst');
+    analystLink.href = options.analystUrl || 'ai-analyst.html';
+    analystLink.target = options.openInNewTab ? '_blank' : '_self';
+    analystLink.rel = 'noopener';
+    actions.appendChild(analystLink);
+  }
+
+  body.appendChild(actions);
+  card.appendChild(body);
+
+  return { element: card };
+}
+
+export function createDocumentViewer(options = {}) {
+  const card = createElement('section', 'pro-card pro-document-review');
+  const header = createElement('header', 'pro-shell-header');
+  const title = createElement('h3', null, 'Document Review');
+  const badge = createElement('span', 'pro-badge subtle', 'Inline preview');
+  header.append(title, badge);
+  card.appendChild(header);
+
+  const info = createElement('div', 'pro-document-meta muted');
+  const name = createElement('strong');
+  info.appendChild(name);
+  const details = createElement('span');
+  info.appendChild(details);
+  info.hidden = true;
+  card.appendChild(info);
+
+  const frame = document.createElement('iframe');
+  frame.className = 'pro-document-frame';
+  frame.title = 'SEC filing preview';
+  frame.loading = 'lazy';
+  frame.hidden = true;
+  card.appendChild(frame);
+
+  const placeholder = createElement(
+    'div',
+    'pro-document-placeholder',
+    'Select a filing to preview it directly within the workspace. Supports most SEC PDF and HTML documents.',
+  );
+  card.appendChild(placeholder);
+
+  const footer = createElement('div', 'pro-shell-actions');
+  const openButton = createElement('a', 'pro-button secondary', 'Open in new tab');
+  openButton.target = '_blank';
+  openButton.rel = 'noopener';
+  openButton.hidden = true;
+  footer.appendChild(openButton);
+  card.appendChild(footer);
+
+  const setDocument = (doc) => {
+    if (!doc || !doc.url) {
+      placeholder.hidden = false;
+      frame.hidden = true;
+      info.hidden = true;
+      openButton.hidden = true;
+      frame.src = 'about:blank';
+      return;
+    }
+
+    placeholder.hidden = true;
+    frame.hidden = false;
+    info.hidden = false;
+    openButton.hidden = false;
+
+    const typeLabel = (doc.documentType || '').trim();
+    const headline = (doc.headline || '').trim();
+    name.textContent = typeLabel && headline ? `${typeLabel} · ${headline}` : typeLabel || headline || 'Selected filing';
+
+    const metaParts = [];
+    if (doc.source) metaParts.push(doc.source);
+    if (doc.publishedAt) {
+      const filedDate = new Date(doc.publishedAt);
+      if (!Number.isNaN(filedDate.getTime())) {
+        metaParts.push(`Filed ${filedDate.toLocaleString()}`);
+      }
+    }
+    details.textContent = metaParts.join(' • ');
+    openButton.href = doc.url;
+    frame.src = doc.url;
+  };
+
+  return {
+    element: card,
+    setDocument,
+    clear: () => setDocument(null),
+  };
+}

--- a/professional/pro-shared.css
+++ b/professional/pro-shared.css
@@ -317,6 +317,24 @@ a:focus {
   gap: 0.5rem;
 }
 
+.pro-intel-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 1.5rem;
+}
+
+@media (max-width: 1200px) {
+  .pro-intel-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.pro-intel-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 .pro-mini-card h3 {
   margin: 0;
   font-size: 1rem;
@@ -339,6 +357,322 @@ a:focus {
   font-size: 0.8rem;
   color: var(--text-secondary);
   text-align: right;
+}
+
+.pro-feed-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 320px;
+}
+
+.pro-feed-header,
+.pro-shell-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pro-feed-heading h3,
+.pro-shell-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.pro-feed-heading p {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+}
+
+.pro-feed-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pro-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.pro-badge[data-variant='mock'] {
+  background: rgba(255, 107, 107, 0.16);
+  color: #ff9f9f;
+}
+
+.pro-badge[data-variant='fallback'] {
+  background: rgba(227, 179, 65, 0.18);
+  color: #e3b341;
+}
+
+.pro-badge.subtle {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 0.78rem;
+}
+
+.pro-feed-notice {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 0.45rem 0.75rem;
+}
+
+.pro-feed-notice[data-variant='warning'] {
+  color: #e3b341;
+  background: rgba(227, 179, 65, 0.14);
+}
+
+.pro-feed-notice[data-variant='error'] {
+  color: var(--negative);
+  background: rgba(255, 107, 107, 0.14);
+}
+
+.pro-feed-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 240px;
+}
+
+.pro-feed-scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding-right: 0.25rem;
+  margin-right: -0.25rem;
+}
+
+.pro-feed-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.pro-feed-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+}
+
+.pro-feed-loader,
+.pro-feed-empty {
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.pro-feed-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.03);
+  transition: border 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pro-feed-item:hover {
+  border-color: var(--accent-strong);
+  background: rgba(76, 141, 255, 0.1);
+}
+
+.pro-feed-item.is-active {
+  border-color: var(--accent);
+  background: rgba(76, 141, 255, 0.18);
+  box-shadow: 0 0 0 1px rgba(76, 141, 255, 0.35);
+}
+
+.pro-feed-headline {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.pro-feed-headline.is-disabled {
+  color: var(--text-secondary);
+  cursor: default;
+}
+
+.pro-feed-headline:is(:hover, :focus-visible) {
+  text-decoration: underline;
+}
+
+.pro-feed-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pro-feed-summary {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.pro-feed-filing-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.pro-feed-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.pro-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pro-shell-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 280px;
+}
+
+.pro-shell-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  flex: 1 1 auto;
+}
+
+.pro-shell-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.pro-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.pro-button.primary {
+  background: linear-gradient(135deg, var(--accent), #5e9bff);
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(76, 141, 255, 0.25);
+}
+
+.pro-button.primary:hover {
+  transform: translateY(-1px);
+}
+
+.pro-button.secondary {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+
+.pro-button.secondary:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.pro-button.tertiary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--accent);
+}
+
+.pro-button.tertiary:hover {
+  border-color: var(--accent);
+  background: rgba(76, 141, 255, 0.08);
+}
+
+.pro-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.pro-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pro-document-review {
+  min-height: 360px;
+}
+
+.pro-document-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.pro-document-meta strong {
+  font-weight: 600;
+}
+
+.pro-document-meta span {
+  color: var(--text-secondary);
+}
+
+.pro-document-frame {
+  width: 100%;
+  height: clamp(260px, 45vh, 520px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(9, 13, 20, 0.7);
+}
+
+.pro-document-placeholder {
+  min-height: clamp(220px, 40vh, 480px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.placeholder-card {
+  opacity: 0.75;
 }
 
 .loading-spinner {


### PR DESCRIPTION
## Summary
- add Tiingo-backed news and SEC filing feeds with inline document preview controls to the professional desk
- introduce a Market Radar shell with navigation buttons to the existing quant screener, valuation lab, and AI analyst experiences
- extend the professional workspace layout and styling to host the new intelligence grid, feed cards, and document review frame

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60637241883298431e78324a7bef5