### PR TITLE
Add analytics run history instrumentation to quant screener

### DIFF
--- a/docs/quant-screener-technical.md
+++ b/docs/quant-screener-technical.md
@@ -1,0 +1,64 @@
+# Quant Screener — Technical Notes
+
+## Overview
+This document captures the engineering-focused additions shipped with the enterprise-grade analytics refresh. The UI contract remains unchanged; all new capabilities are additive, programmatic layers.
+
+## Aggregate Metrics Engine
+- **Module:** `utils/quant-screener-analytics.js`
+- **Purpose:** Compute resilient summary statistics (upside distribution, momentum, sector weights, market-cap aggregates) for any array of screener rows.
+- **Key behaviours:**
+  - Ignores malformed rows and gracefully handles missing numeric inputs.
+  - Tracks extrema for upside and momentum, plus median/average values.
+  - Produces sector leader insights limited to the top five segments.
+  - Returns deterministic plain objects safe for persistence.
+
+The module exports `computeAggregateMetrics(rows)` and `createEmptyAggregateMetrics()`. The former powers the summary chip datasets and run-history records; the latter initialises runtime state.
+
+## Run History Store
+- **Module:** `utils/screen-run-history.js`
+- **Storage key:** `netlifytrading.quantScreener.runHistory.v1`
+- **Retention:** Up to 20 runs (configurable).
+- **Data shape:**
+  - `timestamp`, `universeCount`, `matches`, `durationMs`, `reachedCap`, `errorCount`.
+  - Sanitised filters, sort snapshot, and a 30-ticker universe sample.
+  - Embedded aggregate metrics (mirroring the analytics engine output).
+
+Implementation highlights:
+- Falls back to an in-memory store when local storage is unavailable (e.g., Safari ITP, privacy mode, or unit tests).
+- Sanitises all incoming payloads (numbers, strings, arrays) and deduplicates by timestamp.
+- Provides immutable snapshots via `list()` and `latest()` to prevent accidental mutation by consumers.
+
+## Runtime Bridge
+`quant-screener.js` publishes a stable API to `window.netlifyTrading.quantScreener`:
+- `getLatestMetrics()` — Returns a clone of the current aggregate metrics (kept in sync with every table render).
+- `getRunHistory()` — Returns the full sanitised run history array.
+
+This bridge enables integrations, observability dashboards, and QA tooling without touching the DOM. The bridge is initialised on module load and refreshed whenever analytics change.
+
+## Summary Chip Instrumentation
+The summary chip retains its original text content while exposing analytics via `data-*` attributes. Keys include:
+- `data-count`, `data-avg-upside`, `data-median-upside`
+- `data-positive-upside-count`, `data-negative-upside-count`, `data-zero-upside-count`
+- `data-total-market-cap`, `data-average-market-cap`
+- `data-best-upside-symbol/value`, `data-worst-upside-symbol/value`, `data-best-momentum-symbol/value`
+- `data-top-sectors` (JSON payload of top sector leaders)
+
+These attributes allow dashboards or browser extensions to ingest metrics without DOM parsing or additional requests.
+
+## Workflow Integration
+`runScreen()` now persists both the legacy preference snapshot and a richer run-history entry in a single flow, ensuring data consistency. The flow order is:
+1. Run screener with concurrency autoscaling.
+2. Apply filters and update render metrics.
+3. Persist preferences (including last-run metadata).
+4. Record sanitised run history with the latest metrics and filters.
+
+## Testing
+- Unit tests for analytics and run-history sanitisation live under `tests/utils/`.
+- Existing Vitest configuration picks up the new specs automatically.
+- Tests verify numeric coercion, sector aggregation, storage capacity handling, and snapshot immutability.
+
+## Operational Considerations
+- Storage errors (quota exceeded, JSON corruption) are caught and logged with friendly console warnings.
+- History retention can be tuned by passing `maxEntries` into `createRunHistoryStore` if product requirements evolve.
+
+For further enhancements (e.g., syncing history to a backend), reuse the sanitised payload returned by `createRunHistoryStore().record()`.

