### PR TITLE
Integrate research lab and screener modules into professional desk

### DIFF
--- a/professional/api-client.js
+++ b/professional/api-client.js
@@ -1,3 +1,5 @@
+import { getResearchLabInsights, getScreenerSnapshot } from './research-data.js';
+
 const API_ROOT = '/api/tiingo';
 
 function buildUrl(params = {}) {
@@ -106,4 +108,14 @@ export async function fetchValuationSnapshot(symbol) {
   const payload = await requestTiingo({ symbol: upper, kind: 'valuation' });
   const data = payload?.data || null;
   return { symbol: payload?.symbol || upper, snapshot: data, meta: payload?.meta || {}, warning: payload?.warning || '' };
+}
+
+export async function fetchResearchLabSnapshot(symbol) {
+  const data = getResearchLabInsights(symbol);
+  return { ...data };
+}
+
+export async function fetchScreenerPreview(symbol) {
+  const data = getScreenerSnapshot(symbol);
+  return { ...data };
 }

--- a/professional/pro-shared.css
+++ b/professional/pro-shared.css
@@ -671,6 +671,152 @@ a:focus {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.pro-inline-metrics {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.pro-inline-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.pro-inline-metric .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pro-inline-metric strong {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.pro-inline-metric .delta {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.pro-inline-metric[data-tone='positive'] {
+  border-color: rgba(61, 214, 140, 0.38);
+  box-shadow: 0 6px 18px rgba(61, 214, 140, 0.18);
+}
+
+.pro-inline-metric[data-tone='positive'] strong,
+.pro-inline-metric[data-tone='positive'] .delta {
+  color: var(--positive);
+}
+
+.pro-inline-metric[data-tone='caution'] {
+  border-color: rgba(255, 193, 7, 0.38);
+}
+
+.pro-inline-metric[data-tone='negative'] {
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.pro-inline-metric[data-tone='neutral'] {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.pro-research-card .pro-shell-body,
+.pro-screener-card .pro-shell-body {
+  gap: 1rem;
+}
+
+.pro-research-summary,
+.pro-screener-summary {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.pro-research-positioning {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.9rem;
+}
+
+.pro-research-positioning-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pro-research-diligence ul,
+.pro-research-catalysts ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.pro-research-diligence li,
+.pro-research-catalysts li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.pro-research-diligence strong {
+  font-size: 0.9rem;
+}
+
+.pro-research-diligence .muted {
+  font-size: 0.8rem;
+}
+
+.pro-research-catalysts .pro-pill {
+  margin-right: 0.4rem;
+  background: rgba(76, 141, 255, 0.18);
+  border-color: rgba(76, 141, 255, 0.3);
+}
+
+.pro-mini-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.pro-mini-table thead th {
+  text-align: left;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  padding-bottom: 0.4rem;
+}
+
+.pro-mini-table tbody td {
+  padding: 0.45rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.pro-screener-table-wrapper {
+  overflow-x: auto;
+}
+
+.pro-shell-loader {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.pro-shell-card.is-loading .pro-shell-body > *:not(.pro-shell-loader) {
+  opacity: 0.45;
+  transition: opacity 0.2s ease;
+}
+
 .placeholder-card {
   opacity: 0.75;
 }

--- a/professional/research-data.js
+++ b/professional/research-data.js
@@ -1,0 +1,188 @@
+const LAB_FOCUS = {
+  AAPL: {
+    summary:
+      'Services monetization pacing above plan with ecosystem lock-in offsetting hardware softness. Monitoring Vision Pro ramp and gross margin cadence into FY24.',
+    positioning: 'Overweight bias with tactical adds on 2-3% pullbacks versus NASDAQ futures.',
+    quickStats: [
+      { label: 'Fundamental Bias', value: 'Positive', tone: 'positive' },
+      { label: 'Catalyst Window', value: 'WWDC · 2 weeks', tone: 'neutral' },
+      { label: 'Risk Flag', value: 'China demand volatility', tone: 'caution' },
+    ],
+    diligence: [
+      { title: 'Services ARPU sensitivity refresh', owner: 'Platform Strategy', due: 'Due Friday' },
+      { title: 'Channel inventory pulse check', owner: 'Global Supply', due: 'Rolling' },
+    ],
+    catalysts: [
+      { label: 'June 10', detail: 'WWDC keynote — services roadmap & AI co-pilots' },
+      { label: 'Late July', detail: 'FQ3 print — margin commentary & China update' },
+    ],
+  },
+  MSFT: {
+    summary:
+      'Azure AI workloads comping >35% with strong OpenAI attach; Copilot monetization broadening to security SKUs. Watching enterprise optimization cycle for fatigue.',
+    positioning: 'Maintain core overweight, scale adds around 50-day support with tight risk markers.',
+    quickStats: [
+      { label: 'Fundamental Bias', value: 'Positive', tone: 'positive' },
+      { label: 'Catalyst Window', value: 'Ignite + Inspire', tone: 'neutral' },
+      { label: 'Risk Flag', value: 'Enterprise optimization', tone: 'caution' },
+    ],
+    diligence: [
+      { title: 'Copilot seat adoption tracker', owner: 'Enterprise SaaS', due: 'Updated daily' },
+      { title: 'Azure consumption telemetry', owner: 'Cloud Ops', due: 'Due Monday' },
+    ],
+    catalysts: [
+      { label: 'June', detail: 'Copilot pricing expansion to security bundle' },
+      { label: 'July', detail: 'FY4Q print — AI contribution disclosure' },
+    ],
+  },
+  NVDA: {
+    summary:
+      'Blackwell transition pacing clean with enterprise backlog visibility through CY25; supply chain risk shifting to advanced packaging. Monitoring hyperscaler capex cadence.',
+    positioning: 'Core overweight with hedged gamma; allow for volatility around semi cap prints.',
+    quickStats: [
+      { label: 'Fundamental Bias', value: 'Strong Positive', tone: 'positive' },
+      { label: 'Catalyst Window', value: 'GTC EU updates', tone: 'neutral' },
+      { label: 'Risk Flag', value: 'Packaging capacity & export controls', tone: 'caution' },
+    ],
+    diligence: [
+      { title: 'Hyperscaler orderbook audit', owner: 'Data Infrastructure', due: 'This week' },
+      { title: 'Supply chain policy watch', owner: 'Regulatory Desk', due: 'Continuous' },
+    ],
+    catalysts: [
+      { label: 'Mid-June', detail: 'Computex follow-through — enterprise design wins' },
+      { label: 'Late August', detail: '2Q FY25 results — Blackwell revenue mix' },
+    ],
+  },
+  GOOGL: {
+    summary:
+      'Gemini integration stabilizing search economics with commerce recovery; YouTube shoppable traction improving. Keeping guardrails around AI infra spend.',
+    positioning: 'Overweight pivoting to core ad recovery with defensive stance on TAC inflation.',
+    quickStats: [
+      { label: 'Fundamental Bias', value: 'Constructive', tone: 'positive' },
+      { label: 'Catalyst Window', value: 'Marketing Live · mid-June', tone: 'neutral' },
+      { label: 'Risk Flag', value: 'AI traffic acquisition costs', tone: 'caution' },
+    ],
+    diligence: [
+      { title: 'Retail ad vertical scrub', owner: 'Performance Media', due: 'Due Tuesday' },
+      { title: 'Gemini UX studies', owner: 'Design Research', due: 'Rolling' },
+    ],
+    catalysts: [
+      { label: 'June', detail: 'Marketing Live — shopping roadmap' },
+      { label: 'Late July', detail: 'Q2 earnings — TAC disclosure' },
+    ],
+  },
+};
+
+const SCREENER_PRESETS = {
+  AAPL: {
+    summary: 'Premium franchise with stable cash generation; screening for incremental upside via services growth.',
+    metrics: [
+      { label: 'Fair Value', value: '$213', delta: '+8%', tone: 'positive' },
+      { label: 'Upside vs Spot', value: '+9.6%', tone: 'positive' },
+      { label: 'Momentum Score', value: '58', tone: 'neutral' },
+    ],
+    topIdeas: [
+      { symbol: 'AAPL', upside: '+9%', thesis: 'Services ARPU driving multiple support' },
+      { symbol: 'CRM', upside: '+15%', thesis: 'GenAI attach into core cloud deals' },
+      { symbol: 'ADBE', upside: '+12%', thesis: 'Firefly monetization broadening TAM' },
+    ],
+  },
+  MSFT: {
+    summary: 'Enterprise AI leadership screen highlights premium cash flow durability with optionality in security.',
+    metrics: [
+      { label: 'Fair Value', value: '$465', delta: '+11%', tone: 'positive' },
+      { label: 'Upside vs Spot', value: '+7.8%', tone: 'positive' },
+      { label: 'Momentum Score', value: '62', tone: 'positive' },
+    ],
+    topIdeas: [
+      { symbol: 'MSFT', upside: '+8%', thesis: 'Copilot monetization with strong renewals' },
+      { symbol: 'NOW', upside: '+13%', thesis: 'Platform AI adoption accelerating workflows' },
+      { symbol: 'SNOW', upside: '+18%', thesis: 'Consumption recovery with AI workloads' },
+    ],
+  },
+  NVDA: {
+    summary: 'Accelerated compute complex — screening for downstream beneficiaries and thermal risks.',
+    metrics: [
+      { label: 'Fair Value', value: '$1,200', delta: '+14%', tone: 'positive' },
+      { label: 'Upside vs Spot', value: '+10.2%', tone: 'positive' },
+      { label: 'Momentum Score', value: '74', tone: 'positive' },
+    ],
+    topIdeas: [
+      { symbol: 'NVDA', upside: '+10%', thesis: 'Blackwell cycle extends datacenter demand' },
+      { symbol: 'ASML', upside: '+16%', thesis: 'High-NA EUV leverage to AI capex' },
+      { symbol: 'AVGO', upside: '+11%', thesis: 'Custom accelerators & networking tailwinds' },
+    ],
+  },
+  GOOGL: {
+    summary: 'AI-enabled advertising rebuild — screening for monetization lift and margin resiliency.',
+    metrics: [
+      { label: 'Fair Value', value: '$192', delta: '+9%', tone: 'positive' },
+      { label: 'Upside vs Spot', value: '+6.5%', tone: 'positive' },
+      { label: 'Momentum Score', value: '55', tone: 'neutral' },
+    ],
+    topIdeas: [
+      { symbol: 'GOOGL', upside: '+7%', thesis: 'Search share stabilizes with Gemini roll-out' },
+      { symbol: 'META', upside: '+14%', thesis: 'Reels monetization scaling across surfaces' },
+      { symbol: 'TTD', upside: '+19%', thesis: 'Retail media network expansion' },
+    ],
+  },
+};
+
+function normalizeSymbol(symbol) {
+  return (symbol || '').trim().toUpperCase() || 'AAPL';
+}
+
+export function getResearchLabInsights(symbol) {
+  const key = normalizeSymbol(symbol);
+  const payload = LAB_FOCUS[key] || {
+    summary: 'No dedicated research streams yet. Use the Research Lab to capture diligence findings for this ticker.',
+    positioning: 'Establish baseline coverage with quick peer benchmarking and macro overlays.',
+    quickStats: [
+      { label: 'Coverage Status', value: 'Initiate', tone: 'neutral' },
+      { label: 'Catalyst Window', value: 'TBD', tone: 'neutral' },
+      { label: 'Risk Flag', value: 'Pending', tone: 'caution' },
+    ],
+    diligence: [
+      { title: 'Assign sector lead', owner: 'Research Ops', due: 'Unassigned' },
+      { title: 'Outline diligence cadence', owner: 'Team Lead', due: 'TBD' },
+    ],
+    catalysts: [],
+  };
+
+  return {
+    symbol: key,
+    meta: {
+      source: 'mock',
+      kind: 'research_lab',
+      reason: 'static_sample',
+      label: 'Research Lab',
+      title: 'Source: Research Lab insights (sample data)',
+    },
+    ...payload,
+  };
+}
+
+export function getScreenerSnapshot(symbol) {
+  const key = normalizeSymbol(symbol);
+  const payload = SCREENER_PRESETS[key] || {
+    summary: 'Run a focused quant screen to populate comparative valuation and momentum signals for this symbol.',
+    metrics: [
+      { label: 'Fair Value', value: '—', delta: 'n/a', tone: 'neutral' },
+      { label: 'Upside vs Spot', value: '—', tone: 'neutral' },
+      { label: 'Momentum Score', value: '—', tone: 'neutral' },
+    ],
+    topIdeas: [],
+  };
+
+  return {
+    symbol: key,
+    meta: {
+      source: 'mock',
+      kind: 'quant_screener',
+      reason: 'static_sample',
+      label: 'Quant Screener',
+      title: 'Source: Quant Screener snapshot (sample data)',
+    },
+    ...payload,
+  };
+}

--- a/professional/research-modules.js
+++ b/professional/research-modules.js
@@ -1,0 +1,283 @@
+function createElement(tag, className, textContent) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  if (textContent !== undefined) el.textContent = textContent;
+  return el;
+}
+
+function applyTone(element, tone) {
+  if (!element) return;
+  const valid = ['positive', 'neutral', 'caution', 'negative'];
+  if (element.dataset) {
+    element.dataset.tone = valid.includes(tone) ? tone : 'neutral';
+  }
+}
+
+export function createResearchLabPanel(options = {}) {
+  let activeSymbol = '';
+  const card = createElement('section', 'pro-card pro-shell-card pro-research-card');
+  const header = createElement('header', 'pro-shell-header');
+  const title = createElement('h3', null, 'Research Lab');
+  const badge = createElement('span', 'pro-badge subtle', 'Deep dives');
+  header.append(title, badge);
+  card.appendChild(header);
+
+  const body = createElement('div', 'pro-shell-body');
+  const summary = createElement('p', 'pro-research-summary muted');
+  const positioning = createElement('div', 'pro-research-positioning');
+  positioning.hidden = true;
+  const positioningLabel = createElement('span', 'pro-research-positioning-label', 'Desk stance');
+  const positioningText = createElement('strong');
+  positioning.append(positioningLabel, positioningText);
+
+  const metrics = createElement('div', 'pro-inline-metrics');
+  const diligence = createElement('div', 'pro-research-diligence');
+  const diligenceTitle = createElement('h4', null, 'Active diligence');
+  const diligenceList = createElement('ul');
+  diligence.append(diligenceTitle, diligenceList);
+
+  const catalysts = createElement('div', 'pro-research-catalysts');
+  const catalystsTitle = createElement('h4', null, 'Catalyst watch');
+  const catalystsList = createElement('ul');
+  catalysts.append(catalystsTitle, catalystsList);
+
+  const loader = createElement('div', 'pro-shell-loader muted', 'Loading research insights…');
+  loader.hidden = true;
+
+  body.append(summary, positioning, metrics, diligence, catalysts, loader);
+  card.appendChild(body);
+
+  const actions = createElement('div', 'pro-shell-actions');
+  const labButton = createElement('a', 'pro-button secondary', 'Open Research Lab');
+  labButton.href = options.labUrl || 'valuation-lab.html';
+  labButton.target = options.openInNewTab ? '_blank' : '_self';
+  if (labButton.target === '_blank') labButton.rel = 'noopener';
+  actions.appendChild(labButton);
+
+  const notesButton = createElement('button', 'pro-button tertiary');
+  notesButton.type = 'button';
+  notesButton.textContent = 'Log follow-up';
+  if (typeof options.onLogFollowUp === 'function') {
+    notesButton.addEventListener('click', () => options.onLogFollowUp(activeSymbol));
+  } else {
+    notesButton.disabled = true;
+  }
+  actions.appendChild(notesButton);
+
+  card.appendChild(actions);
+
+  const buildMetric = (item) => {
+    const metric = createElement('div', 'pro-inline-metric');
+    const label = createElement('span', 'label', item.label || 'Metric');
+    const value = createElement('strong', null, item.value || '—');
+    if (item.delta) {
+      const delta = createElement('span', 'delta', item.delta);
+      metric.append(label, value, delta);
+    } else {
+      metric.append(label, value);
+    }
+    applyTone(metric, item.tone);
+    return metric;
+  };
+
+  const buildDiligenceItem = (item) => {
+    const li = createElement('li');
+    const title = createElement('strong', null, item.title || 'Task');
+    const meta = createElement('span', 'muted');
+    const details = [];
+    if (item.owner) details.push(item.owner);
+    if (item.due) details.push(item.due);
+    meta.textContent = details.join(' • ');
+    li.append(title, meta);
+    return li;
+  };
+
+  const buildCatalystItem = (item) => {
+    const li = createElement('li');
+    const badge = createElement('span', 'pro-pill', item.label || 'Upcoming');
+    const text = createElement('span', null, item.detail || 'Pending update');
+    li.append(badge, text);
+    return li;
+  };
+
+  return {
+    element: card,
+    setLoading(flag) {
+      loader.hidden = !flag;
+      card.classList.toggle('is-loading', !!flag);
+    },
+    update(data) {
+      const info = data || {};
+      activeSymbol = info.symbol || '';
+      summary.textContent = info.summary || 'Research stream unavailable.';
+      summary.classList.toggle('muted', !info.summary);
+
+      const stance = (info.positioning || '').trim();
+      positioning.hidden = !stance;
+      positioningText.textContent = stance;
+
+      metrics.innerHTML = '';
+      if (Array.isArray(info.quickStats) && info.quickStats.length) {
+        info.quickStats.forEach((stat) => metrics.appendChild(buildMetric(stat)));
+        metrics.hidden = false;
+      } else {
+        metrics.hidden = true;
+      }
+
+      diligenceList.innerHTML = '';
+      if (Array.isArray(info.diligence) && info.diligence.length) {
+        info.diligence.forEach((item) => diligenceList.appendChild(buildDiligenceItem(item)));
+        diligence.hidden = false;
+      } else {
+        diligence.hidden = true;
+      }
+
+      catalystsList.innerHTML = '';
+      if (Array.isArray(info.catalysts) && info.catalysts.length) {
+        info.catalysts.forEach((item) => catalystsList.appendChild(buildCatalystItem(item)));
+        catalysts.hidden = false;
+      } else {
+        catalysts.hidden = true;
+      }
+
+      this.setLoading(false);
+    },
+    setSource(meta) {
+      if (!badge) return;
+      if (meta?.label) {
+        badge.textContent = meta.label;
+      } else {
+        badge.textContent = 'Deep dives';
+      }
+      badge.title = meta?.title || '';
+    },
+  };
+}
+
+export function createScreenerPreview(options = {}) {
+  const card = createElement('section', 'pro-card pro-shell-card pro-screener-card');
+  const header = createElement('header', 'pro-shell-header');
+  const title = createElement('h3', null, 'Quant Screener');
+  const badge = createElement('span', 'pro-badge subtle', 'Market radar');
+  header.append(title, badge);
+  card.appendChild(header);
+
+  const body = createElement('div', 'pro-shell-body');
+  const summary = createElement('p', 'pro-screener-summary muted');
+  const metrics = createElement('div', 'pro-inline-metrics');
+  const tableWrapper = createElement('div', 'pro-screener-table-wrapper');
+  const table = createElement('table', 'pro-mini-table');
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Symbol', 'Upside', 'Key remark'].forEach((label) => {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  tableWrapper.appendChild(table);
+
+  const loader = createElement('div', 'pro-shell-loader muted', 'Screening universe…');
+  loader.hidden = true;
+
+  body.append(summary, metrics, tableWrapper, loader);
+  card.appendChild(body);
+
+  const actions = createElement('div', 'pro-shell-actions');
+  const launch = createElement('a', 'pro-button primary', 'Run full screener');
+  launch.href = options.screenerUrl || 'quant-screener.html';
+  launch.target = options.openInNewTab ? '_blank' : '_self';
+  if (launch.target === '_blank') launch.rel = 'noopener';
+  actions.appendChild(launch);
+
+  const exportBtn = createElement('a', 'pro-button secondary', 'Export latest batch');
+  exportBtn.href = options.exportUrl || 'quant-screener.html#export';
+  exportBtn.target = options.openInNewTab ? '_blank' : '_self';
+  if (exportBtn.target === '_blank') exportBtn.rel = 'noopener';
+  actions.appendChild(exportBtn);
+
+  card.appendChild(actions);
+
+  const buildMetric = (item) => {
+    const metric = createElement('div', 'pro-inline-metric');
+    const label = createElement('span', 'label', item.label || 'Metric');
+    const value = createElement('strong', null, item.value || '—');
+    metric.append(label, value);
+    if (item.delta) {
+      const delta = createElement('span', 'delta', item.delta);
+      metric.appendChild(delta);
+    }
+    applyTone(metric, item.tone);
+    return metric;
+  };
+
+  const buildRow = (item) => {
+    const row = document.createElement('tr');
+    const symbolCell = document.createElement('td');
+    const link = document.createElement('a');
+    link.textContent = item.symbol || '—';
+    link.href = options.linkBuilder ? options.linkBuilder(item) : `quant-screener.html#${item.symbol || ''}`;
+    link.target = options.openInNewTab ? '_blank' : '_self';
+    if (link.target === '_blank') link.rel = 'noopener';
+    symbolCell.appendChild(link);
+
+    const upsideCell = document.createElement('td');
+    upsideCell.textContent = item.upside || '—';
+
+    const thesisCell = document.createElement('td');
+    thesisCell.textContent = item.thesis || '—';
+
+    row.append(symbolCell, upsideCell, thesisCell);
+    return row;
+  };
+
+  return {
+    element: card,
+    setLoading(flag) {
+      loader.hidden = !flag;
+      card.classList.toggle('is-loading', !!flag);
+    },
+    update(data) {
+      const info = data || {};
+      summary.textContent = info.summary || 'Run a quant screen to populate candidates.';
+      summary.classList.toggle('muted', !info.summary);
+
+      metrics.innerHTML = '';
+      if (Array.isArray(info.metrics) && info.metrics.length) {
+        info.metrics.forEach((item) => metrics.appendChild(buildMetric(item)));
+        metrics.hidden = false;
+      } else {
+        metrics.hidden = true;
+      }
+
+      tbody.innerHTML = '';
+      if (Array.isArray(info.topIdeas) && info.topIdeas.length) {
+        info.topIdeas.slice(0, 5).forEach((item) => tbody.appendChild(buildRow(item)));
+        tableWrapper.hidden = false;
+      } else {
+        const emptyRow = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 3;
+        cell.className = 'muted';
+        cell.textContent = 'No screened ideas yet — trigger a batch run to populate candidates.';
+        emptyRow.appendChild(cell);
+        tbody.appendChild(emptyRow);
+        tableWrapper.hidden = false;
+      }
+
+      this.setLoading(false);
+    },
+    setSource(meta) {
+      if (!badge) return;
+      if (meta?.label) {
+        badge.textContent = meta.label;
+      } else {
+        badge.textContent = 'Market radar';
+      }
+      badge.title = meta?.title || '';
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- integrate Research Lab and Quant Screener cards into the professional desk workspace with dedicated refresh flows
- add reusable modules and sample data powering the new enterprise-focused research and screener experiences
- extend shared styling for inline intelligence metrics and loading treatment to match the desk interface

## Testing
- npm test *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d692d387248329be97ff60637d380e