### PR TITLE
Improve frontend performance and cache AI analyst results

### DIFF
--- a/app.css
+++ b/app.css
@@ -15,8 +15,8 @@ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-se
 .nav-links a{color:var(--text-secondary);text-decoration:none;padding:8px 12px;border-radius:8px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.03);transition:all .2s ease}
 .nav-links a:hover{color:#fff;border-color:rgba(255,255,255,.18)}
 .nav-links a.active{background:var(--accent-blue);color:#fff;border-color:rgba(255,255,255,.25)}
-.main-content{flex:3;padding:24px;display:flex;flex-direction:column;gap:20px;overflow-y:auto;min-width:0}
-.sidebar{flex:1;background-color:rgba(31,37,51,.95);padding:24px;display:flex;flex-direction:column;gap:20px;overflow-y:auto;border-left:1px solid var(--border-color);backdrop-filter:blur(4px);min-width:280px}
+.main-content{flex:3;padding:24px;display:flex;flex-direction:column;gap:20px;overflow-y:auto;min-width:0;min-height:0;-webkit-overflow-scrolling:touch}
+.sidebar{flex:1;background-color:rgba(31,37,51,.95);padding:24px;display:flex;flex-direction:column;gap:20px;overflow-y:auto;border-left:1px solid var(--border-color);backdrop-filter:blur(4px);min-width:280px;min-height:0;-webkit-overflow-scrolling:touch}
 @supports not ((-webkit-backdrop-filter:blur(4px)) or (backdrop-filter:blur(4px))){.sidebar{background-color:rgba(31,37,51,.98)}}
 .card{background-color:rgba(31,37,51,.92);border-radius:14px;padding:20px;border:1px solid var(--border-color);box-shadow:var(--shadow-elevated);backdrop-filter:blur(2px)}
 @supports not ((-webkit-backdrop-filter:blur(2px)) or (backdrop-filter:blur(2px))){.card{background-color:rgba(31,37,51,.98)}}

--- a/index.html
+++ b/index.html
@@ -5,9 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Trading Desk — Good Hope</title>
 
+  <!-- perf hints for third-party assets -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+
   <!-- libs -->
-  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <!-- keep repo filename -->
   <link rel="stylesheet" href="app.css">


### PR DESCRIPTION
## Summary
- defer third-party libraries and add responsive overflow tweaks for smoother page rendering
- reuse the price chart instance, guard timeframe reloads, and surface init failures for faster UI interactions
- introduce short-lived caching for AI analyst intel with cache-aware headers and responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d67211d4f88329b04476e735bdefd5