### PR TITLE
Optimize screener batching workflow

### DIFF
--- a/tests/quantScreenerProcessor.spec.js
+++ b/tests/quantScreenerProcessor.spec.js
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeRow, passesFilters, screenUniverse } from '../utils/quant-screener-core.js';
+
+const buildPayload = ({ price, fairValue, marketCap = 1_000_000_000, sector = 'Technology' }) => ({
+  valuation: {
+    valuation: {
+      price,
+      fairValue,
+    },
+    fundamentals: {
+      sector,
+      metrics: {},
+    },
+  },
+  overview: {
+    marketCap,
+    sector,
+  },
+});
+
+describe('screenUniverse', () => {
+  it('processes a small universe sequentially and applies filters', async () => {
+    const universe = ['AAA', 'BBB', 'CCC'];
+    const payloads = {
+      AAA: buildPayload({ price: 100, fairValue: 130 }),
+      BBB: buildPayload({ price: 100, fairValue: 108 }),
+      CCC: buildPayload({ price: 200, fairValue: 260 }),
+    };
+
+    const filters = {
+      minUpside: 10,
+      maxUpside: null,
+      marketCapMin: null,
+      marketCapMax: null,
+      sectors: [],
+      batchCap: 6,
+    };
+
+    const sequence = [];
+    const matches = [];
+
+    const result = await screenUniverse(universe, {
+      fetchIntel: async (symbol) => ({ data: payloads[symbol] }),
+      computeRow,
+      passesFilters: (row) => passesFilters(row, filters),
+      filters,
+      batchCap: filters.batchCap,
+      concurrency: 1,
+      onItemComplete: ({ row, passes }) => {
+        sequence.push(row.symbol);
+        if (passes) {
+          matches.push(row.symbol);
+        }
+      },
+    });
+
+    expect(sequence).toEqual(['AAA', 'BBB', 'CCC']);
+    expect(matches).toEqual(['AAA', 'CCC']);
+    expect(result.matches.map((row) => row.symbol)).toEqual(['AAA', 'CCC']);
+    expect(result.processed.map((row) => row.symbol)).toEqual(['AAA', 'BBB', 'CCC']);
+    expect(result.reachedCap).toBe(false);
+  });
+
+  it('handles large universes with batched concurrency', async () => {
+    const universe = Array.from({ length: 18 }, (_, index) => `SYM${index + 1}`);
+    let active = 0;
+    let maxActive = 0;
+
+    const fetchIntel = vi.fn(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      return { data: buildPayload({ price: 90, fairValue: 120 }) };
+    });
+
+    const filters = {
+      minUpside: null,
+      maxUpside: null,
+      marketCapMin: null,
+      marketCapMax: null,
+      sectors: [],
+      batchCap: universe.length + 5,
+    };
+
+    const result = await screenUniverse(universe, {
+      fetchIntel,
+      computeRow,
+      passesFilters: () => true,
+      filters,
+      batchCap: filters.batchCap,
+      concurrency: 5,
+    });
+
+    expect(fetchIntel).toHaveBeenCalledTimes(universe.length);
+    expect(result.matches).toHaveLength(universe.length);
+    expect(result.processed).toHaveLength(universe.length);
+    expect(maxActive).toBeGreaterThan(1);
+    expect(result.reachedCap).toBe(false);
+  });
+});

