### PR TITLE
Add AI analyst batch table and batch API

### DIFF
--- a/ai-analyst-batch-table.js
+++ b/ai-analyst-batch-table.js
@@ -1,0 +1,359 @@
+const DEFAULT_SYMBOLS = ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'AMZN'];
+const MAX_SYMBOLS = 12;
+
+const state = {
+  rows: [],
+  sort: { key: 'aiUpsidePct', direction: 'desc' },
+  lastSymbols: [...DEFAULT_SYMBOLS],
+  loading: false,
+  controller: null,
+};
+
+const $ = (selector) => document.querySelector(selector);
+
+const parseSymbols = (raw) => {
+  return (raw || '')
+    .split(/[\s,]+/)
+    .map((token) => token.trim().toUpperCase())
+    .filter((token, index, arr) => token && arr.indexOf(token) === index)
+    .slice(0, MAX_SYMBOLS);
+};
+
+const fmtCurrency = (value, currency = 'USD') => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '—';
+  try {
+    return num.toLocaleString(undefined, {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    });
+  } catch (error) {
+    console.warn('Currency formatting failed', error);
+    return `$${num.toFixed(2)}`;
+  }
+};
+
+const fmtPercent = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '—';
+  const sign = num > 0 ? '+' : num < 0 ? '−' : '';
+  return `${sign}${Math.abs(num).toFixed(1)}%`;
+};
+
+const fmtMultiple = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '—';
+  return `${num.toFixed(1)}×`;
+};
+
+const formatMetricValue = (metric) => {
+  if (!metric || metric.value === null || metric.value === undefined) return '—';
+  switch (metric.unit) {
+    case 'percent':
+      return fmtPercent(metric.value);
+    case 'currency':
+      return fmtCurrency(metric.value, metric.currency || 'USD');
+    case 'multiple':
+      return fmtMultiple(metric.value);
+    default: {
+      const num = Number(metric.value);
+      return Number.isFinite(num) ? num.toLocaleString(undefined, { maximumFractionDigits: 2 }) : '—';
+    }
+  }
+};
+
+const setStatus = (message, tone = 'info') => {
+  const el = $('#batchStatus');
+  if (!el) return;
+  el.textContent = message || '';
+  el.className = `status-message ${tone}`.trim();
+};
+
+const setSummary = (rows) => {
+  const el = $('#batchSummary');
+  if (!el) return;
+  if (!Array.isArray(rows) || !rows.length) {
+    el.textContent = '—';
+    return;
+  }
+  const finiteUpsides = rows
+    .map((row) => Number(row.aiUpsidePct))
+    .filter((value) => Number.isFinite(value));
+  const avgUpside = finiteUpsides.length
+    ? finiteUpsides.reduce((acc, value) => acc + value, 0) / finiteUpsides.length
+    : null;
+  el.textContent = `${rows.length} tickers · Avg upside ${fmtPercent(avgUpside)}`;
+};
+
+const renderPlaceholder = (message) => {
+  const tbody = $('#batchResultsTable tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  const tr = document.createElement('tr');
+  const td = document.createElement('td');
+  td.colSpan = 5;
+  td.className = 'table-empty-cell';
+  td.textContent = message;
+  tr.appendChild(td);
+  tbody.appendChild(tr);
+};
+
+const renderTable = (rows) => {
+  const tbody = $('#batchResultsTable tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  if (!Array.isArray(rows) || !rows.length) {
+    renderPlaceholder(state.loading ? 'Loading batch intelligence…' : 'Run a batch scan to populate results.');
+    return;
+  }
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    const metric1 = row.metrics?.[0] || null;
+    const metric2 = row.metrics?.[1] || null;
+
+    const symbolCell = document.createElement('td');
+    symbolCell.textContent = row.symbol || '—';
+    tr.appendChild(symbolCell);
+
+    const priceCell = document.createElement('td');
+    priceCell.textContent = fmtCurrency(row.price, row.currency || 'USD');
+    tr.appendChild(priceCell);
+
+    const upsideCell = document.createElement('td');
+    upsideCell.textContent = fmtPercent(row.aiUpsidePct);
+    tr.appendChild(upsideCell);
+
+    const metric1Cell = document.createElement('td');
+    metric1Cell.textContent = formatMetricValue(metric1);
+    if (metric1?.label) metric1Cell.title = metric1.label;
+    tr.appendChild(metric1Cell);
+
+    const metric2Cell = document.createElement('td');
+    metric2Cell.textContent = formatMetricValue(metric2);
+    if (metric2?.label) metric2Cell.title = metric2.label;
+    tr.appendChild(metric2Cell);
+
+    tbody.appendChild(tr);
+  });
+};
+
+const getSortValue = (row, key) => {
+  if (!row) return null;
+  if (key === 'metric1') return Number(row.metric1);
+  if (key === 'metric2') return Number(row.metric2);
+  return row[key];
+};
+
+const sortRows = (rows) => {
+  if (!Array.isArray(rows)) return [];
+  const { key, direction } = state.sort;
+  const multiplier = direction === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const va = getSortValue(a, key);
+    const vb = getSortValue(b, key);
+    const aNum = Number(va);
+    const bNum = Number(vb);
+    const aIsFinite = Number.isFinite(aNum);
+    const bIsFinite = Number.isFinite(bNum);
+    if (aIsFinite && bIsFinite) {
+      return (aNum - bNum) * multiplier;
+    }
+    if (aIsFinite) return direction === 'asc' ? -1 : 1;
+    if (bIsFinite) return direction === 'asc' ? 1 : -1;
+    return String(va || '').localeCompare(String(vb || '')) * multiplier;
+  });
+};
+
+const updateSortIndicators = () => {
+  const headers = document.querySelectorAll('#batchResultsTable thead th[data-key]');
+  headers.forEach((th) => {
+    const { key } = th.dataset;
+    if (!key) return;
+    if (state.sort.key === key) {
+      th.dataset.sort = state.sort.direction;
+      th.setAttribute('aria-sort', state.sort.direction === 'asc' ? 'ascending' : 'descending');
+    } else {
+      th.dataset.sort = 'none';
+      th.removeAttribute('aria-sort');
+    }
+  });
+};
+
+const attachSortHandlers = () => {
+  const headers = document.querySelectorAll('#batchResultsTable thead th[data-key]');
+  headers.forEach((th) => {
+    th.dataset.sort = th.dataset.sort || 'none';
+    th.addEventListener('click', () => {
+      const key = th.dataset.key;
+      if (!key || state.loading) return;
+      const nextDirection = state.sort.key === key && state.sort.direction === 'desc' ? 'asc' : 'desc';
+      state.sort = { key, direction: nextDirection };
+      updateSortIndicators();
+      const sorted = sortRows(state.rows);
+      renderTable(sorted);
+    });
+  });
+  updateSortIndicators();
+};
+
+const setLoading = (flag) => {
+  state.loading = flag;
+  const runButton = $('#batchRunButton');
+  const resetButton = $('#batchResetButton');
+  const tableWrapper = $('#batchResultsTable');
+  if (flag) {
+    runButton?.setAttribute('disabled', 'true');
+    resetButton?.setAttribute('disabled', 'true');
+    tableWrapper?.setAttribute('aria-busy', 'true');
+    renderPlaceholder('Loading batch intelligence…');
+  } else {
+    runButton?.removeAttribute('disabled');
+    resetButton?.removeAttribute('disabled');
+    tableWrapper?.removeAttribute('aria-busy');
+  }
+};
+
+const abortInFlight = () => {
+  if (state.controller) {
+    state.controller.abort();
+    state.controller = null;
+  }
+};
+
+const buildRequestUrl = (symbols) => {
+  const url = new URL('/api/aiAnalystBatch', window.location.origin);
+  url.searchParams.set('symbols', symbols.join(','));
+  const lookbackValue = Number($('#lookbackInput')?.value);
+  if (Number.isFinite(lookbackValue) && lookbackValue > 0) {
+    url.searchParams.set('limit', String(Math.min(Math.round(lookbackValue), 500)));
+  }
+  const timeframe = $('#timeframeSelect')?.value;
+  if (timeframe) {
+    url.searchParams.set('timeframe', timeframe);
+  }
+  return url;
+};
+
+const aggregateMessages = (payload) => {
+  const warnings = Array.isArray(payload?.warnings) ? payload.warnings : [];
+  const errors = Array.isArray(payload?.errors) ? payload.errors : [];
+  return [...warnings, ...errors]
+    .map((entry) => {
+      if (!entry) return '';
+      const symbol = entry.symbol ? `${entry.symbol}: ` : '';
+      return `${symbol}${entry.message || entry.warning || entry.error || ''}`.trim();
+    })
+    .filter(Boolean)
+    .join(' | ');
+};
+
+const normaliseRow = (entry = {}) => {
+  const metrics = Array.isArray(entry.metrics) ? entry.metrics.slice(0, 2) : [];
+  return {
+    symbol: entry.symbol || '',
+    price: Number.isFinite(Number(entry.price)) ? Number(entry.price) : null,
+    currency: entry.currency || 'USD',
+    aiUpsidePct: Number.isFinite(Number(entry.aiUpsidePct)) ? Number(entry.aiUpsidePct) : null,
+    metrics,
+    metric1: Number.isFinite(Number(entry.metric1)) ? Number(entry.metric1) : null,
+    metric2: Number.isFinite(Number(entry.metric2)) ? Number(entry.metric2) : null,
+  };
+};
+
+const loadBatchResults = async (symbols) => {
+  const validSymbols = Array.isArray(symbols) && symbols.length ? symbols : DEFAULT_SYMBOLS;
+  abortInFlight();
+  if (!validSymbols.length) {
+    setStatus('Add at least one valid ticker to run a batch scan.', 'error');
+    renderTable([]);
+    return;
+  }
+
+  const controller = new AbortController();
+  state.controller = controller;
+
+  try {
+    setLoading(true);
+    setStatus(`Loading batch intelligence for ${validSymbols.length} tickers…`, 'info');
+    const url = buildRequestUrl(validSymbols);
+    const response = await fetch(url, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errorPayload = await response.json().catch(() => ({}));
+      const message = errorPayload?.error || `Batch request failed (${response.status})`;
+      throw new Error(message);
+    }
+    const payload = await response.json();
+    const rows = Array.isArray(payload?.results)
+      ? payload.results.filter((row) => !row?.error).map((row) => normaliseRow(row))
+      : [];
+    state.rows = rows;
+    state.lastSymbols = [...validSymbols];
+    state.sort = state.sort || { key: 'aiUpsidePct', direction: 'desc' };
+    const sorted = sortRows(rows);
+    renderTable(sorted);
+    setSummary(sorted);
+    const aggregate = aggregateMessages(payload);
+    if (aggregate) {
+      setStatus(aggregate, 'warning');
+    } else {
+      setStatus(`Loaded ${rows.length} tickers from batch call.`, rows.length ? 'success' : 'info');
+    }
+    if (!rows.length) {
+      renderPlaceholder('Batch response returned no usable rows.');
+    }
+  } catch (error) {
+    if (error?.name === 'AbortError') return;
+    console.error('Batch table load failed', error);
+    setStatus(error?.message || 'Unable to load batch intelligence.', 'error');
+    renderTable([]);
+    setSummary([]);
+  } finally {
+    if (state.controller === controller) {
+      state.controller = null;
+    }
+    setLoading(false);
+  }
+};
+
+const handleRunClick = () => {
+  const input = $('#batchSymbolsInput');
+  const symbols = parseSymbols(input?.value || '');
+  loadBatchResults(symbols.length ? symbols : DEFAULT_SYMBOLS);
+};
+
+const handleResetClick = () => {
+  const input = $('#batchSymbolsInput');
+  if (input) {
+    input.value = DEFAULT_SYMBOLS.join(', ');
+  }
+  loadBatchResults([...DEFAULT_SYMBOLS]);
+};
+
+export function initBatchResultsModule() {
+  const input = $('#batchSymbolsInput');
+  if (input && !input.value) {
+    input.value = DEFAULT_SYMBOLS.join(', ');
+  }
+  attachSortHandlers();
+  setSummary([]);
+  renderTable([]);
+  setStatus('Configure tickers and run a batch scan to view aggregate intelligence.', 'info');
+
+  $('#batchRunButton')?.addEventListener('click', handleRunClick);
+  $('#batchResetButton')?.addEventListener('click', handleResetClick);
+  input?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleRunClick();
+    }
+  });
+
+  // Auto-run on load for default coverage.
+  loadBatchResults([...DEFAULT_SYMBOLS]);
+}
+
+export default initBatchResultsModule;