--- a/docs/quant-screener-user-guide.md
+++ b/docs/quant-screener-user-guide.md
@@ -1,0 +1,62 @@
+# Quant Screener — User Guide
+
+## Overview
+The Quant Screener helps research analysts triage equity universes using AI-enriched intelligence. The workflow below mirrors the production interface exactly—no additional buttons or layout changes were introduced in this update.
+
+## Running a Screen
+1. Paste or type the tickers you want to evaluate into the **Universe** text area (comma or newline separated).
+2. Adjust optional filters:
+   - Minimum and maximum upside percentages.
+   - Market capitalisation bounds (in billions of USD).
+   - Sector keywords (comma separated).
+   - Maximum number of tickers to keep per batch.
+3. Click **Screen universe**. Progress updates appear in the existing status banner and the results stream into the table as intelligence is gathered.
+
+## Working with Results
+- The results table supports column sorting (click any column header).
+- The **Export CSV** action downloads the current, filtered table contents.
+- The **Market Radar** heatmap surfaces up to 18 symbols ranked by upside.
+- The summary chip above the table displays the total matches and average upside using the familiar format (`N matches · Avg upside ±X.X%`).
+
+## Persisted Preferences
+The screener automatically remembers:
+- The last ticker universe you entered.
+- Filter values and sorting preferences.
+- Metadata about the last completed run (ticker count, matches, duration, and whether the batch cap was reached).
+
+Preferences are stored in the browser’s local storage namespace `netlifytrading.quantScreener.preferences.v1`. They are scoped per browser profile and can be reset by clearing site data.
+
+## Run History (New)
+Each completed run is now archived (up to 20 entries) in local storage under `netlifytrading.quantScreener.runHistory.v1`. The history is background-only to preserve the current UI, but it unlocks advanced workflows:
+- Inspect run analytics in the developer console via `window.netlifyTrading.quantScreener.getRunHistory()`.
+- Retrieve the latest aggregate metrics (counts, upside distribution, sector leaders, and more) with `window.netlifyTrading.quantScreener.getLatestMetrics()`.
+- Review which universe tickers were sampled in each run without exporting data.
+
+## Summary Chip Data Attributes (New)
+To support enterprise integrations without altering the interface, the summary chip now publishes structured metrics as `data-*` attributes. Example:
+
+```html
+<span id="summaryChip"
+      data-count="12"
+      data-avg-upside="8.42"
+      data-median-upside="7.95"
+      data-positive-upside-count="9"
+      data-negative-upside-count="2"
+      data-zero-upside-count="1"
+      data-total-market-cap="4200000000000"
+      data-average-market-cap="1400000000000"
+      data-best-upside-symbol="AAPL"
+      data-best-upside-value="15.3"
+      data-top-sectors='[{"name":"Technology","count":9,"weight":0.75}]'>
+  12 matches · Avg upside +8.4%
+</span>
+```
+
+Third-party dashboards can read these attributes without DOM changes or additional network calls.
+
+## Troubleshooting
+- **Local storage disabled:** The screener falls back to an in-memory store for the active session. Preferences and run history will not persist across refreshes.
+- **Clearing data:** Use the browser’s dev tools to remove the `netlifytrading.quantScreener.*` keys or call `window.netlifyTrading.quantScreener.getRunHistory()` to inspect before clearing.
+
+## Support
+For workflow or data issues raise a ticket with the Research Engineering team, referencing “Quant Screener” in the subject line.

