### PR TITLE
Normalize AI Analyst Desk payload handling

### DIFF
--- a/quant-screener.js
+++ b/quant-screener.js
@@ -1,3 +1,5 @@
+import normalizeAiAnalystPayload from './utils/ai-analyst-normalizer.js';
+
 const $ = (selector) => document.querySelector(selector);
 
 const fmtCurrency = (value) => {
@@ -21,12 +23,20 @@ async function fetchIntel(symbol) {
   const url = new URL('/api/aiAnalyst', window.location.origin);
   url.searchParams.set('symbol', symbol);
   url.searchParams.set('limit', 120);
+  url.searchParams.set('priceLimit', 120);
   url.searchParams.set('timeframe', '3M');
+  url.searchParams.set('newsLimit', 12);
+  url.searchParams.set('documentLimit', 12);
   const response = await fetch(url, { headers: { accept: 'application/json' } });
   if (!response.ok) {
     throw new Error(`Failed to analyse ${symbol}: ${response.status}`);
   }
-  return response.json();
+  const body = await response.json();
+  const warningHeader =
+    response.headers.get('x-ai-analyst-warning')
+    || response.headers.get('x-intel-warning')
+    || '';
+  return normalizeAiAnalystPayload(body, { warningHeader });
 }
 
 function parseUniverse(raw) {

--- a/tests/aiAnalystNormalizer.spec.js
+++ b/tests/aiAnalystNormalizer.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import normalizeAiAnalystPayload from '../utils/ai-analyst-normalizer.js';
+
+describe('normalizeAiAnalystPayload', () => {
+  it('returns legacy payloads unchanged when data property is present', () => {
+    const legacy = { data: { foo: 'bar' }, warning: 'Heads up' };
+    const result = normalizeAiAnalystPayload(legacy, { warningHeader: 'ignored' });
+    expect(result.data).toEqual({ foo: 'bar' });
+    expect(result.warning).toBe('Heads up');
+  });
+
+  it('normalizes modern orchestrator responses into desk-compatible shape', () => {
+    const body = {
+      symbol: 'msft',
+      generatedAt: '2024-05-01T00:00:00.000Z',
+      tiingo: {
+        data: {
+          valuation: { price: 100, valuation: { fairValue: 120 } },
+          fundamentals: { metrics: { revenuePerShare: 10 } },
+          news: [
+            {
+              headline: 'Earnings beat expectations',
+              summary: 'Revenue up 20%.',
+              source: 'Reuters',
+              url: 'https://example.com/news',
+              publishedAt: '2024-04-20T10:00:00.000Z',
+              sentiment: 0.6,
+            },
+          ],
+          documents: [
+            { headline: '10-Q Filing', url: 'https://example.com/doc', publishedAt: '2024-04-15' },
+          ],
+          actions: {
+            dividends: [
+              { exDate: '2024-03-01', payDate: '2024-03-10', amount: 0.68, currency: 'USD' },
+            ],
+            splits: [
+              { exDate: '2023-06-15', numerator: 2, denominator: 1 },
+            ],
+          },
+          priceHistory: [
+            { date: '2024-01-01', close: 90 },
+            { date: '2024-04-30', close: 110 },
+          ],
+        },
+        responses: {
+          valuation: { status: 200 },
+        },
+      },
+      narrative: {
+        text: 'MSFT maintains strong cloud momentum with resilient fundamentals.',
+        source: 'chatgpt-codex',
+        codex: { model: 'gpt-codex' },
+      },
+      warnings: ['Limited filings available'],
+      quant: { priceToEarnings: 28 },
+    };
+
+    const result = normalizeAiAnalystPayload(body, { warningHeader: 'Upstream notice' });
+
+    expect(result.data.symbol).toBe('MSFT');
+    expect(result.data.aiSummary).toContain('cloud momentum');
+    expect(Array.isArray(result.data.timeline)).toBe(true);
+    expect(result.data.timeline.length).toBeGreaterThan(0);
+    expect(result.data.documents[0]).toMatchObject({ headline: '10-Q Filing', documentType: 'Filing' });
+    expect(result.data.valuation.fundamentals).toEqual({ metrics: { revenuePerShare: 10 } });
+    expect(result.warning).toContain('Upstream notice');
+    expect(result.warning).toContain('Limited filings available');
+    expect(result.meta.narrativeSource).toBe('chatgpt-codex');
+  });
+});

--- a/utils/ai-analyst-normalizer.js
+++ b/utils/ai-analyst-normalizer.js
@@ -1,0 +1,162 @@
+const toNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const toDate = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const normalizeDocument = (doc = {}) => ({
+  headline: doc.headline || doc.title || doc.name || 'Document',
+  url: doc.url || doc.link || '#',
+  publishedAt: doc.publishedAt || doc.date || doc.filedAt || doc.updatedAt || null,
+  documentType: doc.documentType || doc.type || 'Filing',
+  source: doc.source || doc.provider || '',
+});
+
+const buildTimeline = (symbol, news = [], actions = {}) => {
+  const entries = [];
+
+  news.forEach((item) => {
+    const publishedAt = toDate(item?.publishedAt);
+    if (!publishedAt) return;
+    entries.push({
+      type: 'news',
+      symbol,
+      headline: item?.headline || item?.title || 'News',
+      summary: item?.summary || '',
+      source: item?.source || '',
+      url: item?.url || '#',
+      publishedAt: publishedAt.toISOString(),
+      sentiment: toNumber(item?.sentiment),
+    });
+  });
+
+  (actions?.dividends || []).forEach((div) => {
+    const date = toDate(div?.exDate || div?.payDate || div?.recordDate);
+    if (!date) return;
+    entries.push({
+      type: 'dividend',
+      symbol,
+      headline: `Dividend $${Number(div?.amount ?? 0).toFixed(2)}`,
+      summary: `Ex-date ${div?.exDate || '—'} · Pay date ${div?.payDate || '—'}`,
+      publishedAt: date.toISOString(),
+      amount: toNumber(div?.amount),
+      currency: div?.currency || 'USD',
+    });
+  });
+
+  (actions?.splits || []).forEach((split) => {
+    const date = toDate(split?.exDate);
+    if (!date) return;
+    const ratioNumerator = Number.isFinite(Number(split?.numerator)) ? split.numerator : 1;
+    const ratioDenominator = Number.isFinite(Number(split?.denominator)) ? split.denominator : 1;
+    entries.push({
+      type: 'split',
+      symbol,
+      headline: `Stock split ${ratioNumerator}:${ratioDenominator}`,
+      summary: 'Corporate action recorded by Tiingo.',
+      publishedAt: date.toISOString(),
+    });
+  });
+
+  return entries
+    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))
+    .slice(0, 40);
+};
+
+const coalesceWarning = (bodyWarning, headerWarning, warningsArray = [], narrativeErrors = {}) => {
+  const combined = [bodyWarning, headerWarning, ...warningsArray];
+  combined.push(...Object.values(narrativeErrors || {}));
+  return combined
+    .map((message) => (typeof message === 'string' ? message.trim() : ''))
+    .filter(Boolean)
+    .join(' | ');
+};
+
+const attachFundamentals = (valuation = {}, fundamentals) => {
+  if (!fundamentals) return valuation;
+  if (valuation && typeof valuation === 'object') {
+    if (!('fundamentals' in valuation) || !valuation.fundamentals) {
+      return { ...valuation, fundamentals };
+    }
+  }
+  return valuation;
+};
+
+export function normalizeAiAnalystPayload(body = {}, { warningHeader } = {}) {
+  if (body && typeof body === 'object' && 'data' in body) {
+    return {
+      data: body.data,
+      warning: body.warning || warningHeader || '',
+      meta: {},
+    };
+  }
+
+  const datasets = body?.tiingo?.data || {};
+  const symbol = (body?.symbol || datasets?.valuation?.symbol || '').toUpperCase();
+  const valuation = attachFundamentals(
+    datasets?.valuation ? { ...datasets.valuation } : {},
+    datasets?.fundamentals,
+  );
+  const news = Array.isArray(datasets?.news) ? datasets.news : [];
+  const actions = datasets?.actions && typeof datasets.actions === 'object' ? datasets.actions : {};
+  const documents = Array.isArray(datasets?.documents)
+    ? datasets.documents.map((doc) => normalizeDocument(doc))
+    : [];
+  const trend = Array.isArray(datasets?.priceHistory)
+    ? datasets.priceHistory
+    : Array.isArray(datasets?.trend)
+      ? datasets.trend
+      : [];
+  const aiSummary = typeof body?.narrative?.text === 'string' && body.narrative.text.trim()
+    ? body.narrative.text.trim()
+    : typeof body?.narrative === 'string' && body.narrative.trim()
+      ? body.narrative.trim()
+      : (valuation?.narrative && typeof valuation.narrative === 'string' ? valuation.narrative : '').trim();
+
+  const timeline = buildTimeline(symbol, news, actions);
+  const generatedAt = body?.generatedAt || body?.tiingo?.generatedAt || '';
+
+  const warning = coalesceWarning(
+    body?.warning,
+    warningHeader,
+    Array.isArray(body?.warnings) ? body.warnings : [],
+    body?.narrative?.errors,
+  );
+
+  const meta = {
+    narrativeSource: body?.narrative?.source || 'fallback',
+    llm: {
+      codex: body?.narrative?.codex,
+      grok: body?.narrative?.grok,
+      gemini: body?.narrative?.gemini,
+    },
+    tiingo: body?.tiingo?.responses || {},
+    quant: body?.quant || null,
+    warnings: Array.isArray(body?.warnings) ? body.warnings : [],
+  };
+
+  return {
+    data: {
+      symbol,
+      valuation,
+      news,
+      documents,
+      actions,
+      timeline,
+      trend,
+      aiSummary,
+      generatedAt,
+      quant: body?.quant || null,
+      meta,
+    },
+    warning,
+    meta,
+  };
+}
+
+export default normalizeAiAnalystPayload;


### PR DESCRIPTION
## Summary
- add a shared normalizer that converts orchestrator responses into the desk-compatible payload shape
- update the AI Analyst and Quant Screener clients to request expanded datasets and consume normalized data
- cover the new normalizer with Vitest unit tests alongside the existing suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6723710e48329a128c95778fc038e