### PR TITLE
Improve security redaction coverage

### DIFF
--- a/netlify/functions/lib/security-patterns.js
+++ b/netlify/functions/lib/security-patterns.js
@@ -1,0 +1,44 @@
+/**
+ * Centralised library of secret redaction patterns.
+ *
+ * The goal is to keep the pattern catalogue in a dedicated module so it can be
+ * expanded safely without creating merge conflicts in the redaction logic.
+ * These patterns intentionally cover common SaaS/API providers that regularly
+ * appear in incident reports and bug bounty write-ups.  All patterns should be
+ * case-insensitive unless noted otherwise.
+ */
+
+const STRIPE_KEY_PREFIXES = ['sk', 'rk', 'pk'];
+const STRIPE_KEY_VARIANTS = ['live', 'test', 'secret', 'sandbox'];
+
+const STRIPE_KEY_PATTERN = new RegExp(
+  `\\b(?:${STRIPE_KEY_PREFIXES.join('|')})_(?:${STRIPE_KEY_VARIANTS.join('|')})_[A-Za-z0-9]{16,}\\b`,
+  'gi',
+);
+const STRIPE_SHORT_KEY_PATTERN = /\b(?:sk|rk|pk)_[A-Za-z0-9]{16,}\b/gi;
+
+const GITHUB_TOKEN_PATTERN = /\bgh[pousr]_[A-Za-z0-9]{32,}\b/gi;
+const SLACK_TOKEN_PATTERN = /\bxox[a-z]-[A-Za-z0-9-]{10,48}\b/gi;
+const GOOGLE_OAUTH_TOKEN_PATTERN = /\bya29\.[0-9A-Za-z\-_]{30,}\b/g;
+const AWS_ACCESS_KEY_PATTERN = /\bAKIA[0-9A-Z]{16}\b/g;
+const AWS_SESSION_KEY_PATTERN = /\bASIA[0-9A-Z]{16}\b/g;
+const PRIVATE_KEY_FOOTER_PATTERN = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----/g;
+const GENERIC_BEARER_PATTERN = /bearer\s+[A-Za-z0-9\-._~+/=]{16,}/gi;
+const HEX_TOKEN_PATTERN = /\b[0-9a-f]{32,}\b/gi;
+const ALPHANUMERIC_TOKEN_PATTERN = /\b[A-Za-z0-9]{40,}\b/g;
+
+export const buildDefaultSecretPatterns = () => [
+  STRIPE_KEY_PATTERN,
+  STRIPE_SHORT_KEY_PATTERN,
+  GITHUB_TOKEN_PATTERN,
+  SLACK_TOKEN_PATTERN,
+  GOOGLE_OAUTH_TOKEN_PATTERN,
+  AWS_ACCESS_KEY_PATTERN,
+  AWS_SESSION_KEY_PATTERN,
+  PRIVATE_KEY_FOOTER_PATTERN,
+  GENERIC_BEARER_PATTERN,
+  HEX_TOKEN_PATTERN,
+  ALPHANUMERIC_TOKEN_PATTERN,
+];
+
+export default buildDefaultSecretPatterns;

--- a/netlify/functions/lib/security.js
+++ b/netlify/functions/lib/security.js
@@ -1,3 +1,5 @@
+import { buildDefaultSecretPatterns } from './security-patterns.js';
+
 const SECRET_KEY_HINTS = [
   'KEY',
   'TOKEN',
@@ -14,12 +16,7 @@ const DEFAULT_REPLACEMENT = '[redacted]';
 const MIN_ENV_SECRET_LENGTH = 16;
 const ENV_CACHE_TTL_MS = 60_000;
 
-const DEFAULT_PATTERNS = [
-  /\b(?:sk|rk|pk)_[A-Za-z0-9]{16,}\b/gi,
-  /\b[A-Za-z0-9]{40,}\b/g,
-  /\b[0-9a-f]{32,}\b/gi,
-  /bearer\s+[A-Za-z0-9\-._~+/=]{16,}/gi,
-];
+const DEFAULT_PATTERNS = buildDefaultSecretPatterns();
 
 let cachedEnvSecrets = null;
 let cachedEnvFetchedAt = 0;


### PR DESCRIPTION
## Summary
- extract the redaction pattern catalogue into a dedicated module to reduce merge conflicts
- expand default secret detection patterns to cover Stripe variants, GitHub/Slack tokens, AWS keys, OAuth strings, and private key blocks
- wire the security utilities to the shared catalogue so downstream consumers benefit automatically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69bc169e8832990d7b0af57a82a46