### PR TITLE
Add peer review report and inventory tooling

### DIFF
--- a/docs/peer-review/file-inventory.json
+++ b/docs/peer-review/file-inventory.json
@@ -1,0 +1,492 @@
+{
+  "generatedAt": "2025-09-26T13:45:32.589Z",
+  "summary": {
+    "totalFiles": 92,
+    "byCategory": {
+      "frontend": 29,
+      "backend": 18,
+      "shared": 11,
+      "tooling": 2,
+      "tests": 20,
+      "docs": 0,
+      "data": 11,
+      "other": 1
+    }
+  },
+  "files": {
+    "other": [
+      {
+        "path": ".grok/settings.json",
+        "size": "30 B",
+        "bytes": 30
+      }
+    ],
+    "frontend": [
+      {
+        "path": "ai-analyst-batch-table.js",
+        "size": "11.3 KB",
+        "bytes": 11546
+      },
+      {
+        "path": "ai-analyst.css",
+        "size": "14.5 KB",
+        "bytes": 14886
+      },
+      {
+        "path": "ai-analyst.html",
+        "size": "9.6 KB",
+        "bytes": 9813
+      },
+      {
+        "path": "ai-analyst.js",
+        "size": "14.9 KB",
+        "bytes": 15260
+      },
+      {
+        "path": "app.css",
+        "size": "13.9 KB",
+        "bytes": 14245
+      },
+      {
+        "path": "app.js",
+        "size": "66.0 KB",
+        "bytes": 67567
+      },
+      {
+        "path": "index.html",
+        "size": "6.4 KB",
+        "bytes": 6525
+      },
+      {
+        "path": "package-lock.json",
+        "size": "661.7 KB",
+        "bytes": 677557
+      },
+      {
+        "path": "package.json",
+        "size": "794 B",
+        "bytes": 794
+      },
+      {
+        "path": "professional-desk.html",
+        "size": "5.4 KB",
+        "bytes": 5482
+      },
+      {
+        "path": "professional/api-client.js",
+        "size": "4.1 KB",
+        "bytes": 4166
+      },
+      {
+        "path": "professional/feeds.js",
+        "size": "13.4 KB",
+        "bytes": 13733
+      },
+      {
+        "path": "professional/pro-shared.css",
+        "size": "24.9 KB",
+        "bytes": 25469
+      },
+      {
+        "path": "professional/professional-desk.js",
+        "size": "13.9 KB",
+        "bytes": 14281
+      },
+      {
+        "path": "professional/research-data.js",
+        "size": "8.2 KB",
+        "bytes": 8408
+      },
+      {
+        "path": "professional/research-modules.js",
+        "size": "10.1 KB",
+        "bytes": 10371
+      },
+      {
+        "path": "professional/ui-components.js",
+        "size": "2.9 KB",
+        "bytes": 3018
+      },
+      {
+        "path": "professional/valuation-lab.js",
+        "size": "8.6 KB",
+        "bytes": 8809
+      },
+      {
+        "path": "quant-screener.html",
+        "size": "3.7 KB",
+        "bytes": 3824
+      },
+      {
+        "path": "quant-screener.js",
+        "size": "17.8 KB",
+        "bytes": 18264
+      },
+      {
+        "path": "run-tiingo.mjs",
+        "size": "398 B",
+        "bytes": 398
+      },
+      {
+        "path": "style.css",
+        "size": "417 B",
+        "bytes": 417
+      },
+      {
+        "path": "test-tiingo.js",
+        "size": "1.3 KB",
+        "bytes": 1322
+      },
+      {
+        "path": "tmp-import.mjs",
+        "size": "77 B",
+        "bytes": 77
+      },
+      {
+        "path": "tmp-load.mjs",
+        "size": "66 B",
+        "bytes": 66
+      },
+      {
+        "path": "tmp-load2.mjs",
+        "size": "84 B",
+        "bytes": 84
+      },
+      {
+        "path": "tmp-run-search.mjs",
+        "size": "269 B",
+        "bytes": 269
+      },
+      {
+        "path": "valuation-lab.html",
+        "size": "14.8 KB",
+        "bytes": 15169
+      },
+      {
+        "path": "vitest.config.js",
+        "size": "298 B",
+        "bytes": 298
+      }
+    ],
+    "data": [
+      {
+        "path": "data/mocks/tiingo/AAPL-actions.json",
+        "size": "466 B",
+        "bytes": 466
+      },
+      {
+        "path": "data/mocks/tiingo/AAPL-documents.json",
+        "size": "347 B",
+        "bytes": 347
+      },
+      {
+        "path": "data/mocks/tiingo/AAPL-eod.json",
+        "size": "1.0 KB",
+        "bytes": 1047
+      },
+      {
+        "path": "data/mocks/tiingo/AAPL-fundamentals.json",
+        "size": "1.6 KB",
+        "bytes": 1608
+      },
+      {
+        "path": "data/mocks/tiingo/AAPL-intraday.json",
+        "size": "1.0 KB",
+        "bytes": 1046
+      },
+      {
+        "path": "data/mocks/tiingo/AAPL-news.json",
+        "size": "775 B",
+        "bytes": 775
+      },
+      {
+        "path": "data/mocks/tiingo/AAPL-overview.json",
+        "size": "253 B",
+        "bytes": 253
+      },
+      {
+        "path": "data/symbols.json",
+        "size": "1.78 MB",
+        "bytes": 1861860
+      },
+      {
+        "path": "data/tiingo-mock/AAPL.json",
+        "size": "7.2 KB",
+        "bytes": 7388
+      },
+      {
+        "path": "data/tiingo-mock/GENERIC.json",
+        "size": "3.2 KB",
+        "bytes": 3236
+      },
+      {
+        "path": "data/tiingo-mock/MSFT.json",
+        "size": "4.5 KB",
+        "bytes": 4601
+      }
+    ],
+    "backend": [
+      {
+        "path": "netlify/functions/ai-analyst.js",
+        "size": "22.2 KB",
+        "bytes": 22730
+      },
+      {
+        "path": "netlify/functions/aiAnalyst.js",
+        "size": "9.8 KB",
+        "bytes": 10053
+      },
+      {
+        "path": "netlify/functions/aiAnalystBatch.js",
+        "size": "7.6 KB",
+        "bytes": 7743
+      },
+      {
+        "path": "netlify/functions/env-check.js",
+        "size": "1.7 KB",
+        "bytes": 1716
+      },
+      {
+        "path": "netlify/functions/hello.js",
+        "size": "126 B",
+        "bytes": 126
+      },
+      {
+        "path": "netlify/functions/lib/cache.js",
+        "size": "2.6 KB",
+        "bytes": 2691
+      },
+      {
+        "path": "netlify/functions/lib/codex.js",
+        "size": "2.1 KB",
+        "bytes": 2134
+      },
+      {
+        "path": "netlify/functions/lib/env.js",
+        "size": "1.7 KB",
+        "bytes": 1719
+      },
+      {
+        "path": "netlify/functions/lib/gemini.js",
+        "size": "2.4 KB",
+        "bytes": 2420
+      },
+      {
+        "path": "netlify/functions/lib/grok.js",
+        "size": "2.2 KB",
+        "bytes": 2248
+      },
+      {
+        "path": "netlify/functions/lib/localSymbolSearch.js",
+        "size": "4.6 KB",
+        "bytes": 4739
+      },
+      {
+        "path": "netlify/functions/lib/valuation.js",
+        "size": "6.5 KB",
+        "bytes": 6625
+      },
+      {
+        "path": "netlify/functions/manifest.json",
+        "size": "2.1 KB",
+        "bytes": 2189
+      },
+      {
+        "path": "netlify/functions/news.js",
+        "size": "6.1 KB",
+        "bytes": 6247
+      },
+      {
+        "path": "netlify/functions/search.js",
+        "size": "5.7 KB",
+        "bytes": 5795
+      },
+      {
+        "path": "netlify/functions/sendEmail.js",
+        "size": "2.6 KB",
+        "bytes": 2706
+      },
+      {
+        "path": "netlify/functions/tiingo-data.js",
+        "size": "40.1 KB",
+        "bytes": 41073
+      },
+      {
+        "path": "netlify/functions/tiingo.js",
+        "size": "123 B",
+        "bytes": 123
+      }
+    ],
+    "tooling": [
+      {
+        "path": "scripts/build-symbols.mjs",
+        "size": "8.2 KB",
+        "bytes": 8383
+      },
+      {
+        "path": "scripts/peer-review/generate-file-inventory.mjs",
+        "size": "4.0 KB",
+        "bytes": 4143
+      }
+    ],
+    "tests": [
+      {
+        "path": "tests/ai-analyst-batch-table.js",
+        "size": "56 B",
+        "bytes": 56
+      },
+      {
+        "path": "tests/aiAnalyst.spec.js",
+        "size": "2.5 KB",
+        "bytes": 2522
+      },
+      {
+        "path": "tests/aiAnalystBatch.spec.js",
+        "size": "9.3 KB",
+        "bytes": 9472
+      },
+      {
+        "path": "tests/aiAnalystFunction.spec.js",
+        "size": "5.6 KB",
+        "bytes": 5750
+      },
+      {
+        "path": "tests/aiAnalystNormalizer.spec.js",
+        "size": "2.7 KB",
+        "bytes": 2781
+      },
+      {
+        "path": "tests/browser-cache.spec.js",
+        "size": "2.9 KB",
+        "bytes": 3016
+      },
+      {
+        "path": "tests/quantMath.spec.js",
+        "size": "1.1 KB",
+        "bytes": 1150
+      },
+      {
+        "path": "tests/quantScreenerProcessor.spec.js",
+        "size": "2.8 KB",
+        "bytes": 2875
+      },
+      {
+        "path": "tests/setup-environment.js",
+        "size": "1.2 KB",
+        "bytes": 1271
+      },
+      {
+        "path": "tests/tiingo.documents_actions.spec.js",
+        "size": "1.5 KB",
+        "bytes": 1534
+      },
+      {
+        "path": "tests/tiingo.fallback.spec.js",
+        "size": "1.9 KB",
+        "bytes": 1910
+      },
+      {
+        "path": "tests/tiingo.spec.js",
+        "size": "6.5 KB",
+        "bytes": 6685
+      },
+      {
+        "path": "tests/utils/ai-analyst-normalizer.js",
+        "size": "64 B",
+        "bytes": 64
+      },
+      {
+        "path": "tests/utils/cache.spec.js",
+        "size": "2.3 KB",
+        "bytes": 2352
+      },
+      {
+        "path": "tests/utils/frontend-errors.js",
+        "size": "48 B",
+        "bytes": 48
+      },
+      {
+        "path": "tests/utils/persistentScreenPreferences.spec.js",
+        "size": "2.7 KB",
+        "bytes": 2744
+      },
+      {
+        "path": "tests/utils/user-preferences.spec.js",
+        "size": "2.8 KB",
+        "bytes": 2858
+      },
+      {
+        "path": "tests/utils/valuation-scorer.js",
+        "size": "49 B",
+        "bytes": 49
+      },
+      {
+        "path": "tests/valuation-radar.spec.js",
+        "size": "1.6 KB",
+        "bytes": 1631
+      },
+      {
+        "path": "tests/valuation.spec.js",
+        "size": "1.8 KB",
+        "bytes": 1840
+      }
+    ],
+    "shared": [
+      {
+        "path": "utils/ai-analyst-batch.js",
+        "size": "6.7 KB",
+        "bytes": 6881
+      },
+      {
+        "path": "utils/ai-analyst-client.js",
+        "size": "2.6 KB",
+        "bytes": 2697
+      },
+      {
+        "path": "utils/ai-analyst-normalizer.js",
+        "size": "5.0 KB",
+        "bytes": 5120
+      },
+      {
+        "path": "utils/browser-cache.js",
+        "size": "6.7 KB",
+        "bytes": 6864
+      },
+      {
+        "path": "utils/cache.js",
+        "size": "2.0 KB",
+        "bytes": 2093
+      },
+      {
+        "path": "utils/frontend-errors.js",
+        "size": "6.8 KB",
+        "bytes": 6967
+      },
+      {
+        "path": "utils/persistent-screen-preferences.js",
+        "size": "5.9 KB",
+        "bytes": 6073
+      },
+      {
+        "path": "utils/quant-math.js",
+        "size": "1.2 KB",
+        "bytes": 1218
+      },
+      {
+        "path": "utils/quant-screener-core.js",
+        "size": "5.6 KB",
+        "bytes": 5739
+      },
+      {
+        "path": "utils/user-preferences.js",
+        "size": "3.4 KB",
+        "bytes": 3468
+      },
+      {
+        "path": "utils/valuation-scorer.js",
+        "size": "3.1 KB",
+        "bytes": 3174
+      }
+    ]
+  }
+}

