### PR TITLE
Add merge conflict safeguards and staging QA checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ AI Analyst, Quant Screener, Valuation Lab, and Professional Desk experiences.
 ### Quality Assurance
 
 - Automated unit tests: `npm test`
+- Merge conflict scan: `npm run qa:conflicts`
 - Manual regression playbook: [`docs/manual-testing/e2e-regression-plan.md`](docs/manual-testing/e2e-regression-plan.md)
+- Staging deployment checklist: [`docs/manual-testing/staging-deployment-checklist.md`](docs/manual-testing/staging-deployment-checklist.md)
 
 ### Documentation
 

--- a/docs/manual-testing/staging-deployment-checklist.md
+++ b/docs/manual-testing/staging-deployment-checklist.md
@@ -1,0 +1,44 @@
+# Staging Deployment & Final QA Checklist
+
+Use this checklist to coordinate staging releases without disrupting the existing interface. The steps are designed for enterprise-grade rigor and can be followed by any release manager or engineer.
+
+## 1. Pre-flight Validation
+
+1. Run automated test suites:
+   - `npm test`
+   - `npm run qa:conflicts`
+2. Confirm the working branch is rebased on the latest `main` and free of merge commits.
+3. Verify environment variables required by Netlify Functions are present in the staging workspace.
+
+## 2. Build Verification
+
+1. Execute `npm run build` to produce the deployable artifact.
+2. Inspect the generated `build/` directory to ensure the following assets exist:
+   - `index.html`
+   - `app.js`
+   - `app.css`
+   - `netlify/functions/*`
+3. Run the local Netlify dev server (`npm start`) and spot-check the major surfaces:
+   - AI Analyst
+   - Quant Screener
+   - Valuation Lab
+   - Professional Desk
+
+## 3. Staging Deployment
+
+1. Deploy the build to the staging environment using the Netlify dashboard or CLI.
+2. Confirm deployment metadata (commit SHA, branch name, and timestamp) is documented in the release tracker.
+3. Share the staging URL with QA and stakeholders.
+
+## 4. Final QA Pass
+
+1. Execute the manual regression plan documented in [`docs/manual-testing/e2e-regression-plan.md`](./e2e-regression-plan.md).
+2. Capture screenshots or recordings of critical workflows, noting any anomalies.
+3. Log defects in the issue tracker with reproduction steps and environment details.
+
+## 5. Release Sign-off
+
+1. Ensure all open defects are triaged and resolved or explicitly waived by stakeholders.
+2. Re-run `npm run qa:conflicts` and `npm test` after fixes are applied.
+3. Obtain sign-off from engineering, QA, and product before promoting the build to production.
+4. Archive the checklist in the release documentation repository for auditability.