--- a/tests/utils/quantScreenerAnalytics.spec.js
+++ b/tests/utils/quantScreenerAnalytics.spec.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { computeAggregateMetrics, createEmptyAggregateMetrics } from '../../utils/quant-screener-analytics.js';
+
+describe('quant screener analytics', () => {
+  it('returns empty metrics when rows are missing', () => {
+    const baseline = createEmptyAggregateMetrics();
+    const metrics = computeAggregateMetrics();
+    expect(metrics).toEqual({ ...baseline, sectorLeaders: [] });
+    expect(metrics.count).toBe(0);
+    expect(metrics.sectorLeaders).toEqual([]);
+  });
+
+  it('aggregates upside, momentum, and sectors', () => {
+    const rows = [
+      {
+        symbol: 'AAPL',
+        upside: 10,
+        momentum: 5,
+        marketCap: 2_000_000_000_000,
+        sector: 'Technology',
+      },
+      {
+        symbol: 'MSFT',
+        upside: -5,
+        momentum: 2,
+        marketCap: 1_800_000_000_000,
+        sector: 'Technology',
+      },
+      {
+        symbol: 'JPM',
+        upside: 0,
+        momentum: null,
+        marketCap: 400_000_000_000,
+        sector: 'Financials',
+      },
+    ];
+
+    const metrics = computeAggregateMetrics(rows);
+    expect(metrics.count).toBe(3);
+    expect(metrics.positiveUpsideCount).toBe(1);
+    expect(metrics.negativeUpsideCount).toBe(1);
+    expect(metrics.zeroUpsideCount).toBe(1);
+    expect(metrics.bestUpside).toEqual({ symbol: 'AAPL', value: 10 });
+    expect(metrics.worstUpside).toEqual({ symbol: 'MSFT', value: -5 });
+    expect(metrics.bestMomentum).toEqual({ symbol: 'AAPL', value: 5 });
+    expect(metrics.avgUpside).toBeCloseTo((10 - 5 + 0) / 3, 5);
+    expect(metrics.medianUpside).toBeCloseTo(0, 5);
+    expect(metrics.totalMarketCap).toBe(4_200_000_000_000);
+    expect(metrics.averageMarketCap / 1_000_000_000_000).toBeCloseTo(1.4, 5);
+    expect(metrics.sectorLeaders.length).toBe(2);
+    const [tech, financials] = metrics.sectorLeaders;
+    expect(tech.name).toBe('Technology');
+    expect(tech.count).toBe(2);
+    expect(tech.weight).toBeCloseTo(2 / 3, 5);
+    expect(tech.averageUpside).toBeCloseTo((10 - 5) / 2, 5);
+    expect(financials.name).toBe('Financials');
+    expect(financials.count).toBe(1);
+    expect(financials.weight).toBeCloseTo(1 / 3, 5);
+  });
+});

--- a/tests/utils/screenRunHistory.spec.js
+++ b/tests/utils/screenRunHistory.spec.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { createRunHistoryStore } from '../../utils/screen-run-history.js';
+
+const createMemoryStorage = () => {
+  const data = new Map();
+  return {
+    getItem: (key) => (data.has(key) ? data.get(key) : null),
+    setItem: (key, value) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key) => {
+      data.delete(key);
+    },
+  };
+};
+
+describe('screen run history store', () => {
+  it('records sanitized entries and enforces capacity', () => {
+    const storage = createMemoryStorage();
+    const store = createRunHistoryStore({ storage, maxEntries: 2 });
+
+    store.record({
+      timestamp: 100,
+      universeCount: '5',
+      matches: '2',
+      durationMs: '42.9',
+      filters: { minUpside: '10', sectors: 'Tech, Health Care' },
+      sort: { key: 'momentum', direction: 'asc' },
+      universeSample: ['AAPL', 'MSFT'],
+      metrics: {
+        count: 2,
+        avgUpside: '12.3',
+        sectorLeaders: [{ name: 'Technology', count: '2', weight: '0.5' }],
+      },
+    });
+
+    store.record({
+      timestamp: 200,
+      universeCount: 10,
+      matches: 3,
+      errorCount: 1,
+      universeSample: 'NVDA, AMD, GOOG',
+      metrics: {},
+    });
+
+    store.record({
+      timestamp: 50,
+      universeCount: 1,
+      matches: 1,
+    });
+
+    const entries = store.list();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].timestamp).toBe(200);
+    expect(entries[0].errorCount).toBe(1);
+    expect(entries[0].metrics.count).toBe(0);
+    expect(entries[0].universeSample).toEqual(['NVDA', 'AMD', 'GOOG']);
+
+    const second = entries[1];
+    expect(second.timestamp).toBe(100);
+    expect(second.filters.minUpside).toBe(10);
+    expect(second.filters.sectors).toEqual(['Tech', 'Health Care']);
+    expect(second.sort).toEqual({ key: 'momentum', direction: 'asc' });
+    expect(second.metrics.avgUpside).toBeCloseTo(12.3);
+    expect(second.metrics.sectorLeaders[0]).toEqual({
+      name: 'Technology',
+      count: 2,
+      weight: 0.5,
+      averageUpside: null,
+    });
+  });
+
+  it('provides immutable snapshots and supports clearing', () => {
+    const storage = createMemoryStorage();
+    const store = createRunHistoryStore({ storage });
+    store.record({ timestamp: 10, universeCount: 1, matches: 1 });
+
+    const snapshot = store.list();
+    snapshot[0].filters.minUpside = 999;
+    snapshot[0].universeSample.push('TSLA');
+
+    const next = store.list();
+    expect(next[0].filters.minUpside).not.toBe(999);
+    expect(next[0].universeSample).toEqual([]);
+
+    store.clear();
+    expect(store.list()).toEqual([]);
+  });
+});