--- a/ai-analyst.css
+++ b/ai-analyst.css
@@ -149,6 +149,21 @@ body {
   margin-top: 1rem;
 }
 
+.batch-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.batch-controls .field {
+  margin-bottom: 0;
+}
+
+.batch-controls .action-row {
+  margin-top: 0;
+}
+
 .btn {
   border-radius: 12px;
   border: none;
@@ -613,6 +628,23 @@ body {
   z-index: 1;
 }
 
+.screener-table th[data-sort='asc']::after,
+.screener-table th[data-sort='desc']::after {
+  display: inline-block;
+  margin-left: 0.35rem;
+  font-size: 0.7rem;
+  color: var(--primary);
+  opacity: 0.75;
+}
+
+.screener-table th[data-sort='asc']::after {
+  content: '▲';
+}
+
+.screener-table th[data-sort='desc']::after {
+  content: '▼';
+}
+
 .screener-table tbody tr:hover {
   background: rgba(74, 215, 168, 0.06);
 }
@@ -620,6 +652,13 @@ body {
 .screener-table td.summary-cell {
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+.table-empty-cell {
+  text-align: center;
+  padding: 1.35rem 1rem;
+  color: var(--muted);
+  font-style: italic;
 }
 
 .legend {

--- a/ai-analyst.html
+++ b/ai-analyst.html
@@ -137,6 +137,44 @@
         </article>
       </div>
 
+      <div class="card large" id="batchResultsCard">
+        <div class="card-header">
+          <h2>Batch intelligence</h2>
+          <span id="batchSummary" class="chip">—</span>
+        </div>
+        <div class="batch-controls">
+          <label class="field" for="batchSymbolsInput">
+            <span>Batch symbols (comma separated)</span>
+            <input id="batchSymbolsInput" type="text" value="AAPL, MSFT, NVDA, GOOGL, AMZN" autocomplete="off" spellcheck="false" />
+          </label>
+          <div class="action-row">
+            <button id="batchRunButton" class="btn primary" type="button">
+              <i class="fa-solid fa-layer-group"></i>
+              Run batch scan
+            </button>
+            <button id="batchResetButton" class="btn ghost" type="button">
+              <i class="fa-solid fa-rotate"></i>
+              Reset list
+            </button>
+          </div>
+          <div id="batchStatus" class="status-message" role="status" aria-live="polite"></div>
+        </div>
+        <div class="table-wrapper" aria-live="polite">
+          <table class="screener-table" id="batchResultsTable">
+            <thead>
+              <tr>
+                <th scope="col" data-key="symbol" data-type="string">Symbol</th>
+                <th scope="col" data-key="price" data-type="number">Price</th>
+                <th scope="col" data-key="aiUpsidePct" data-type="number">AI Upside %</th>
+                <th scope="col" data-key="metric1" data-type="number">Key Metric 1</th>
+                <th scope="col" data-key="metric2" data-type="number">Key Metric 2</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="card large">
         <div class="card-header">
           <h2>Price evolution</h2>

--- a/ai-analyst.js
+++ b/ai-analyst.js
@@ -1,6 +1,7 @@
 import { computeValuationScores, VALUATION_RADAR_LABELS } from './utils/valuation-scorer.js';
 import { enrichError } from './utils/frontend-errors.js';
 import normalizeAiAnalystPayload from './utils/ai-analyst-normalizer.js';
+import initBatchResultsModule from './ai-analyst-batch-table.js';
 
 const $ = (selector) => document.querySelector(selector);
 
@@ -737,6 +738,8 @@ function init() {
       setStatus('Report downloaded as Markdown snapshot.', 'success');
     });
   }
+
+  initBatchResultsModule();
 
   runAnalysis().catch((error) => {
     console.error('Initial analysis failed', error);

--- a/netlify/functions/aiAnalystBatch.js
+++ b/netlify/functions/aiAnalystBatch.js
@@ -1,0 +1,216 @@
+import { gatherSymbolIntel } from './aiAnalyst.js';
+
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '*';
+const corsHeaders = {
+  'access-control-allow-origin': ALLOWED_ORIGIN,
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': 'content-type',
+};
+
+const MAX_SYMBOLS = 20;
+const DEFAULT_CONCURRENCY = 3;
+const MAX_CONCURRENCY = 6;
+const MAX_LIMIT = 500;
+
+const parseSymbols = (raw) => {
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw
+      .map((value) => String(value || '').trim().toUpperCase())
+      .filter((value, index, arr) => value && arr.indexOf(value) === index)
+      .slice(0, MAX_SYMBOLS);
+  }
+  return String(raw)
+    .split(/[\s,]+/)
+    .map((value) => value.trim().toUpperCase())
+    .filter((value, index, arr) => value && arr.indexOf(value) === index)
+    .slice(0, MAX_SYMBOLS);
+};
+
+const handleOptions = () => new Response(null, { status: 204, headers: corsHeaders });
+
+const computeSummary = (intel = {}) => {
+  const symbol = intel.symbol || '';
+  const valuation = intel.valuation || {};
+  const valuationMetrics = valuation.valuation || valuation;
+  const price = Number(valuation.price ?? valuationMetrics.price ?? null);
+  const fairValue = Number(valuationMetrics.fairValue ?? null);
+  let upside = Number(valuationMetrics.upside ?? null);
+  if (!Number.isFinite(upside) && Number.isFinite(price) && Number.isFinite(fairValue) && price !== 0) {
+    upside = ((fairValue - price) / price);
+  }
+  const growthBase = Number(valuationMetrics?.growth?.base ?? null);
+  const marginOfSafety = Number(valuationMetrics?.marginOfSafety ?? null);
+  const currency = intel.overview?.currency || valuation?.currency || 'USD';
+
+  const metricEntries = [
+    {
+      key: 'growthBase',
+      label: 'Base growth CAGR',
+      value: Number.isFinite(growthBase) ? growthBase * 100 : null,
+      unit: 'percent',
+    },
+    {
+      key: 'marginOfSafety',
+      label: 'Margin of safety',
+      value: Number.isFinite(marginOfSafety) ? marginOfSafety * 100 : null,
+      unit: 'percent',
+    },
+  ];
+
+  return {
+    symbol,
+    price: Number.isFinite(price) ? price : null,
+    currency,
+    aiUpsidePct: Number.isFinite(upside) ? upside * 100 : null,
+    metrics: metricEntries,
+    metric1: metricEntries[0]?.value ?? null,
+    metric2: metricEntries[1]?.value ?? null,
+    generatedAt: intel.generatedAt || new Date().toISOString(),
+  };
+};
+
+const normaliseMessage = (entry = {}) => {
+  if (typeof entry === 'string') {
+    return { symbol: '', message: entry };
+  }
+  const symbol = entry.symbol ? String(entry.symbol).toUpperCase() : '';
+  const message = entry.message || entry.warning || entry.error || '';
+  return message
+    ? { symbol, message }
+    : null;
+};
+
+const gatherInBatches = async (symbols, { limit, timeframe, concurrency = DEFAULT_CONCURRENCY } = {}) => {
+  const upperLimit = Number.isFinite(limit) && limit > 0 ? Math.min(Math.round(limit), MAX_LIMIT) : undefined;
+  const safeTimeframe = timeframe ? String(timeframe).toUpperCase() : '3M';
+  const workerCount = Math.max(1, Math.min(concurrency, MAX_CONCURRENCY, symbols.length));
+
+  const results = new Array(symbols.length).fill(null);
+  const warnings = [];
+  const errors = [];
+  let index = 0;
+
+  const options = {};
+  if (upperLimit) options.limit = upperLimit;
+  if (safeTimeframe) options.timeframe = safeTimeframe;
+
+  const worker = async () => {
+    while (index < symbols.length) {
+      const currentIndex = index;
+      index += 1;
+      const symbol = symbols[currentIndex];
+      try {
+        const intel = await gatherSymbolIntel(symbol, options);
+        results[currentIndex] = computeSummary(intel);
+        if (intel.warning) {
+          const warningEntry = normaliseMessage({ symbol: intel.symbol || symbol, warning: intel.warning });
+          if (warningEntry) warnings.push(warningEntry);
+        }
+      } catch (error) {
+        console.error('Batch intel failed', symbol, error);
+        const message = error?.message || 'Failed to load intelligence.';
+        errors.push({ symbol, message });
+        results[currentIndex] = { symbol, error: true, message };
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return { results: results.filter(Boolean), warnings, errors };
+};
+
+export async function handleRequest(request) {
+  if (request.method === 'OPTIONS') return handleOptions();
+
+  let symbols = [];
+  let limit;
+  let timeframe = '3M';
+  let concurrency = DEFAULT_CONCURRENCY;
+
+  if (request.method === 'GET') {
+    const url = new URL(request.url);
+    symbols = parseSymbols(url.searchParams.get('symbols'));
+    const limitParam = Number(url.searchParams.get('limit'));
+    if (Number.isFinite(limitParam) && limitParam > 0) limit = limitParam;
+    const timeframeParam = url.searchParams.get('timeframe');
+    if (timeframeParam) timeframe = timeframeParam;
+    const concurrencyParam = Number(url.searchParams.get('concurrency'));
+    if (Number.isFinite(concurrencyParam) && concurrencyParam > 0) concurrency = concurrencyParam;
+  } else if (request.method === 'POST') {
+    let payload = {};
+    try {
+      payload = await request.json();
+    } catch (error) {
+      return Response.json({ error: 'Invalid JSON payload.' }, { status: 400, headers: corsHeaders });
+    }
+    symbols = parseSymbols(payload.symbols || payload.tickers || []);
+    const limitParam = Number(payload.limit ?? payload.priceLimit);
+    if (Number.isFinite(limitParam) && limitParam > 0) limit = limitParam;
+    if (payload.timeframe) timeframe = payload.timeframe;
+    const concurrencyParam = Number(payload.concurrency);
+    if (Number.isFinite(concurrencyParam) && concurrencyParam > 0) concurrency = concurrencyParam;
+  } else {
+    return Response.json({ error: 'Method not allowed.' }, { status: 405, headers: corsHeaders });
+  }
+
+  if (!symbols.length) {
+    return Response.json({ error: 'Provide one or more symbols via the "symbols" parameter.' }, {
+      status: 400,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const { results, warnings, errors } = await gatherInBatches(symbols, { limit, timeframe, concurrency });
+    const successful = results.filter((row) => !row?.error);
+    const responseBody = {
+      requestedSymbols: symbols,
+      results,
+      warnings: warnings.map(normaliseMessage).filter(Boolean),
+      errors: errors.map(normaliseMessage).filter(Boolean),
+      meta: {
+        count: successful.length,
+        generatedAt: new Date().toISOString(),
+        limit: Number.isFinite(limit) ? Math.min(Math.round(limit), MAX_LIMIT) : null,
+        timeframe: timeframe ? String(timeframe).toUpperCase() : '3M',
+      },
+    };
+    return Response.json(responseBody, { headers: corsHeaders });
+  } catch (error) {
+    console.error('Batch handler failed', error);
+    return Response.json({ error: 'AI analyst batch request failed.' }, { status: 500, headers: corsHeaders });
+  }
+}
+
+export const handler = async (event) => {
+  const rawQuery = event?.rawQuery ?? '';
+  const path = event?.path || '/';
+  const host = event?.headers?.host || 'example.org';
+  const url = event?.rawUrl || `https://${host}${path}${rawQuery ? `?${rawQuery}` : ''}`;
+  const method = event?.httpMethod || 'GET';
+  const body = method === 'GET' || method === 'HEAD' ? undefined : event?.body;
+
+  const request = new Request(url, {
+    method,
+    headers: event?.headers || {},
+    body,
+  });
+
+  const response = await handleRequest(request);
+  const headers = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const responseBody = await response.text();
+
+  return {
+    statusCode: response.status,
+    headers,
+    body: responseBody,
+  };
+};
+
+export default handleRequest;

--- a/tests/aiAnalystBatch.spec.js
+++ b/tests/aiAnalystBatch.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as env from '../netlify/functions/lib/env.js';
+import { handleRequest } from '../netlify/functions/aiAnalystBatch.js';
+
+const buildRequest = (path) => new Request(`http://localhost${path}`, { method: 'GET' });
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('aiAnalystBatch', () => {
+  it('returns batch intelligence for provided symbols', async () => {
+    vi.spyOn(env, 'getTiingoToken').mockReturnValue('');
+    const response = await handleRequest(buildRequest('/.netlify/functions/aiAnalystBatch?symbols=AAPL,MSFT&limit=60'));
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(Array.isArray(payload.results)).toBe(true);
+    expect(payload.results.length).toBeGreaterThan(0);
+    const first = payload.results[0];
+    expect(first).toHaveProperty('symbol');
+    expect(first).toHaveProperty('aiUpsidePct');
+  });
+
+  it('requires at least one symbol', async () => {
+    const response = await handleRequest(buildRequest('/.netlify/functions/aiAnalystBatch'));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/provide/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a batch intelligence card to the AI Analyst experience with controls and a sortable results table
- implement a dedicated client module that calls the batch endpoint, renders metrics, and handles sorting/state updates
- expose a new `aiAnalystBatch` Netlify function with accompanying unit coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d677b423cc8329ba6c69d700c24d4d