--- a/utils/quant-screener-core.js
+++ b/utils/quant-screener-core.js
@@ -1,0 +1,184 @@
+const safeNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const defaultFilters = {
+  minUpside: null,
+  maxUpside: null,
+  marketCapMin: null,
+  marketCapMax: null,
+  sectors: [],
+};
+
+export const mergeFilters = (filters = {}) => ({ ...defaultFilters, ...filters });
+
+export function computeRow(symbol, data) {
+  const valuation = data?.valuation?.valuation || data?.valuation;
+  const valuationRoot = data?.valuation || {};
+  const overview = data?.overview || {};
+  const fundamentals = valuationRoot?.fundamentals || {};
+  const metrics = fundamentals?.metrics || {};
+  const price = valuationRoot?.price ?? valuation?.price ?? valuationRoot?.quote?.price;
+  const fairValue = valuation?.fairValue ?? null;
+  const upside = price && fairValue ? ((fairValue - price) / price) * 100 : null;
+  let marketCap = safeNumber(overview.marketCap);
+  if (!Number.isFinite(marketCap)) {
+    const shares = safeNumber(overview.sharesOutstanding ?? metrics.sharesOutstanding);
+    if (Number.isFinite(shares) && Number.isFinite(price)) {
+      marketCap = price * shares;
+    } else {
+      marketCap = null;
+    }
+  }
+  const sector = overview.sector || fundamentals.sector || fundamentals.profile?.sector || '';
+  const industry = overview.industry || fundamentals.industry || fundamentals.profile?.industry || '';
+  const momentum = (() => {
+    if (!Array.isArray(data?.trend) || data.trend.length < 2) return 0;
+    const first = Number(data.trend[0]?.close ?? data.trend[0]?.price);
+    const last = Number(data.trend[data.trend.length - 1]?.close ?? data.trend[data.trend.length - 1]?.price);
+    if (!Number.isFinite(first) || !Number.isFinite(last) || Math.abs(first) < 1e-6) return 0;
+    return ((last - first) / first) * 100;
+  })();
+  const remark = (data?.aiSummary || '').split('. ').slice(0, 2).join('. ');
+
+  return {
+    symbol,
+    sector,
+    industry,
+    price,
+    fairValue,
+    upside,
+    marketCap,
+    momentum,
+    summary: remark,
+    raw: data,
+  };
+}
+
+export function passesFilters(row, filters = defaultFilters) {
+  const merged = mergeFilters(filters);
+  const { minUpside, maxUpside, marketCapMin, marketCapMax, sectors } = merged;
+
+  if (minUpside !== null) {
+    if (!Number.isFinite(row.upside) || row.upside < minUpside) return false;
+  }
+
+  if (maxUpside !== null) {
+    if (!Number.isFinite(row.upside) || row.upside > maxUpside) return false;
+  }
+
+  if (marketCapMin !== null) {
+    if (!Number.isFinite(row.marketCap) || row.marketCap < marketCapMin) return false;
+  }
+
+  if (marketCapMax !== null) {
+    if (!Number.isFinite(row.marketCap) || row.marketCap > marketCapMax) return false;
+  }
+
+  if (sectors.length) {
+    const rowSector = (row.sector || '').toLowerCase();
+    if (!rowSector) return false;
+    const matches = sectors.some((sector) => rowSector.includes(sector));
+    if (!matches) return false;
+  }
+
+  return true;
+}
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+export function suggestConcurrency(total, explicit) {
+  if (!Number.isFinite(total) || total <= 0) return 1;
+  if (Number.isFinite(explicit) && explicit > 0) {
+    return clamp(Math.floor(explicit), 1, total);
+  }
+  if (total <= 5) return 1;
+  if (total <= 20) return 3;
+  if (total <= 50) return 5;
+  if (total <= 100) return 6;
+  return 8;
+}
+
+export async function screenUniverse(universe, options) {
+  const {
+    fetchIntel,
+    computeRow: compute = computeRow,
+    passesFilters: filterRow = passesFilters,
+    filters = defaultFilters,
+    batchCap = Infinity,
+    concurrency,
+    onItemComplete,
+    onError,
+  } = options || {};
+
+  if (!Array.isArray(universe)) {
+    throw new TypeError('Universe must be an array of symbols.');
+  }
+  if (typeof fetchIntel !== 'function') {
+    throw new TypeError('fetchIntel must be a function.');
+  }
+
+  const total = universe.length;
+  if (!total) {
+    return { matches: [], processed: [], errors: [], reachedCap: false };
+  }
+
+  const parallel = suggestConcurrency(total, concurrency);
+  const matches = [];
+  const processed = [];
+  const errors = [];
+  let processedCount = 0;
+
+  for (let start = 0; start < total; start += parallel) {
+    if (matches.length >= batchCap) break;
+    const slice = universe.slice(start, start + parallel);
+    const settled = await Promise.allSettled(
+      slice.map((symbol) =>
+        Promise.resolve()
+          .then(() => fetchIntel(symbol))
+          .then((payload) => ({ symbol, payload }))
+      )
+    );
+
+    for (let offset = 0; offset < settled.length; offset += 1) {
+      const fallbackSymbol = slice[offset];
+      const outcome = settled[offset];
+      const index = start + offset;
+
+      if (outcome.status === 'fulfilled') {
+        const { symbol = fallbackSymbol, payload } = outcome.value || {};
+        const row = compute(symbol, payload?.data);
+        processed.push(row);
+        processedCount += 1;
+        const passes = filterRow(row, filters);
+        if (passes) {
+          matches.push(row);
+        }
+        const reachedCap = matches.length >= batchCap;
+        onItemComplete?.({
+          symbol,
+          index,
+          row,
+          passes,
+          total,
+          processedCount,
+          matchesCount: matches.length,
+          reachedCap,
+        });
+        if (reachedCap) break;
+      } else {
+        const error = outcome.reason;
+        const symbol = fallbackSymbol;
+        errors.push({ symbol, error });
+        processedCount += 1;
+        onError?.({ symbol, index, error, total, processedCount });
+      }
+    }
+
+    if (matches.length >= batchCap) break;
+  }
+
+  const reachedCap = matches.length >= batchCap && Number.isFinite(batchCap);
+  return { matches, processed, errors, reachedCap };
+}


### PR DESCRIPTION
## Summary
- refactor the quant screener to batch symbol analysis via a reusable processor without changing the interface
- extract shared screening utilities for computing rows, applying filters, and tuning concurrency
- add vitest coverage that exercises small and large universes to guard the new batch processor

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d677ff57a08329ac57ded750c5c211