--- a/docs/peer-review/frontend-backend-review.md
+++ b/docs/peer-review/frontend-backend-review.md
@@ -1,0 +1,50 @@
+# Netlify Trading Peer Review
+
+## Executive Summary
+- The frontend and backend codebases are robustly structured with reusable caches, resilient fallbacks, and consistent data normalization that align with enterprise reliability goals.
+- Several modules directly manipulate `innerHTML` with interpolated content; hardening these surfaces with DOM factories or sanitization utilities would reduce XSS risk without altering the current UI.
+- Observability can be expanded by standardizing structured logging (instead of raw `console.*`) and surfacing cache statistics, which will aid production troubleshooting across the stack.
+
+## Frontend Review
+
+### Platform Infrastructure
+- `app.js` bootstraps defensive polyfills for `window`, `document`, and `localStorage` to enable server-side rendering and Vitest execution, demonstrating forethought for cross-environment testing.【F:app.js†L5-L53】
+- Market-data fetches are wrapped in a request cache with TTL-aware eviction and friendly warning handling, ensuring responsive UX during upstream failures.【F:app.js†L85-L215】
+- `utils/browser-cache.js` offers animation-frame render batching and cache statistics, which keeps large DOM updates performant for watchlists and movers views.【F:utils/browser-cache.js†L200-L254】
+
+### Feature Modules
+- The watchlist renderer normalizes persisted symbols, leverages dataset keys to sync price updates, and redraws through a queued render function to avoid layout thrash.【F:app.js†L310-L399】
+- Search and quote components clear results via scheduled renders, balancing responsive typing with stable UI state; request caches prevent redundant symbol lookups within short windows.【F:app.js†L443-L455】【F:app.js†L85-L137】
+- `ai-analyst.js` converts valuation payloads into rich dashboards with computed AI scores, accessible aria attributes, and guardrails for missing data, aligning with professional research workflows.【F:ai-analyst.js†L25-L200】
+- `quant-screener.js` shares async caches with AI Analyst APIs, enforces batch limits, and persists user filter preferences for reproducible screening sessions.【F:quant-screener.js†L1-L200】
+- Professional desk modules compose feeds, valuation lab, and research widgets via modular ES modules, keeping styles and DOM updates encapsulated for enterprise maintainability.【F:professional/research-modules.js†L119-L256】【F:professional/valuation-lab.js†L60-L110】
+
+### Risks & Recommendations
+- Many components interpolate user- or API-derived values into `innerHTML`, e.g., watchlists, search rows, and valuation panels; introducing a small templating helper that escapes text nodes by default would mitigate injection risks while preserving the existing markup contract.【F:app.js†L377-L390】【F:ai-analyst.js†L70-L160】【F:quant-screener.js†L239-L323】
+- Logging relies on `console.*` without log levels or correlation identifiers; wiring a shared logging facade that tags modules and request IDs would ease telemetry ingestion in production observability stacks.【F:app.js†L164-L210】【F:quant-screener.js†L97-L117】
+- Preferences and cached data are persisted in localStorage without schema versioning; capturing a version field would unlock backwards-compatible migrations when future releases adjust stored structures.【F:app.js†L310-L345】【F:quant-screener.js†L87-L200】
+
+## Backend Review
+
+### Data Services
+- `netlify/functions/tiingo-data.js` centralizes Tiingo access with deterministic mock generators, LRU caching, and valuation synthesis, enabling offline demos while guarding production throughput.【F:netlify/functions/tiingo-data.js†L1-L156】【F:netlify/functions/tiingo-data.js†L833-L920】
+- The module gracefully falls back to seeded procedural data when tokens are absent, annotating responses with meta headers to inform clients of degraded states.【F:netlify/functions/tiingo-data.js†L835-L905】
+- Environment discovery utilities scan multiple env var permutations and validate token shape, reducing misconfiguration risks during deployments.【F:netlify/functions/lib/env.js†L1-L49】
+
+### API Endpoints
+- `aiAnalyst.js` orchestrates valuation, news, and filings into a coherent intelligence package, exposing CORS-safe JSON responses with preview headers for auditability.【F:netlify/functions/aiAnalyst.js†L1-L148】
+- When tokens are missing, the AI Analyst endpoint synthesizes narratives from deterministic mocks, ensuring the UI remains operable for demos without real credentials.【F:netlify/functions/aiAnalyst.js†L151-L200】
+- Batch intelligence runs symbols concurrently with bounded workers, capturing warnings and errors per symbol so clients can distinguish partial failures.【F:netlify/functions/aiAnalystBatch.js†L84-L185】
+- Symbol search merges local datasets with Tiingo results through cached remote calls and exchange-aware normalization, maintaining snappy suggestions even during API hiccups.【F:netlify/functions/search.js†L1-L121】
+- Market news requests respect HTTP methods, apply per-source caches, and fall back to seeded articles when upstream dependencies fail, safeguarding the newsroom modules.【F:netlify/functions/news.js†L1-L180】
+- Email dispatching validates configuration at runtime and surfaces upstream errors, providing a predictable integration point for transactional messaging.【F:netlify/functions/sendEmail.js†L1-L87】
+
+### Risks & Recommendations
+- Serverless functions log via `console.error` without structured context; replacing with a logger that emits JSON payloads (request ID, symbol, upstream URL) would simplify observability pipelines.【F:netlify/functions/news.js†L168-L179】【F:netlify/functions/aiAnalystBatch.js†L110-L183】
+- Mock fallbacks respond with generic warnings; extending payload metadata with deterministic status codes or feature flags would let frontend modules differentiate between mock and production responses programmatically.【F:netlify/functions/tiingo-data.js†L835-L905】【F:netlify/functions/aiAnalyst.js†L151-L200】
+- Cache layers use in-memory Maps, which reset on cold starts; persisting hot symbol intel (e.g., to Netlify Edge storage or KV) would further harden response latency for enterprise workloads.【F:netlify/functions/tiingo-data.js†L29-L33】【F:netlify/functions/search.js†L7-L97】
+
+## Cross-Cutting Improvements
+- Establish a lint rule or automated check to detect new `innerHTML` interpolations so mitigation strategies remain enforceable across teams.【F:app.js†L377-L390】【F:quant-screener.js†L239-L323】
+- Introduce shared TypeScript types (or JSDoc typedefs) for response payloads to guarantee contract stability between frontend and backend modules.【F:app.js†L126-L215】【F:netlify/functions/aiAnalyst.js†L1-L200】
+- Centralize configuration (API base URLs, cache TTL defaults) into environment-specific manifests to streamline future environment promotions and reduce drift.【F:app.js†L117-L200】【F:netlify/functions/tiingo-data.js†L9-L33】

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npm run clean && shx mkdir -p build/netlify/functions && shx cp index.html app.js app.css _redirects build/ && shx cp -r netlify/functions build/netlify/functions && shx cp -r data build/data",
     "start": "npx netlify-cli@latest dev",
     "generate:symbols": "node scripts/build-symbols.mjs",
