### PR TITLE
Add async cache for AI intel fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## Netlify Trading Workspace
+
+This repository powers the Netlify Trading research workstation, including the
+AI Analyst, Quant Screener, Valuation Lab, and Professional Desk experiences.
+
+### Quality Assurance
+
+- Automated unit tests: `npm test`
+- Manual regression playbook: [`docs/manual-testing/e2e-regression-plan.md`](docs/manual-testing/e2e-regression-plan.md)

--- a/docs/manual-testing/e2e-regression-plan.md
+++ b/docs/manual-testing/e2e-regression-plan.md
@@ -1,0 +1,88 @@
+# Manual End-to-End Regression Plan
+
+This playbook enumerates the manual smoke and regression tests that should be
+performed before shipping any changes to the Netlify Trading workspace. The
+goal is to exercise every public surface area of the platform while keeping
+the browser interface exactly as designed today.
+
+## 1. Global Smoke Checks
+
+1. Launch the development server (`npm start`) and confirm it compiles without
+   warnings.
+2. From the landing page (`/index.html`) validate that the navigation links
+   open the following experiences in dedicated tabs:
+   - AI Analyst (`/ai-analyst.html`)
+   - AI Analyst Batch Table (`/ai-analyst-batch-table.html`)
+   - Quant Screener (`/quant-screener.html`)
+   - Valuation Lab (`/valuation-lab.html`)
+   - Professional Desk (`/professional-desk.html`)
+3. Resize the browser between 1366px and 1920px widths to ensure the
+   responsive layout does not collapse or overlap navigation controls.
+
+## 2. AI Analyst (`ai-analyst.html`)
+
+1. Enter a liquid ticker (e.g. `AAPL`) and trigger the analysis flow.
+2. Verify that:
+   - The summary, valuation, and risk cards populate with data.
+   - The timeline modules render analyst notes in chronological order.
+   - The investment checklist badges reflect the underlying score state
+     (bullish, neutral, cautious).
+3. Trigger a second lookup with the same ticker to confirm cached data is
+   reused without flashing the interface.
+4. Request an illiquid ticker to ensure the UI surfaces the fallback error
+   message from the Tiingo integration.
+5. Use the document filter controls to confirm the news and filings tables
+   react immediately without reloading the page.
+
+## 3. AI Analyst Batch Table (`ai-analyst-batch-table.html`)
+
+1. Paste a CSV with at least ten tickers and run the batch request.
+2. Confirm the progress bar tracks the API requests and finalises at 100%.
+3. Export the completed table to CSV and validate that the downloaded file
+   includes the same columns and number formatting as the on-screen table.
+4. Refresh the page and ensure the most recent batch remains available from
+   local storage for continuity.
+
+## 4. Quant Screener (`quant-screener.html`)
+
+1. Load the default universe and start the screening process.
+2. Observe the concurrency banner to verify it recommends the expected number
+   of simultaneous API calls based on the universe size.
+3. Sort by Upside, Downside, and Risk to confirm stable ordering behaviour and
+   sticky headers.
+4. Apply market cap, upside, and sector filters concurrently and ensure the
+   result set updates instantly without layout shift.
+5. Drill into a row to open the AI Analyst drawer and validate that repeated
+   openings reuse cached research, avoiding redundant network requests.
+6. Export the current screen to CSV and verify the file reflects the filtered
+   dataset.
+
+## 5. Valuation Lab (`valuation-lab.html`)
+
+1. Enter sample financials and ensure the discounted cash flow and comparable
+   valuation widgets recalculate immediately.
+2. Toggle between bull, base, and bear scenarios and confirm the charts update
+   without flicker.
+3. Download the valuation workbook and check that the spreadsheet opens with
+   all worksheets populated.
+
+## 6. Professional Desk (`professional-desk.html`)
+
+1. Authenticate with a professional account (staging credentials) and verify
+   that entitlements gatekeep premium modules.
+2. Exercise the order management blotter: submit a dummy order, move it to
+   filled, and cancel it. Confirm audit logs update in real time.
+3. Review the compliance tab to ensure the exception report renders with the
+   latest data timestamp.
+
+## 7. Regression Checklist
+
+- Confirm all CSV exports open in Excel/Sheets with UTF-8 encoding.
+- Validate accessibility: keyboard navigation, focus outlines, and ARIA
+  attributes for each interactive control.
+- Clear browser storage (local/session) and ensure the application gracefully
+  rehydrates default state on reload.
+- Capture screenshots of each primary view for release documentation.
+
+Document every discrepancy, attach console/network logs, and assign follow-up
+tickets before marking the run as complete.