--- a/utils/quant-screener-analytics.js
+++ b/utils/quant-screener-analytics.js
@@ -1,0 +1,202 @@
+const toNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const toCount = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return 0;
+  return Math.round(num);
+};
+
+const normalizeSymbol = (value) => {
+  if (typeof value !== 'string') return '';
+  return value.trim().toUpperCase();
+};
+
+const normalizeSector = (value) => {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+};
+
+const computeMedian = (values) => {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+};
+
+const createEmptyExtrema = () => ({ symbol: null, value: null });
+
+const EMPTY_METRICS = Object.freeze({
+  count: 0,
+  avgUpside: null,
+  medianUpside: null,
+  positiveUpsideCount: 0,
+  negativeUpsideCount: 0,
+  zeroUpsideCount: 0,
+  totalMarketCap: null,
+  averageMarketCap: null,
+  bestUpside: null,
+  worstUpside: null,
+  bestMomentum: null,
+  momentumAverage: null,
+  momentumMedian: null,
+  sectorLeaders: [],
+});
+
+const cloneExtrema = (extrema) => {
+  if (!extrema || typeof extrema !== 'object') return null;
+  const symbol = normalizeSymbol(extrema.symbol);
+  const value = toNumber(extrema.value);
+  if (!symbol || value === null) return null;
+  return { symbol, value };
+};
+
+/**
+ * Computes aggregate metrics for screener rows, including distribution
+ * statistics used for run history and developer tooling.
+ *
+ * @param {Array<object>} rows
+ * @returns {object}
+ */
+export function computeAggregateMetrics(rows = []) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { ...EMPTY_METRICS, sectorLeaders: [] };
+  }
+
+  const metrics = {
+    count: 0,
+    avgUpside: null,
+    medianUpside: null,
+    positiveUpsideCount: 0,
+    negativeUpsideCount: 0,
+    zeroUpsideCount: 0,
+    totalMarketCap: null,
+    averageMarketCap: null,
+    bestUpside: null,
+    worstUpside: null,
+    bestMomentum: null,
+    momentumAverage: null,
+    momentumMedian: null,
+    sectorLeaders: [],
+  };
+
+  const upsides = [];
+  const momentumValues = [];
+  const sectorStats = new Map();
+
+  let upsideAccumulator = 0;
+  let upsideCount = 0;
+  let marketCapAccumulator = 0;
+  let marketCapCount = 0;
+  let momentumAccumulator = 0;
+
+  const bestUpside = createEmptyExtrema();
+  const worstUpside = createEmptyExtrema();
+  const bestMomentum = createEmptyExtrema();
+
+  for (const candidate of rows) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    metrics.count += 1;
+
+    const symbol = normalizeSymbol(candidate.symbol);
+    const sector = normalizeSector(candidate.sector || candidate.industry || '');
+    const upside = toNumber(candidate.upside);
+    const momentum = toNumber(candidate.momentum);
+    const marketCap = toNumber(candidate.marketCap);
+
+    if (upside !== null) {
+      upsides.push(upside);
+      upsideAccumulator += upside;
+      upsideCount += 1;
+      if (upside > 0) metrics.positiveUpsideCount += 1;
+      else if (upside < 0) metrics.negativeUpsideCount += 1;
+      else metrics.zeroUpsideCount += 1;
+
+      if (bestUpside.value === null || upside > bestUpside.value) {
+        bestUpside.symbol = symbol || candidate.symbol || null;
+        bestUpside.value = upside;
+      }
+      if (worstUpside.value === null || upside < worstUpside.value) {
+        worstUpside.symbol = symbol || candidate.symbol || null;
+        worstUpside.value = upside;
+      }
+    }
+
+    if (momentum !== null) {
+      momentumValues.push(momentum);
+      momentumAccumulator += momentum;
+      if (bestMomentum.value === null || momentum > bestMomentum.value) {
+        bestMomentum.symbol = symbol || candidate.symbol || null;
+        bestMomentum.value = momentum;
+      }
+    }
+
+    if (marketCap !== null) {
+      marketCapAccumulator += marketCap;
+      marketCapCount += 1;
+    }
+
+    if (sector) {
+      const key = sector.toLowerCase();
+      if (!sectorStats.has(key)) {
+        sectorStats.set(key, {
+          name: sector,
+          count: 0,
+          upsideTotal: 0,
+          upsideCount: 0,
+        });
+      }
+      const stat = sectorStats.get(key);
+      stat.count += 1;
+      if (upside !== null) {
+        stat.upsideTotal += upside;
+        stat.upsideCount += 1;
+      }
+    }
+  }
+
+  if (upsideCount) {
+    metrics.avgUpside = upsideAccumulator / upsideCount;
+    metrics.medianUpside = computeMedian(upsides);
+    metrics.bestUpside = cloneExtrema(bestUpside);
+    metrics.worstUpside = cloneExtrema(worstUpside);
+  }
+
+  if (marketCapCount) {
+    metrics.totalMarketCap = marketCapAccumulator;
+    metrics.averageMarketCap = marketCapAccumulator / marketCapCount;
+  }
+
+  if (momentumValues.length) {
+    metrics.momentumAverage = momentumAccumulator / momentumValues.length;
+    metrics.momentumMedian = computeMedian(momentumValues);
+    metrics.bestMomentum = cloneExtrema(bestMomentum);
+  }
+
+  const leaders = Array.from(sectorStats.values())
+    .map((stat) => ({
+      name: stat.name,
+      count: stat.count,
+      weight: metrics.count ? stat.count / metrics.count : 0,
+      averageUpside: stat.upsideCount ? stat.upsideTotal / stat.upsideCount : null,
+    }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, 5);
+
+  metrics.sectorLeaders = leaders;
+
+  return metrics;
+}
+
+export function createEmptyAggregateMetrics() {
+  return { ...EMPTY_METRICS, sectorLeaders: [] };
+}