+    "peer-review:inventory": "node scripts/peer-review/generate-file-inventory.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/peer-review/generate-file-inventory.mjs
+++ b/scripts/peer-review/generate-file-inventory.mjs
@@ -1,0 +1,143 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..');
+const OUTPUT_DIR = join(ROOT, 'docs', 'peer-review');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'file-inventory.json');
+
+const SKIP_DIRS = new Set([
+  '.git',
+  '.github',
+  'node_modules',
+  'build',
+  '.netlify',
+  '.vercel',
+  '.idea',
+  '.vscode',
+]);
+
+const IGNORED_PREFIXES = ['tmp', 'dist'];
+
+const TRACKED_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.ts',
+  '.tsx',
+  '.jsx',
+  '.css',
+  '.scss',
+  '.sass',
+  '.less',
+  '.html',
+  '.htm',
+  '.json',
+]);
+
+const CATEGORY_ORDER = [
+  'frontend',
+  'backend',
+  'shared',
+  'tooling',
+  'tests',
+  'docs',
+  'data',
+  'other',
+];
+
+function normalizePath(p) {
+  return p.split('\\').join('/');
+}
+
+function shouldSkipDir(name) {
+  if (SKIP_DIRS.has(name)) return true;
+  return IGNORED_PREFIXES.some((prefix) => name === prefix || name.startsWith(`${prefix}-`));
+}
+
+async function walk(dir, visitor) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (shouldSkipDir(entry.name)) continue;
+      await walk(entryPath, visitor);
+    } else if (entry.isFile()) {
+      await visitor(entryPath);
+    }
+  }
+}
+
+function classifyFile(relPath) {
+  const path = normalizePath(relPath);
+  if (path.startsWith('netlify/functions/')) return 'backend';
+  if (path.startsWith('utils/')) return 'shared';
+  if (path.startsWith('scripts/')) return 'tooling';
+  if (path.startsWith('tests/')) return 'tests';
+  if (path.startsWith('docs/')) return 'docs';
+  if (path.startsWith('data/')) return 'data';
+  if (path.startsWith('professional/') || path.startsWith('quant-screener') || path.startsWith('ai-analyst')) {
+    return 'frontend';
+  }
+  if (path.endsWith('.html') || path.endsWith('.css')) return 'frontend';
+  if (!path.includes('/')) return 'frontend';
+  return 'other';
+}
+
+function formatSize(bytes) {
+  if (!Number.isFinite(bytes)) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+async function buildInventory() {
+  const files = [];
+  await walk(ROOT, async (absPath) => {
+    const relPath = normalizePath(relative(ROOT, absPath));
+    const ext = relPath.includes('.') ? `.${relPath.split('.').pop()}` : '';
+    if (!TRACKED_EXTENSIONS.has(ext.toLowerCase())) return;
+    if (relPath.startsWith('docs/peer-review/file-inventory.json')) return;
+    const stat = await fs.stat(absPath);
+    files.push({
+      path: relPath,
+      bytes: stat.size,
+      size: formatSize(stat.size),
+      category: classifyFile(relPath),
+    });
+  });
+  files.sort((a, b) => a.path.localeCompare(b.path));
+
+  const summary = { totalFiles: files.length, byCategory: {} };
+  for (const category of CATEGORY_ORDER) {
+    summary.byCategory[category] = files.filter((file) => file.category === category).length;
+  }
+  const otherCount = files.filter((file) => !CATEGORY_ORDER.includes(file.category)).length;
+  if (otherCount > 0) summary.byCategory.other = (summary.byCategory.other || 0) + otherCount;
+
+  const grouped = {};
+  for (const file of files) {
+    const key = CATEGORY_ORDER.includes(file.category) ? file.category : 'other';
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push({ path: file.path, size: file.size, bytes: file.bytes });
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    summary,
+    files: grouped,
+  };
+}
+
+async function main() {
+  const inventory = await buildInventory();
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  await fs.writeFile(OUTPUT_FILE, `${JSON.stringify(inventory, null, 2)}\n`, 'utf8');
+  console.log(`Wrote inventory for ${inventory.summary.totalFiles} files to ${relative(ROOT, OUTPUT_FILE)}`);
+}
+
+main().catch((error) => {
+  console.error('Failed to generate peer review inventory:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a scripted peer review inventory generator and wire it into npm scripts
- document frontend and backend peer review findings with citations into the existing codebase

## Testing
- npm run peer-review:inventory
- npm test *(fails: jsdom dependency missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d697ea6fe48329b84856e4dbd3fc07