### PR TITLE
Add security sanitization utilities for serverless error logging

### DIFF
--- a/netlify/functions/ai-analyst.js
+++ b/netlify/functions/ai-analyst.js
@@ -1,5 +1,6 @@
 import handleTiingoRequest from './tiingo.js';
 import { createCache } from './lib/cache.js';
+import { logError } from './lib/security.js';
 import { summarizeValuationNarrative } from './lib/valuation.js';
 import { getGeminiKeyDetail, getGeminiModel, generateGeminiContent } from './lib/gemini.js';
 import { getCodexKeyDetail, getCodexModel, generateCodexContent } from './lib/codex.js';
@@ -587,7 +588,7 @@ export async function handleRequest(request) {
 
     return ok(responseBody, warningHeader, cacheHeaders);
   } catch (error) {
-    console.error('AI analyst orchestrator failed:', error);
+    logError('AI analyst orchestrator failed:', error);
     return Response.json({ error: 'AI analyst orchestrator failed.' }, { status: 500, headers: corsHeaders });
   }
 }

--- a/netlify/functions/aiAnalyst.js
+++ b/netlify/functions/aiAnalyst.js
@@ -9,6 +9,7 @@ import {
   __private as tiingoMock,
 } from './tiingo.js';
 import buildValuationSnapshot, { summarizeValuationNarrative } from './lib/valuation.js';
+import { logError } from './lib/security.js';
 
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '*';
 const corsHeaders = { 'access-control-allow-origin': ALLOWED_ORIGIN };