--- a/utils/screen-run-history.js
+++ b/utils/screen-run-history.js
@@ -1,0 +1,299 @@
+const DEFAULT_STORAGE_KEY = 'netlifytrading.quantScreener.runHistory.v1';
+const MAX_ENTRIES = 20;
+
+const createMemoryStorage = () => {
+  const data = new Map();
+  return {
+    getItem: (key) => (data.has(key) ? data.get(key) : null),
+    setItem: (key, value) => {
+      data.set(key, String(value));
+    },
+    removeItem: (key) => {
+      data.delete(key);
+    },
+  };
+};
+
+const resolveStorage = (storage, key) => {
+  if (storage) return storage;
+  if (typeof window === 'undefined') return createMemoryStorage();
+  const driver = window.localStorage;
+  if (!driver) return createMemoryStorage();
+  try {
+    const probe = `${key}.__probe__`;
+    driver.setItem(probe, '1');
+    driver.removeItem(probe);
+    return driver;
+  } catch (error) {
+    console.warn('Run history storage unavailable, falling back to memory store.', error);
+    return createMemoryStorage();
+  }
+};
+
+const toNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const toCount = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return 0;
+  return Math.round(num);
+};
+
+const normalizeString = (value) => {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+};
+
+const normalizeSymbol = (value) => {
+  const str = normalizeString(value);
+  return str.toUpperCase();
+};
+
+const cloneMetrics = (metrics) => {
+  if (!metrics) {
+    return {
+      count: 0,
+      avgUpside: null,
+      medianUpside: null,
+      positiveUpsideCount: 0,
+      negativeUpsideCount: 0,
+      zeroUpsideCount: 0,
+      totalMarketCap: null,
+      averageMarketCap: null,
+      bestUpside: null,
+      worstUpside: null,
+      bestMomentum: null,
+      momentumAverage: null,
+      momentumMedian: null,
+      sectorLeaders: [],
+    };
+  }
+
+  const sanitizeExtrema = (extrema) => {
+    if (!extrema || typeof extrema !== 'object') return null;
+    const symbol = normalizeSymbol(extrema.symbol);
+    const value = toNumber(extrema.value);
+    if (!symbol || value === null) return null;
+    return { symbol, value };
+  };
+
+  const sanitizeSector = (sector) => {
+    if (!sector || typeof sector !== 'object') return null;
+    const name = normalizeString(sector.name);
+    if (!name) return null;
+    return {
+      name,
+      count: toCount(sector.count),
+      weight: toNumber(sector.weight),
+      averageUpside: toNumber(sector.averageUpside),
+    };
+  };
+
+  const sanitized = {
+    count: toCount(metrics.count),
+    avgUpside: toNumber(metrics.avgUpside),
+    medianUpside: toNumber(metrics.medianUpside),
+    positiveUpsideCount: toCount(metrics.positiveUpsideCount),
+    negativeUpsideCount: toCount(metrics.negativeUpsideCount),
+    zeroUpsideCount: toCount(metrics.zeroUpsideCount),
+    totalMarketCap: toNumber(metrics.totalMarketCap),
+    averageMarketCap: toNumber(metrics.averageMarketCap),
+    bestUpside: sanitizeExtrema(metrics.bestUpside),
+    worstUpside: sanitizeExtrema(metrics.worstUpside),
+    bestMomentum: sanitizeExtrema(metrics.bestMomentum),
+    momentumAverage: toNumber(metrics.momentumAverage),
+    momentumMedian: toNumber(metrics.momentumMedian),
+    sectorLeaders: Array.isArray(metrics.sectorLeaders)
+      ? metrics.sectorLeaders.map(sanitizeSector).filter(Boolean).slice(0, 5)
+      : [],
+  };
+
+  return sanitized;
+};
+
+const sanitizeFilters = (filters) => {
+  const base = {
+    minUpside: null,
+    maxUpside: null,
+    marketCapMin: null,
+    marketCapMax: null,
+    batchCap: null,
+    sectors: [],
+  };
+  if (!filters || typeof filters !== 'object') return base;
+
+  const resolveSectors = (value) => {
+    if (Array.isArray(value)) {
+      return value.map(normalizeString).filter(Boolean).slice(0, 12);
+    }
+    if (typeof value === 'string') {
+      return value
+        .split(/[\n,]+/)
+        .map(normalizeString)
+        .filter(Boolean)
+        .slice(0, 12);
+    }
+    return [];
+  };
+
+  return {
+    minUpside: toNumber(filters.minUpside),
+    maxUpside: toNumber(filters.maxUpside),
+    marketCapMin: toNumber(filters.marketCapMin),
+    marketCapMax: toNumber(filters.marketCapMax),
+    batchCap: toCount(filters.batchCap) || null,
+    sectors: resolveSectors(filters.sectors),
+  };
+};
+
+const sanitizeSort = (sort) => {
+  const key = normalizeString(sort && sort.key);
+  const direction = sort && sort.direction === 'asc' ? 'asc' : 'desc';
+  return {
+    key: key || 'upside',
+    direction,
+  };
+};
+
+const sanitizeUniverse = (universe, limit = 30) => {
+  if (!universe) return [];
+  const tokens = Array.isArray(universe)
+    ? universe.map(normalizeSymbol)
+    : String(universe)
+        .split(/[\s,]+/)
+        .map(normalizeSymbol);
+  return tokens.filter(Boolean).slice(0, limit);
+};
+
+const sanitizeEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') return null;
+  const timestamp = toNumber(entry.timestamp) ?? Date.now();
+  const universeCount = toCount(entry.universeCount || entry.universeSize);
+  const matches = toCount(entry.matches || entry.matchesCount || entry.results);
+  const duration = toNumber(entry.durationMs);
+  const reachedCap = Boolean(entry.reachedCap);
+  const errorCount = toCount(entry.errorCount || entry.errors);
+
+  const sanitized = {
+    timestamp,
+    universeCount,
+    matches,
+    durationMs: duration !== null ? Math.max(0, Math.round(duration)) : null,
+    reachedCap,
+    errorCount,
+    filters: sanitizeFilters(entry.filters || {}),
+    sort: sanitizeSort(entry.sort || {}),
+    universeSample: sanitizeUniverse(entry.universeSample || entry.universe),
+    metrics: cloneMetrics(entry.metrics),
+  };
+
+  return sanitized;
+};
+
+const sanitizeEntries = (entries) => {
+  if (!Array.isArray(entries)) return [];
+  const deduped = new Map();
+  for (const candidate of entries) {
+    const sanitized = sanitizeEntry(candidate);
+    if (!sanitized) continue;
+    deduped.set(sanitized.timestamp, sanitized);
+  }
+  return Array.from(deduped.values()).sort((a, b) => b.timestamp - a.timestamp);
+};
+
+const cloneEntry = (entry) => ({
+  timestamp: entry.timestamp,
+  universeCount: entry.universeCount,
+  matches: entry.matches,
+  durationMs: entry.durationMs,
+  reachedCap: entry.reachedCap,
+  errorCount: entry.errorCount,
+  filters: { ...entry.filters, sectors: [...entry.filters.sectors] },
+  sort: { ...entry.sort },
+  universeSample: [...entry.universeSample],
+  metrics: {
+    ...entry.metrics,
+    bestUpside: entry.metrics.bestUpside ? { ...entry.metrics.bestUpside } : null,
+    worstUpside: entry.metrics.worstUpside ? { ...entry.metrics.worstUpside } : null,
+    bestMomentum: entry.metrics.bestMomentum ? { ...entry.metrics.bestMomentum } : null,
+    sectorLeaders: entry.metrics.sectorLeaders.map((leader) => ({ ...leader })),
+  },
+});
+
+export function createRunHistoryStore({ storage: explicitStorage, key = DEFAULT_STORAGE_KEY, maxEntries = MAX_ENTRIES } = {}) {
+  const storage = resolveStorage(explicitStorage, key);
+  let snapshot = [];
+
+  const read = () => {
+    if (snapshot.length) {
+      return snapshot.map(cloneEntry);
+    }
+
+    const raw = storage.getItem(key);
+    if (!raw) {
+      snapshot = [];
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      snapshot = sanitizeEntries(parsed);
+      return snapshot.map(cloneEntry);
+    } catch (error) {
+      console.warn('Failed to parse quant screener run history. Resetting state.', error);
+      snapshot = [];
+      return [];
+    }
+  };
+
+  const persist = (entries) => {
+    snapshot = sanitizeEntries(entries);
+    const serialized = JSON.stringify(snapshot);
+    try {
+      storage.setItem(key, serialized);
+    } catch (error) {
+      console.warn('Failed to persist quant screener run history.', error);
+    }
+    return snapshot.map(cloneEntry);
+  };
+
+  const list = () => {
+    return read();
+  };
+
+  const latest = () => {
+    const entries = read();
+    return entries.length ? entries[0] : null;
+  };
+
+  const record = (entry) => {
+    const sanitized = sanitizeEntry(entry);
+    if (!sanitized) {
+      throw new TypeError('Run history entry must be a non-null object.');
+    }
+    const entries = read();
+    const filtered = entries.filter((candidate) => candidate.timestamp !== sanitized.timestamp);
+    filtered.push(sanitized);
+    filtered.sort((a, b) => b.timestamp - a.timestamp);
+    while (filtered.length > maxEntries) {
+      filtered.pop();
+    }
+    persist(filtered);
+    return sanitized;
+  };
+
+  const clear = () => {
+    snapshot = [];
+    try {
+      storage.removeItem(key);
+    } catch (error) {
+      console.warn('Failed to clear quant screener run history.', error);
+    }
+  };
+
+  return { key, list, latest, record, clear };
+}
+
+export const SCREEN_RUN_HISTORY_STORAGE_KEY = DEFAULT_STORAGE_KEY;


### PR DESCRIPTION
## Summary
- add an aggregate metrics engine and persistent run-history store for the quant screener, providing programmatic analytics without UI changes
- publish structured metrics via the summary chip, expose a runtime bridge for integrations, and record each screen run alongside existing preferences
- document the new capabilities and cover them with targeted vitest suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d697db165c8329b199f150d23f8184