--- a/netlify/functions/lib/security.js
+++ b/netlify/functions/lib/security.js
@@ -15,6 +15,7 @@ const MIN_ENV_SECRET_LENGTH = 16;
 const ENV_CACHE_TTL_MS = 60_000;
 
 const DEFAULT_PATTERNS = [
+  /\b(?:sk|rk|pk)_[a-z]+_[A-Za-z0-9]{16,}\b/gi,
   /\b(?:sk|rk|pk)_[A-Za-z0-9]{16,}\b/gi,
   /\b[A-Za-z0-9]{40,}\b/g,
   /\b[0-9a-f]{32,}\b/gi,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "npx netlify-cli@latest dev",
     "generate:symbols": "node scripts/build-symbols.mjs",
     "peer-review:inventory": "node scripts/peer-review/generate-file-inventory.mjs",
+    "qa:conflicts": "node scripts/qa/check-merge-conflicts.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/qa/check-merge-conflicts.mjs
+++ b/scripts/qa/check-merge-conflicts.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { scanForMergeConflicts, mergeConflictMarkers } from '../../utils/merge-conflict-scanner.js';
+
+async function main() {
+  const argv = new Set(process.argv.slice(2));
+  const format = argv.has('--json') ? 'json' : 'text';
+  const ignore = [];
+
+  for (const arg of argv) {
+    if (arg.startsWith('--ignore=')) {
+      const [, value] = arg.split('=');
+      if (value) {
+        ignore.push(value);
+      }
+    }
+  }
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const rootDir = path.resolve(__dirname, '..', '..');
+
+  try {
+    const conflicts = await scanForMergeConflicts(rootDir, { ignore });
+
+    if (conflicts.length === 0) {
+      if (format === 'json') {
+        process.stdout.write(JSON.stringify({ ok: true, conflicts: [] }, null, 2));
+      } else {
+        process.stdout.write('✅ No merge conflict markers detected.\n');
+      }
+      return;
+    }
+
+    if (format === 'json') {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            ok: false,
+            markers: mergeConflictMarkers,
+            conflicts,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      process.stdout.write(`❌ Detected merge conflict markers (${mergeConflictMarkers.join(', ')}).\n\n`);
+      for (const conflict of conflicts) {
+        process.stdout.write(`• ${conflict.path}\n`);
+        for (const marker of conflict.markers) {
+          process.stdout.write(`   - line ${marker.line}: ${marker.markers.join(', ')} → ${marker.preview}\n`);
+        }
+        process.stdout.write('\n');
+      }
+      process.stdout.write('Resolve the conflicts and re-run this command before continuing.\n');
+    }
+
+    process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(`Failed to scan for merge conflicts: ${error.message}\n`);
+    process.exitCode = 2;
+  }
+}
+
+main();

--- a/tests/utils/merge-conflict-scanner.spec.js
+++ b/tests/utils/merge-conflict-scanner.spec.js
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  scanForMergeConflicts,
+  hasMergeConflicts,
+  mergeConflictMarkers,
+} from '../../utils/merge-conflict-scanner.js';
+
+async function makeTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'merge-conflict-scanner-'));
+  return dir;
+}
+
+async function cleanupTempDir(directory) {
+  await fs.rm(directory, { recursive: true, force: true });
+}
+
+describe('merge conflict scanner', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await cleanupTempDir(tempDir);
+      tempDir = undefined;
+    }
+  });
+
+  it('returns an empty array when no conflict markers are present', async () => {
+    const target = path.join(tempDir, 'clean.txt');
+    await fs.writeFile(target, 'The quick brown fox jumps over the lazy dog.');
+
+    const conflicts = await scanForMergeConflicts(tempDir);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('detects merge conflict markers with line numbers', async () => {
+    const target = path.join(tempDir, 'conflict.txt');
+    const content = [
+      'function example() {',
+      '<<<<<<< HEAD',
+      "  return 'alpha';",
+      '=======',
+      "  return 'beta';",
+      '>>>>>>> feature-branch',
+      '}',
+      '',
+    ].join('\n');
+    await fs.writeFile(target, content);
+
+    const conflicts = await scanForMergeConflicts(tempDir);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].path).toBe('conflict.txt');
+    const lineNumbers = conflicts[0].markers.map((marker) => marker.line);
+    expect(lineNumbers).toEqual([2, 4, 6]);
+    expect(conflicts[0].markers[0].markers).toEqual(['<<<<<<<']);
+  });
+
+  it('skips binary files and compressed assets', async () => {
+    const binaryTarget = path.join(tempDir, 'image.png');
+    const binaryContent = Buffer.from([0, 120, 3, 255, 17, 42, 0, 5]);
+    await fs.writeFile(binaryTarget, binaryContent);
+
+    const conflicts = await scanForMergeConflicts(tempDir);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('respects the ignore option', async () => {
+    const ignoredDirectory = path.join(tempDir, 'ignored');
+    await fs.mkdir(ignoredDirectory);
+    await fs.writeFile(
+      path.join(ignoredDirectory, 'conflict.txt'),
+      ['<<<<<<< ours', '=======', '>>>>>>> theirs'].join('\n'),
+    );
+
+    const conflicts = await scanForMergeConflicts(tempDir, { ignore: ['ignored'] });
+    expect(conflicts).toEqual([]);
+  });
+
+  it('reports presence of conflicts through hasMergeConflicts', async () => {
+    const target = path.join(tempDir, 'conflict.txt');
+    await fs.writeFile(target, ['<<<<<<< ours', '=======', '>>>>>>> theirs'].join('\n'));
+
+    const hasConflicts = await hasMergeConflicts(tempDir);
+    expect(hasConflicts).toBe(true);
+  });
+
+  it('exposes mergeConflictMarkers constant for reporting', () => {
+    expect(mergeConflictMarkers).toEqual(['<<<<<<<', '=======', '>>>>>>>', '|||||||']);
+  });
+});