--- a/quant-screener.js
+++ b/quant-screener.js
@@ -1,5 +1,6 @@
 import normalizeAiAnalystPayload from './utils/ai-analyst-normalizer.js';
 import { computeRow, passesFilters, screenUniverse, suggestConcurrency } from './utils/quant-screener-core.js';
+import createAsyncCache from './utils/cache.js';
 
 const $ = (selector) => document.querySelector(selector);
 
@@ -73,25 +74,28 @@ let processedRows = [];
 let currentSort = { key: 'upside', direction: 'desc' };
 let isScreening = false;
 let visibleRows = [];
+const intelCache = createAsyncCache({ ttlMs: 5 * 60 * 1000, maxSize: 256 });
 
 async function fetchIntel(symbol) {
-  const url = new URL('/api/aiAnalyst', window.location.origin);
-  url.searchParams.set('symbol', symbol);
-  url.searchParams.set('limit', 120);
-  url.searchParams.set('priceLimit', 120);
-  url.searchParams.set('timeframe', '3M');
-  url.searchParams.set('newsLimit', 12);
-  url.searchParams.set('documentLimit', 12);
-  const response = await fetch(url, { headers: { accept: 'application/json' } });
-  if (!response.ok) {
-    throw new Error(`Failed to analyse ${symbol}: ${response.status}`);
-  }
-  const body = await response.json();
-  const warningHeader =
-    response.headers.get('x-ai-analyst-warning')
-    || response.headers.get('x-intel-warning')
-    || '';
-  return normalizeAiAnalystPayload(body, { warningHeader });
+  return intelCache.get(symbol, async () => {
+    const url = new URL('/api/aiAnalyst', window.location.origin);
+    url.searchParams.set('symbol', symbol);
+    url.searchParams.set('limit', 120);
+    url.searchParams.set('priceLimit', 120);
+    url.searchParams.set('timeframe', '3M');
+    url.searchParams.set('newsLimit', 12);
+    url.searchParams.set('documentLimit', 12);
+    const response = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!response.ok) {
+      throw new Error(`Failed to analyse ${symbol}: ${response.status}`);
+    }
+    const body = await response.json();
+    const warningHeader =
+      response.headers.get('x-ai-analyst-warning')
+      || response.headers.get('x-intel-warning')
+      || '';
+    return normalizeAiAnalystPayload(body, { warningHeader });
+  });
 }
 
 function parseUniverse(raw) {

--- a/tests/utils/cache.spec.js
+++ b/tests/utils/cache.spec.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createAsyncCache } from '../../utils/cache.js';
+
+describe('createAsyncCache', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns cached values within the configured ttl', async () => {
+    vi.useFakeTimers();
+    const cache = createAsyncCache({ ttlMs: 1_000, maxSize: 10 });
+    const loader = vi.fn().mockResolvedValue('alpha');
+
+    const first = await cache.get('key', loader);
+    expect(first).toBe('alpha');
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(500);
+    const second = await cache.get('key', loader);
+    expect(second).toBe('alpha');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes values once the ttl expires', async () => {
+    vi.useFakeTimers();
+    const cache = createAsyncCache({ ttlMs: 250, maxSize: 10 });
+    const loader = vi.fn()
+      .mockResolvedValueOnce('initial')
+      .mockResolvedValueOnce('refreshed');
+
+    const first = await cache.get('symbol', loader);
+    expect(first).toBe('initial');
+
+    vi.advanceTimersByTime(500);
+    const second = await cache.get('symbol', loader);
+    expect(second).toBe('refreshed');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent loader calls', async () => {
+    const cache = createAsyncCache({ ttlMs: 5_000, maxSize: 10 });
+    let resolver;
+    const loader = vi.fn().mockImplementation(
+      () => new Promise((resolve) => {
+        resolver = resolve;
+      }),
+    );
+
+    const promiseA = cache.get('parallel', loader);
+    const promiseB = cache.get('parallel', loader);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    resolver('done');
+
+    const [valueA, valueB] = await Promise.all([promiseA, promiseB]);
+    expect(valueA).toBe('done');
+    expect(valueB).toBe('done');
+  });
+
+  it('evicts the oldest entries when the cache exceeds maxSize', async () => {
+    const cache = createAsyncCache({ ttlMs: 0, maxSize: 2 });
+
+    await cache.get('first', async () => 'A');
+    await cache.get('second', async () => 'B');
+    await cache.get('third', async () => 'C');
+
+    expect(cache.size()).toBe(2);
+
+    const loader = vi.fn().mockResolvedValue('A2');
+    const value = await cache.get('first', loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(value).toBe('A2');
+  });
+});

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,96 @@
+/**
+ * A small utility to provide reusable in-memory caching for expensive async operations.
+ * The cache is aware of expiry (time-to-live) and deduplicates concurrent requests for
+ * the same key while the loader is still in flight.
+ */
+export function createAsyncCache({ ttlMs = 0, maxSize = Infinity } = {}) {
+  if (ttlMs < 0) {
+    throw new Error('ttlMs must be a positive number.');
+  }
+
+  if (maxSize === Infinity) {
+    // unlimited size
+  } else if (!Number.isFinite(maxSize) || maxSize <= 0) {
+    throw new Error('maxSize must be a finite positive number or Infinity.');
+  }
+
+  const store = new Map();
+
+  const computeExpiry = () => (ttlMs > 0 ? Date.now() + ttlMs : Infinity);
+
+  const enforceMaxSize = () => {
+    while (store.size > maxSize) {
+      const oldestKey = store.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      store.delete(oldestKey);
+    }
+  };
+
+  const isExpired = (entry) => ttlMs > 0 && entry.expiresAt <= Date.now();
+
+  const load = (key, loader) => {
+    const inFlight = (async () => {
+      try {
+        const value = await loader();
+        const nextEntry = {
+          value,
+          expiresAt: computeExpiry(),
+          inFlight: null,
+        };
+        store.set(key, nextEntry);
+        enforceMaxSize();
+        return value;
+      } catch (error) {
+        store.delete(key);
+        throw error;
+      }
+    })();
+
+    store.set(key, {
+      value: undefined,
+      expiresAt: computeExpiry(),
+      inFlight,
+    });
+
+    return inFlight;
+  };
+
+  const get = (key, loader) => {
+    if (!store.has(key)) {
+      return load(key, loader);
+    }
+
+    const entry = store.get(key);
+
+    if (entry.inFlight) {
+      return entry.inFlight;
+    }
+
+    if (!isExpired(entry)) {
+      return Promise.resolve(entry.value);
+    }
+
+    return load(key, loader);
+  };
+
+  const deleteKey = (key) => {
+    store.delete(key);
+  };
+
+  const clear = () => {
+    store.clear();
+  };
+
+  const size = () => store.size;
+
+  return {
+    get,
+    delete: deleteKey,
+    clear,
+    size,
+  };
+}
+
+export default createAsyncCache;


### PR DESCRIPTION
## Summary
- add a reusable async cache utility to dedupe requests and limit stale intel fetches
- wire the quant screener to reuse cached AI analyst research responses
- document the full manual E2E regression plan and surface it from the README

## Testing
- npm test *(fails: jsdom dependency is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d692cd53a4832981f8c04f98cd8542