### PR TITLE
Add Netlify staging deployment workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Netlify authentication token with permissions to deploy to the staging site.
+NETLIFY_AUTH_TOKEN=
+
+# Unique identifier of the staging site in Netlify.
+NETLIFY_STAGING_SITE_ID=
+
+# Optional overrides for deployment behavior.
+# NETLIFY_DEPLOY_ALIAS=staging
+# NETLIFY_DEPLOY_MESSAGE="Staging deploy $(date --iso-8601=seconds)"
+# NETLIFY_DEPLOY_DIR=build
+# NETLIFY_SKIP_BUILD=false

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ AI Analyst, Quant Screener, Valuation Lab, and Professional Desk experiences.
 ### Documentation
 
 - Platform usage guide: [`docs/platform-user-guide.md`](docs/platform-user-guide.md)
+- Netlify staging deployment guide: [`docs/devops/netlify-staging-deploy.md`](docs/devops/netlify-staging-deploy.md)

--- a/docs/devops/netlify-staging-deploy.md
+++ b/docs/devops/netlify-staging-deploy.md
@@ -1,0 +1,55 @@
+# Netlify Staging Deployment Guide
+
+This guide documents how to deploy the Netlify Trading workspace to the staging environment using the automated script introduced in this repository.
+
+## Prerequisites
+
+1. **Netlify CLI authentication token**
+   - Generate a personal access token from the Netlify user settings page with the `sites` scope.
+   - Store the token securely (for example in a password manager or the CI secret store) and expose it as the `NETLIFY_AUTH_TOKEN` environment variable when running the deployment script.
+2. **Staging site identifier**
+   - From the staging site dashboard in Netlify, copy the **Site ID** value (UUID).
+   - Provide it to the deployment process through the `NETLIFY_STAGING_SITE_ID` environment variable.
+3. **Local environment file (optional)**
+   - Copy `.env.example` to `.env` and populate the token and site identifier fields for local usage.
+
+## One-time setup
+
+1. Install dependencies: `npm install`
+2. Log into Netlify CLI (optional if using tokens only): `npx netlify login`
+3. Confirm the staging site exists and is configured with the appropriate build settings specified in `netlify.toml`.
+
+## Deployment workflow
+
+Run the following command from the repository root:
+
+```bash
+NETLIFY_AUTH_TOKEN=... NETLIFY_STAGING_SITE_ID=... npm run deploy:staging
+```
+
+The script performs these steps:
+
+1. Builds the production bundle via `npm run build` (skip with `NETLIFY_SKIP_BUILD=true`).
+2. Invokes the Netlify CLI to deploy the build artifacts to the staging alias (defaults to `staging`).
+3. Prints the staging deployment URL upon success.
+
+### Optional environment overrides
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `NETLIFY_DEPLOY_ALIAS` | Alias used for the staging deploy. | `staging` |
+| `NETLIFY_DEPLOY_MESSAGE` | Message shown in the Netlify deploy history. | `Staging deploy <timestamp>` |
+| `NETLIFY_DEPLOY_DIR` | Directory containing the build artifacts. | `build` |
+| `NETLIFY_SKIP_BUILD` | Set to `true` to reuse an existing build directory. | `false` |
+
+## CI/CD integration
+
+To integrate with CI, add the required environment variables as protected secrets and run `npm run deploy:staging` in the pipeline after tests pass. The command exits with a non-zero status when prerequisites are missing or the Netlify CLI reports a failure, making it safe for automated workflows.
+
+## Troubleshooting
+
+- **Missing credentials**: Ensure both `NETLIFY_AUTH_TOKEN` and `NETLIFY_STAGING_SITE_ID` are exported before invoking the script.
+- **Build directory missing**: When skipping the build step, confirm the path provided in `NETLIFY_DEPLOY_DIR` exists.
+- **Alias conflicts**: If another deploy is occupying the alias, set `NETLIFY_DEPLOY_ALIAS` to a unique value for the run.
+
+For additional CLI options, review the [Netlify CLI deployment documentation](https://docs.netlify.com/cli/get-started/#manual-deploys). 

--- a/netlify/functions/lib/security.js
+++ b/netlify/functions/lib/security.js
@@ -15,6 +15,7 @@ const MIN_ENV_SECRET_LENGTH = 16;
 const ENV_CACHE_TTL_MS = 60_000;
 
 const DEFAULT_PATTERNS = [
+  /\b(?:sk|rk|pk)_[a-z]+_[A-Za-z0-9]{16,}\b/gi,
   /\b(?:sk|rk|pk)_[A-Za-z0-9]{16,}\b/gi,
   /\b[A-Za-z0-9]{40,}\b/g,
   /\b[0-9a-f]{32,}\b/gi,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "generate:symbols": "node scripts/build-symbols.mjs",
     "peer-review:inventory": "node scripts/peer-review/generate-file-inventory.mjs",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "deploy:staging": "node scripts/deploy-staging.mjs"
   },
   "devDependencies": {
     "cross-env": "^10.0.0",

--- a/scripts/deploy-staging.mjs
+++ b/scripts/deploy-staging.mjs
@@ -1,0 +1,111 @@
+import { spawn } from 'child_process';
+import { access } from 'fs/promises';
+import { constants } from 'fs';
+import path from 'path';
+
+const BUILD_DIR = process.env.NETLIFY_DEPLOY_DIR ?? 'build';
+const STAGING_ALIAS = process.env.NETLIFY_DEPLOY_ALIAS ?? 'staging';
+const DEPLOY_MESSAGE = process.env.NETLIFY_DEPLOY_MESSAGE ?? `Staging deploy ${new Date().toISOString()}`;
+const SITE_ID = process.env.NETLIFY_STAGING_SITE_ID;
+const AUTH_TOKEN = process.env.NETLIFY_AUTH_TOKEN;
+const SKIP_BUILD = (process.env.NETLIFY_SKIP_BUILD ?? '').toLowerCase() === 'true';
+
+function assertEnv(value, name) {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: options.stdio ?? 'inherit',
+      shell: process.platform === 'win32',
+      ...options,
+    });
+
+    let capturedStdout = '';
+    if (options.captureStdout) {
+      child.stdout?.on('data', (chunk) => {
+        const text = chunk.toString();
+        capturedStdout += text;
+        process.stdout.write(text);
+      });
+    }
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(capturedStdout);
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function ensureBuildArtifacts() {
+  if (!SKIP_BUILD) {
+    await runCommand('npm', ['run', 'build']);
+  }
+
+  try {
+    await access(path.resolve(BUILD_DIR), constants.F_OK);
+  } catch (error) {
+    throw new Error(`Expected build output directory "${BUILD_DIR}" does not exist.`);
+  }
+}
+
+async function deploy() {
+  assertEnv(SITE_ID, 'NETLIFY_STAGING_SITE_ID');
+  assertEnv(AUTH_TOKEN, 'NETLIFY_AUTH_TOKEN');
+
+  await ensureBuildArtifacts();
+
+  const deployArgs = [
+    'netlify-cli@latest',
+    'deploy',
+    '--dir',
+    BUILD_DIR,
+    '--alias',
+    STAGING_ALIAS,
+    '--site',
+    SITE_ID,
+    '--message',
+    DEPLOY_MESSAGE,
+    '--json',
+  ];
+
+  const stdout = await runCommand('npx', deployArgs, {
+    env: { ...process.env, NETLIFY_AUTH_TOKEN: AUTH_TOKEN },
+    stdio: ['inherit', 'pipe', 'inherit'],
+    captureStdout: true,
+  });
+
+  const lines = stdout?.trim().split('\n') ?? [];
+  const lastLine = lines.reverse().find((line) => {
+    const trimmed = line.trim();
+    return trimmed.startsWith('{') && trimmed.endsWith('}');
+  });
+
+  if (!lastLine) {
+    console.log('\nNetlify deploy command completed. Review the log above for deployment details.');
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(lastLine);
+    if (parsed?.url) {
+      console.log(`\nStaging deployment available at: ${parsed.url}`);
+    } else {
+      console.log('\nNetlify deploy command completed. Review the log above for deployment details.');
+    }
+  } catch (error) {
+    console.warn('Unable to parse Netlify deploy output as JSON. Review the log above for deployment details.');
+  }
+}
+
+deploy().catch((error) => {
+  console.error(error.message ?? error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a scripted staging deployment workflow that builds artifacts and triggers the Netlify CLI with JSON output parsing
- document the staging deployment process, environment variables, and provide an example `.env` template
- tighten secret-redaction patterns to cover segmented API tokens before logging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69bb9bcec83299a26bdaa2ee42bab