--- a/utils/merge-conflict-scanner.js
+++ b/utils/merge-conflict-scanner.js
@@ -1,0 +1,158 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_IGNORED_DIRECTORIES = new Set([
+  '.git',
+  'node_modules',
+  'build',
+  '.netlify',
+  'coverage',
+  'dist',
+  '.cache',
+]);
+
+const MARKER_PATTERNS = [
+  { marker: '<<<<<<<', regex: /^<{7}( |$)/ },
+  { marker: '=======', regex: /^={7}( |$)/ },
+  { marker: '>>>>>>>', regex: /^>{7}( |$)/ },
+  { marker: '|||||||', regex: /^\|{7}( |$)/ },
+];
+
+const SKIPPED_FILE_EXTENSIONS = new Set([
+  '.zip',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.pdf',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+]);
+
+const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+function isProbablyBinary(buffer) {
+  const length = Math.min(buffer.length, 8192);
+  let suspicious = 0;
+
+  for (let i = 0; i < length; i += 1) {
+    const byte = buffer[i];
+    if (byte === 0) {
+      return true;
+    }
+
+    if (byte < 7 || (byte > 13 && byte < 32)) {
+      suspicious += 1;
+      if (suspicious / length > 0.3) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function detectConflictMarkers(line) {
+  return MARKER_PATTERNS.filter(({ regex }) => regex.test(line)).map(({ marker }) => marker);
+}
+
+export async function scanForMergeConflicts(rootDir, options = {}) {
+  if (!rootDir) {
+    throw new Error('rootDir is required');
+  }
+
+  const {
+    ignore = [],
+    includeDotfiles = true,
+    maxFileSize = DEFAULT_MAX_FILE_SIZE,
+  } = options;
+
+  const ignoredDirectories = new Set([...DEFAULT_IGNORED_DIRECTORIES, ...ignore]);
+  const conflicts = [];
+
+  async function walk(currentDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (ignoredDirectories.has(entry.name)) {
+          continue;
+        }
+        if (!includeDotfiles && entry.name.startsWith('.')) {
+          continue;
+        }
+
+        await walk(path.join(currentDir, entry.name));
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      if (!includeDotfiles && entry.name.startsWith('.')) {
+        continue;
+      }
+
+      const filePath = path.join(currentDir, entry.name);
+      const stats = await fs.stat(filePath);
+      if (stats.size === 0) {
+        continue;
+      }
+
+      if (typeof maxFileSize === 'number' && maxFileSize > 0 && stats.size > maxFileSize) {
+        continue;
+      }
+
+      const extension = path.extname(entry.name).toLowerCase();
+      if (SKIPPED_FILE_EXTENSIONS.has(extension)) {
+        continue;
+      }
+
+      const buffer = await fs.readFile(filePath);
+      if (isProbablyBinary(buffer)) {
+        continue;
+      }
+
+      const content = buffer.toString('utf8');
+      const lines = content.split(/\r?\n/);
+      const fileConflicts = [];
+
+      for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        const markers = detectConflictMarkers(line);
+        if (markers.length > 0) {
+          fileConflicts.push({
+            line: index + 1,
+            markers,
+            preview: line.trim(),
+          });
+        }
+      }
+
+      if (fileConflicts.length > 0) {
+        conflicts.push({
+          path: path.relative(rootDir, filePath) || entry.name,
+          markers: fileConflicts,
+        });
+      }
+    }
+  }
+
+  await walk(rootDir);
+
+  conflicts.sort((a, b) => a.path.localeCompare(b.path));
+
+  return conflicts;
+}
+
+export async function hasMergeConflicts(rootDir, options = {}) {
+  const conflicts = await scanForMergeConflicts(rootDir, options);
+  return conflicts.length > 0;
+}
+
+export const mergeConflictMarkers = MARKER_PATTERNS.map((pattern) => pattern.marker);


### PR DESCRIPTION
## Summary
- add a reusable merge-conflict scanner utility with a CLI entrypoint for QA
- expand secret redaction patterns to cover multi-segment API keys
- document a staging deployment and final QA checklist for release readiness

## Testing
- npm test
- npm run qa:conflicts

------
https://chatgpt.com/codex/tasks/task_e_68d69bafe534832993d6997fd4c6c190