### PR TITLE
Add monitoring and insights to quant screener

### DIFF
--- a/ai-analyst.css
+++ b/ai-analyst.css
@@ -223,6 +223,10 @@ body {
   color: var(--primary);
 }
 
+.status-message.warning {
+  color: var(--neutral);
+}
+
 .loading-strip {
   display: none;
   align-items: center;
@@ -602,6 +606,12 @@ body {
   border: 1px solid rgba(74, 215, 168, 0.3);
 }
 
+.chip-muted {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
 .split-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -718,6 +728,231 @@ body {
   margin: 0;
   font-size: 0.85rem;
   color: var(--muted);
+}
+
+.insight-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.insight-item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 1rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.insight-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.insight-value {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.insight-subvalue {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.insight-extrema {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.insight-extrema-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.insight-extrema-row span {
+  white-space: nowrap;
+}
+
+.sector-leaders {
+  margin-top: 1.4rem;
+}
+
+.sector-leaders h3 {
+  margin: 0 0 0.8rem 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sector-leader-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.sector-leader-item {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.sector-leader-item strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.sector-leader-weight {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.sector-leader-placeholder {
+  justify-content: flex-start;
+  color: var(--muted);
+  opacity: 0.85;
+}
+
+.history-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.history-list.is-empty {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.history-entry {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.history-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.history-entry-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text);
+  flex: 1;
+}
+
+.history-entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.history-entry-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.history-entry-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.history-entry button {
+  border-radius: 10px;
+  border: 1px solid rgba(74, 215, 168, 0.35);
+  background: rgba(74, 215, 168, 0.12);
+  color: var(--primary);
+  font-size: 0.78rem;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.history-entry button:hover {
+  background: rgba(74, 215, 168, 0.2);
+}
+
+.status-log {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  max-height: 220px;
+  overflow-y: auto;
+  font-size: 0.82rem;
+}
+
+.status-log.is-empty {
+  color: var(--muted);
+}
+
+.status-log-entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.status-log-entry time {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.status-log-entry span {
+  color: var(--text);
+}
+
+.status-log-entry.info {
+  border-color: rgba(74, 215, 168, 0.25);
+}
+
+.status-log-entry.success {
+  border-color: rgba(0, 200, 83, 0.35);
+}
+
+.status-log-entry.error {
+  border-color: rgba(255, 82, 82, 0.4);
+}
+
+.status-log-entry.warning {
+  border-color: rgba(255, 160, 0, 0.35);
+}
+
+.status-log-placeholder {
+  margin: 0;
 }
 
 .table-wrapper {

--- a/quant-screener.html
+++ b/quant-screener.html
@@ -69,6 +69,13 @@
         <h2>Market Radar</h2>
         <div id="heatmap" class="valuation-breakdown market-radar"></div>
       </div>
+
+      <div class="card" id="activityCard">
+        <h2>Activity monitor</h2>
+        <div id="statusLog" class="status-log is-empty">
+          <p class="status-log-placeholder">Run the screener to start logging activity.</p>
+        </div>
+      </div>
     </section>
 
     <section class="intel-panel">
@@ -94,6 +101,48 @@
             <tbody></tbody>
           </table>
         </div>
+      </div>
+
+      <div class="card" id="insightsCard">
+        <div class="card-header">
+          <h2>Screen insights</h2>
+          <span id="insightsMeta" class="chip chip-muted">Awaiting results</span>
+        </div>
+        <div class="insight-grid" id="insightGrid">
+          <div class="insight-item">
+            <span class="insight-label">Average upside</span>
+            <span class="insight-value" data-field="avgUpside">—</span>
+            <span class="insight-subvalue" data-field="medianUpside">Median —</span>
+          </div>
+          <div class="insight-item">
+            <span class="insight-label">Momentum</span>
+            <span class="insight-value" data-field="momentumAverage">—</span>
+            <span class="insight-subvalue" data-field="momentumMedian">Median —</span>
+          </div>
+          <div class="insight-item">
+            <span class="insight-label">Market cap</span>
+            <span class="insight-value" data-field="averageMarketCap">—</span>
+            <span class="insight-subvalue" data-field="totalMarketCap">Total —</span>
+          </div>
+          <div class="insight-item" id="insightExtrema">
+            <span class="insight-label">Extremes</span>
+            <div class="insight-extrema" data-field="extrema">No data</div>
+          </div>
+        </div>
+        <div class="sector-leaders" id="sectorLeaders">
+          <h3>Sector leadership</h3>
+          <ul class="sector-leader-list" id="sectorLeaderList"></ul>
+        </div>
+      </div>
+
+      <div class="card" id="historyCard">
+        <div class="card-header">
+          <h2>Run history</h2>
+          <div class="history-actions">
+            <button class="btn ghost" id="clearRunHistory" type="button"><i class="fa-solid fa-broom"></i> Clear</button>
+          </div>
+        </div>
+        <div class="history-list" id="runHistory"></div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add dedicated insights and sector leadership panels to the quant screener experience
- surface run history with reusable filter restoration controls and persistent storage
- introduce an on-page activity monitor and supporting styles for the expanded UI

## Testing
- npm test *(fails: aiAnalystFunction.spec.js -> handleRequest is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e6f794b883298d628417fb7f16a2