@@ -240,7 +241,7 @@ export async function handleRequest(request) {
     const intel = await gatherSymbolIntel(symbol, { limit, timeframe });
     return ok({ symbol, data: intel }, intel.warning);
   } catch (error) {
-    console.error('AI analyst failed', error);
+    logError('AI analyst failed', error);
     const fallback = await gatherSymbolIntel(symbol, { limit, timeframe }).catch(() => null);
     if (fallback) {
       return ok({ symbol, data: fallback }, 'AI analyst fallback using simulated data.');

--- a/netlify/functions/aiAnalystBatch.js
+++ b/netlify/functions/aiAnalystBatch.js
@@ -1,4 +1,5 @@
 import { gatherSymbolIntel } from './aiAnalyst.js';
+import { logError } from './lib/security.js';
 
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '*';
 const corsHeaders = {
@@ -108,8 +109,7 @@ const gatherInBatches = async (symbols, { limit, timeframe, concurrency = DEFAUL
           if (warningEntry) warnings.push(warningEntry);
         }
       } catch (error) {
-        console.error('Batch intel failed', symbol, error);
-        const message = error?.message || 'Failed to load intelligence.';
+        const message = logError(`Batch intel failed for ${symbol}`, error, { fallback: 'Failed to load intelligence.' });
         errors.push({ symbol, message });
         results[currentIndex] = { symbol, error: true, message };
       }
@@ -179,7 +179,7 @@ export async function handleRequest(request) {
     };
     return Response.json(responseBody, { headers: corsHeaders });
   } catch (error) {
-    console.error('Batch handler failed', error);
+    logError('Batch handler failed', error);
     return Response.json({ error: 'AI analyst batch request failed.' }, { status: 500, headers: corsHeaders });
   }
 }

--- a/netlify/functions/lib/security.js
+++ b/netlify/functions/lib/security.js
@@ -1,0 +1,160 @@
+const SECRET_KEY_HINTS = [
+  'KEY',
+  'TOKEN',
+  'SECRET',
+  'PASSWORD',
+  'API',
+  'ACCESS',
+  'PRIVATE',
+  'CLIENT',
+  'AUTH',
+];
+
+const DEFAULT_REPLACEMENT = '[redacted]';
+const MIN_ENV_SECRET_LENGTH = 16;
+const ENV_CACHE_TTL_MS = 60_000;
+
+const DEFAULT_PATTERNS = [
+  /\b(?:sk|rk|pk)_[A-Za-z0-9]{16,}\b/gi,
+  /\b[A-Za-z0-9]{40,}\b/g,
+  /\b[0-9a-f]{32,}\b/gi,
+  /bearer\s+[A-Za-z0-9\-._~+/=]{16,}/gi,
+];
+
+let cachedEnvSecrets = null;
+let cachedEnvFetchedAt = 0;
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const looksLikeSecretKeyName = (key) => {
+  const upperKey = key.toUpperCase();
+  return SECRET_KEY_HINTS.some((hint) => upperKey.includes(hint));
+};
+
+const looksLikeSecretValue = (value) => {
+  if (!value || typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length < MIN_ENV_SECRET_LENGTH) return false;
+  if (/^[0-9]+$/.test(trimmed)) return false;
+  if (/^[A-Za-z]+$/.test(trimmed) && trimmed.length < 24) return false;
+  return /[A-Za-z]/.test(trimmed) && /[0-9]/.test(trimmed);
+};
+
+const collectLikelyEnvSecrets = () => {
+  const env = process.env || {};
+  const secrets = new Set();
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (!looksLikeSecretValue(trimmed)) continue;
+    if (!looksLikeSecretKeyName(key)) {
+      // Only keep non-hinted keys if they look like cryptographic material.
+      if (!DEFAULT_PATTERNS.some((pattern) => {
+        pattern.lastIndex = 0;
+        return pattern.test(trimmed);
+      })) {
+        continue;
+      }
+    }
+    secrets.add(trimmed);
+  }
+  return Array.from(secrets).slice(0, 100);
+};
+
+const getCachedEnvSecrets = () => {
+  if (cachedEnvSecrets && Date.now() - cachedEnvFetchedAt < ENV_CACHE_TTL_MS) {
+    return cachedEnvSecrets;
+  }
+  cachedEnvSecrets = collectLikelyEnvSecrets();
+  cachedEnvFetchedAt = Date.now();
+  return cachedEnvSecrets;
+};
+
+export const redactSecrets = (input, options = {}) => {
+  if (input === null || input === undefined) return '';
+  const value = typeof input === 'string' ? input : String(input);
+  const replaceValue = options.replaceValue || DEFAULT_REPLACEMENT;
+  const includeEnvSecrets = options.includeEnvSecrets !== false;
+  const additionalPatterns = Array.isArray(options.additionalPatterns)
+    ? options.additionalPatterns
+        .filter((pattern) => pattern instanceof RegExp)
+        .map((pattern) => new RegExp(pattern.source, pattern.flags))
+    : [];
+
+  let result = value;
+
+  const patterns = [...DEFAULT_PATTERNS.map((pattern) => new RegExp(pattern.source, pattern.flags)), ...additionalPatterns];
+  for (const pattern of patterns) {
+    result = result.replace(pattern, replaceValue);
+  }
+
+  if (includeEnvSecrets) {
+    const envSecrets = getCachedEnvSecrets();
+    for (const secret of envSecrets) {
+      if (!secret) continue;
+      const escaped = escapeRegExp(secret);
+      if (!escaped) continue;
+      const envPattern = new RegExp(escaped, 'g');
+      result = result.replace(envPattern, replaceValue);
+    }
+  }
+
+  return result;
+};
+
+const coerceErrorMessage = (error) => {
+  if (error === null || error === undefined) return '';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) {
+    const message = error.message || '';
+    const stack = typeof error.stack === 'string' ? error.stack : '';
+    if (stack && stack.includes(message)) {
+      return stack;
+    }
+    return [message, stack].filter(Boolean).join('\n');
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+export const sanitizeErrorDetail = (error, options = {}) => {
+  const fallback = options.fallback || 'Unexpected error.';
+  const maxLength = Number.isFinite(options.maxLength) && options.maxLength > 0 ? options.maxLength : null;
+  const raw = coerceErrorMessage(error);
+  if (!raw) return fallback;
+  let sanitized = redactSecrets(raw, options).trim();
+  if (!sanitized) return fallback;
+  if (maxLength && sanitized.length > maxLength) {
+    sanitized = `${sanitized.slice(0, maxLength - 1)}…`;
+  }
+  return sanitized;
+};
+
+export const logError = (labelOrError, maybeError, options = {}) => {
+  if (maybeError === undefined) {
+    return logError('', labelOrError, options);
+  }
+  const label = typeof labelOrError === 'string' ? labelOrError : '';
+  const detail = sanitizeErrorDetail(maybeError, options);
+  if (label) {
+    console.error(label, detail);
+  } else {
+    console.error(detail);
+  }
+  return detail;
+};
+
+export const resetEnvSecretCache = () => {
+  cachedEnvSecrets = null;
+  cachedEnvFetchedAt = 0;
+};
+
+export default {
+  redactSecrets,
+  sanitizeErrorDetail,
+  logError,
+  resetEnvSecretCache,
+};

--- a/netlify/functions/news.js
+++ b/netlify/functions/news.js
@@ -1,4 +1,5 @@
 import { createCache } from './lib/cache.js';
+import { logError } from './lib/security.js';
 
 const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
 
@@ -166,16 +167,16 @@ export default async (request) => {
 
     return buildResponse(source, articles, { fetchedAt: payload.fetchedAt || new Date().toISOString() });
   } catch (error) {
-    console.error('news function error', error);
+    const detail = logError('news function error', error, { maxLength: 400 });
     const cachedFallback = newsCache.get(cacheKey);
     if (cachedFallback) {
       return buildResponse(source, cachedFallback.articles, {
         fromCache: true,
         fetchedAt: cachedFallback.fetchedAt,
         error: 'news fetch failed',
-        detail: String(error),
+        detail,
       });
     }
-    return fallbackResponse(source, { error: 'news fetch failed', detail: String(error) });
+    return fallbackResponse(source, { error: 'news fetch failed', detail });
   }
 };

--- a/netlify/functions/search.js
+++ b/netlify/functions/search.js
@@ -1,6 +1,7 @@
 import { searchLocalSymbols } from './lib/localSymbolSearch.js';
 import { getTiingoToken } from './lib/env.js';
 import { createCache } from './lib/cache.js';
+import { logError } from './lib/security.js';
 
 const corsHeaders = { 'access-control-allow-origin': process.env.ALLOWED_ORIGIN || '*' };
 const DEFAULT_LIMIT = 25;
@@ -44,8 +45,9 @@ export default async (request) => {
     return Response.json({ data: combined }, { headers: corsHeaders });
   } catch (e) {
     const fallback = localMatches.length ? localMatches : [];
+    const detail = logError('tiingo search failed', e, { maxLength: 200 });
     return Response.json(
-      { data: fallback, warning: 'tiingo search failed', detail: String(e) },
+      { data: fallback, warning: 'tiingo search failed', detail },
       { status: 200, headers: corsHeaders }
     );
   }

--- a/netlify/functions/tiingo-data.js
+++ b/netlify/functions/tiingo-data.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { getTiingoToken, TIINGO_TOKEN_ENV_KEYS } from './lib/env.js';
 import { createCache } from './lib/cache.js';
 import buildValuationSnapshot, { summarizeValuationNarrative, valuationUtils } from './lib/valuation.js';
+import { logError } from './lib/security.js';
 
 // --- Configuration & Constants ---
 
@@ -1080,10 +1081,10 @@ async function handleTiingoRequest(request) {
     }
     return respondWithMock(kind, symbol, limit, 'EOD unavailable. Showing sample data.', { reason: 'eod_unavailable' });
   } catch (err) {
-    console.error(`Tiingo request failed for ${symbol}:`, err);
+    const message = logError(`Tiingo request failed for ${symbol}`, err, { maxLength: 200 });
     return respondWithMock(kind, symbol, limit, 'Tiingo request failed. Showing sample data.', {
       reason: 'exception',
-      message: err?.message?.slice(0, 200) || String(err),
+      message,
     });
   }
 }

--- a/tests/security.spec.js
+++ b/tests/security.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { redactSecrets, sanitizeErrorDetail, logError, resetEnvSecretCache } from '../netlify/functions/lib/security.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+const restoreEnv = () => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key];
+    }
+  }
+  Object.assign(process.env, ORIGINAL_ENV);
+  resetEnvSecretCache();
+};
+
+describe('security utilities', () => {
+  beforeEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('redacts obvious tokens using default patterns', () => {
+    const input = 'Access token sk_live_ABC1234567890TOKEN should be hidden.';
+    const redacted = redactSecrets(input);
+    expect(redacted).not.toContain('sk_live_ABC1234567890TOKEN');
+    expect(redacted).toContain('[redacted]');
+  });
+
+  it('redacts values discovered from environment variables', () => {
+    process.env.SECRET_KEY = 'envSecretValue1234567890';
+    resetEnvSecretCache();
+    const message = 'Leaked envSecretValue1234567890 in error log.';
+    const redacted = redactSecrets(message);
+    expect(redacted).not.toContain('envSecretValue1234567890');
+    expect(redacted).toContain('[redacted]');
+  });
+
+  it('sanitizes error details with fallback and max length', () => {
+    const error = new Error('Token leak sk_test_1234567890123456 should not appear.');
+    const detail = sanitizeErrorDetail(error, { maxLength: 40 });
+    expect(detail.length).toBeLessThanOrEqual(40);
+    expect(detail).not.toContain('sk_test_1234567890123456');
+  });
+
+  it('logs sanitized errors and returns the detail', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const detail = logError('secure log', 'API key sk_secret_abcdefghijklmnopqrstuvwxyz1234 leaked');
+    expect(detail).toContain('[redacted]');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toBe('secure log');
+    expect(spy.mock.calls[0][1]).toContain('[redacted]');
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable security helpers to redact secrets from logs and error details
- update Netlify functions to use sanitized error logging and preserve response interfaces
- add unit coverage for the new security utilities

## Testing
- npm test *(fails: missing optional dependency jsdom in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d697d313e8832989643edcd30dd644